### PR TITLE
Warning removal

### DIFF
--- a/libecl/src/ecl_grid.c
+++ b/libecl/src/ecl_grid.c
@@ -616,27 +616,6 @@ static double point_dot_product( const point_type * v1 , const point_type * v2) 
   return v1->x*v2->x + v1->y*v2->y + v1->z*v2->z;
 }
 
-/**
-   This function calculates the (signed) distance from point 'p' to
-   the plane specifed by the plane vector 'n' and the point
-   'plane_point' which is part of the plane.
-*/
-
-static double point_plane_distance(const point_type * p , const point_type * n , const point_type * plane_point) {
-  point_type diff = *p;
-  point_inplace_sub( &diff, plane_point );
-  return point_dot_product( n, &diff );
-}
-
-static void point_normal_vector(point_type * n, const point_type * p0, const point_type * p1 , const point_type * p2) {
-  point_type v1 = *p1;
-  point_type v2 = *p2;
-
-  point_inplace_sub( &v1, p0 );
-  point_inplace_sub( &v2, p0 );
-
-  point_vector_cross( n, &v1, &v2 );
-}
 
 static void point_compare( const point_type *p1 , const point_type * p2, bool * equal) {
   const double tolerance = 0.001;

--- a/libert_util/src/struct_vector.c
+++ b/libert_util/src/struct_vector.c
@@ -114,6 +114,7 @@ void * struct_vector_iget_ptr( const struct_vector_type * struct_vector , int in
     return &struct_vector->data[offset];
   } else
     util_abort("%s: fatal error - invalid index:%d size:%d\n",__func__ , index , struct_vector->size);
+  return NULL;
 }
 
 

--- a/libert_util/src/struct_vector.c
+++ b/libert_util/src/struct_vector.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2014  Statoil ASA, Norway. 
-    
-   The file 'struct_vector.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2014  Statoil ASA, Norway.
+
+   The file 'struct_vector.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #include <string.h>
@@ -30,7 +30,7 @@ struct struct_vector_struct {
   int size;
   int element_size;
   int alloc_size;
-  
+
   char * data;
 };
 
@@ -63,9 +63,9 @@ struct_vector_type * struct_vector_alloc( int element_size ) {
     vector->alloc_size = 0;
     vector->element_size = element_size;
     vector->data = NULL;
-    
+
     struct_vector_resize( vector , 10 );
-    
+
     return vector;
   }
 }


### PR DESCRIPTION
Removed two unused functions in `ecl_grid.c`, and added a `return NULL` to silence "end of non-void function reached" warning.