### PR TITLE
Using 'PATH' in get_filename_components( )

### DIFF
--- a/python/cmake/Modules/add_python_package.cmake
+++ b/python/cmake/Modules/add_python_package.cmake
@@ -30,7 +30,8 @@ function(add_python_package target package_path source_files install_package)
      list(APPEND build_files ${build_file} )
 
      if (install_package)
-        get_filename_component( src_path ${file} DIRECTORY )
+        # For cmake versions >= 2.8.12 the preferred keyword is DIRECTORY.
+        get_filename_component( src_path ${file} PATH )
         install(FILES ${build_file} DESTINATION ${CMAKE_INSTALL_PREFIX}/${package_path}/${src_path})
         install(CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_BINARY_DIR}/bin/cmake_pyc_file ${install_file})")
      endif()


### PR DESCRIPTION
The syntax `get_filename_compinent( var ${PATH} DIRECTORY)` fails for cmake < 2.8.12. Downstream builds (go on a different runtime environment?) fail with the `DIRECTORY` keyword.