### PR TITLE
Extendedtestcase: __str__ instead of __repr__

### DIFF
--- a/python/python/ert/test/extended_testcase.py
+++ b/python/python/ert/test/extended_testcase.py
@@ -56,10 +56,10 @@ class ExtendedTestCase(TestCase):
         self.__share_root = None
         installAbortSignals()
         super(ExtendedTestCase , self).__init__(*args , **kwargs)
-        self.__str__ = self.__repr__
 
-    def __repr__(self):
-        return 'ExtendedTestCase( TESTADATA_ROOT=%s, SOURCE_ROOT=%s, SHARE_ROOT=%s, BUILD_ROOT=%s)' % (TESDATA_ROOT,
+
+    def __str__(self):
+        return 'ExtendedTestCase( TESTADATA_ROOT=%s, SOURCE_ROOT=%s, SHARE_ROOT=%s, BUILD_ROOT=%s)' % (TESTDATA_ROOT,
                                                                                                        SOURCE_ROOT,
                                                                                                        SHARE_ROOT,
                                                                                                        BUILD_ROOT)


### PR DESCRIPTION
Seems it will not climb the class hierarchy looking for `__repr__` - makes sense.