### PR TITLE
PathContextTest tests fail on OS X

### DIFF
--- a/python/tests/util/test_path_context.py
+++ b/python/tests/util/test_path_context.py
@@ -18,8 +18,10 @@ class PathContextTest(ExtendedTestCase):
             
     def test_chdir(self):
         with PathContext("/tmp/pc"):
-            self.assertEqual( os.getcwd() , "/tmp/pc")
-
+            self.assertEqual(
+                    os.path.realpath(os.getcwd()),
+                    os.path.realpath("/tmp/pc")
+                    )
 
     def test_cleanup(self):
         with TestAreaContext("pathcontext"):


### PR DESCRIPTION
Currently three tests fails fails both locally on my machine and at the travis setup in (#88):

 - tests.util.test_path_context.PathContextTest [FIXED]
 - tests.ecl.test_ecl_kw.KWTest
 - tests.cwrap.test_metawrap.MetaWrapTest

The last one seems to give the same error as reported in (#81 on Ubuntu 17.04) and is probably not an OS X problem - although that is the only of our current test builds that catches this one.

UPDATE: The MetaWrapTest seems to fail due to 32-bit vs 64-bit pointer being passed from C to Python via ctypes. This should be resolved in a separate PR! Hence I suggest that we merge this very small PR as it is.