### PR TITLE
Include Windows.h in util_env.c

### DIFF
--- a/lib/util/util_env.c
+++ b/lib/util/util_env.c
@@ -39,6 +39,8 @@ void util_setenv( const char * variable , const char * value) {
 
 #else
 
+#include <Windows.h>
+
 #define PATHVAR_SPLIT ";"
 void util_setenv( const char * variable , const char * value) {
   SetEnvironmentVariable( variable , NULL );


### PR DESCRIPTION
If Windows.h is not included, SetEnvironmentVariable linking does not
work as expected.