### PR TITLE
WIP Respect grid orientation in cell containment calculations

### DIFF
--- a/python/tests/ecl/test_grid.py
+++ b/python/tests/ecl/test_grid.py
@@ -389,11 +389,13 @@ class GridTest(ExtendedTestCase):
                             for i in range(grid.getGlobalSize())
                         ].count(True)
 
-                self.assertTrue(hits in [0, 1])
+                self.assertIn(hits, [0, 1])
 
+                expected = 1 if wgrid.cell_contains(x, y, z, 0) else 0
                 self.assertEqual(
-                        1 if wgrid.cell_contains(x, y, z, 0) else 0,
-                        hits
+                        expected,
+                        hits,
+                        'Expected %d for (%g,%g,%g), got %d' % (expected, x, y, z, hits)
                         )
 
     def test_cell_corner_containment(self):

--- a/python/tests/well/CMakeLists.txt
+++ b/python/tests/well/CMakeLists.txt
@@ -8,7 +8,7 @@ set(TEST_SOURCES
 add_python_package("python.tests.well"  ${PYTHON_INSTALL_PREFIX}/tests/well "${TEST_SOURCES}" False)
 
 if (STATOIL_TESTDATA_ROOT)
-  addPythonTest(well.test_ecl_well.EclWellTest LABELS StatoilData)
-  addPythonTest(well.test_ecl_well2.EclWellTest2 LABELS StatoilData)
-  addPythonTest(well.test_ecl_well3.EclWellTest3 LABELS StatoilData)
+  addPythonTest(tests.well.test_ecl_well.EclWellTest LABELS StatoilData)
+  addPythonTest(tests.well.test_ecl_well2.EclWellTest2 LABELS StatoilData)
+  addPythonTest(tests.well.test_ecl_well3.EclWellTest3 LABELS StatoilData)
 endif()


### PR DESCRIPTION
If a grid is "mirrored", i.e. (exactly one of) decreasing `i` index increases east coordinates, or decreasing `j` index increases north coordinates, the cell containment did not work correctly for points close to the walls.