### PR TITLE
Adding log level enums and a simplified log function

### DIFF
--- a/libert_util/include/ert/util/log.h
+++ b/libert_util/include/ert/util/log.h
@@ -26,12 +26,23 @@ extern "C" {
 #include <stdbool.h>
 #include <stdlib.h>
 
+//Same as pythons default log levels, but with different numeric values.
+typedef enum {
+  LOG_CRITICAL=0, //OOM.
+  LOG_ERROR=1, //When something we really expected to work does not, e.g. IO failure.
+  LOG_WARNING=2, //Important, but not error. E.g. combination of settings which can be intended, but probably are not.
+  LOG_INFO=3, //Entering functions/parts of the code
+  LOG_DEBUG=4 //Inside the for-loop, when you need the nitty gritty details. Think TRACE.
+} message_level_type;
+
+
 typedef struct log_struct log_type;
 
   FILE       * log_get_stream(log_type * logh );
   void         log_reopen( log_type * logh , const char * filename );
   log_type   * log_open(const char *filename, int log_level);
   void         log_add_message(log_type *logh, int message_level , FILE * dup_stream , char* message, bool free_message);
+  void         log_add_message_str(log_type *logh, message_level_type message_level , const char* message);
   void         log_add_fmt_message(log_type * logh , int message_level , FILE * dup_stream , const char * fmt , ...);
   int          log_get_level( const log_type * logh);
   void         log_set_level( log_type * logh , int new_level);

--- a/libert_util/src/log.c
+++ b/libert_util/src/log.c
@@ -128,6 +128,15 @@ bool log_include_message(const log_type *logh , int message_level) {
     return false;
 }
 
+/**
+ * Adds a string to the log if message_level is below the threshold. It is the callers duty to either free the string
+ * or make sure that it is a string literal.
+ */
+void log_add_message_str(log_type *logh, message_level_type message_level , const char* message){
+  //The conversion to (char*) is safe since free_message=false
+  log_add_message(logh,message_level, NULL, (char*) message,false);
+}
+
 
 /**
    If dup_stream != NULL the message (without the date/time header) is duplicated on this stream.
@@ -171,7 +180,10 @@ void log_add_message(log_type *logh, int message_level , FILE * dup_stream , cha
 
 
 
-
+/**
+ * Adds a formated log message if message_level is below the threshold, fmt is expected to be the format string,
+ * and "..." contains any arguments to it.
+ */
 void log_add_fmt_message(log_type * logh , int message_level , FILE * dup_stream , const char * fmt , ...) {
   if (log_include_message(logh,message_level)) {
     char * message;


### PR DESCRIPTION
Added the function:
 void log_add_message_str(log_type *logh, message_level_type message_level , const char* message);
which does not take in a dup_stream or a flag for freeing (it will not free the message as it is const)