### PR TITLE
Fixed broken statoil test paths

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -683,10 +683,10 @@ if (HAVE_UTIL_ABORT_INTERCEPT)
    add_test(NAME ecl_fortio COMMAND ecl_fortio ${_eclpath}/Gurbat/ECLIPSE.UNRST)
 endif()
 
-add_executable(well_state_load tests/well_state_load.c)
+add_executable(well_state_load ecl/tests/well_state_load.c)
 target_link_libraries( well_state_load ecl)
 
-add_executable(well_state_load_missing_RSEG tests/well_state_load_missing_RSEG.c)
+add_executable(well_state_load_missing_RSEG ecl/tests/well_state_load_missing_RSEG.c)
 target_link_libraries(well_state_load_missing_RSEG ecl)
 
 add_test(NAME well_state_load1 COMMAND well_state_load ${_eclpath}/Gurbat/ECLIPSE.EGRID
@@ -706,25 +706,25 @@ add_test(NAME well_state_load_missing_RSEG2
          COMMAND well_state_load_missing_RSEG ${_eclpath}/Troll/MSW/MSW.EGRID
                                               ${_eclpath}/Troll/MSW/MSW.X0123)
 
-add_executable(well_segment_load tests/well_segment_load.c)
+add_executable(well_segment_load ecl/tests/well_segment_load.c)
 target_link_libraries(well_segment_load ecl)
 add_test(NAME well_segment_load
         COMMAND well_segment_load ${_eclpath}/MSWcase/MSW_CASE.X0021)
 
-add_executable(well_segment_branch_conn_load tests/well_segment_branch_conn_load.c)
+add_executable(well_segment_branch_conn_load ecl/tests/well_segment_branch_conn_load.c)
 target_link_libraries(well_segment_branch_conn_load ecl)
 add_test(NAME well_segment_branch_conn_load
          COMMAND well_segment_branch_conn_load ${_eclpath}/MSWcase/MSW_CASE.X0021)
 
-add_executable(well_info tests/well_info.c)
+add_executable(well_info ecl/tests/well_info.c)
 target_link_libraries(well_info ecl)
 add_test(NAME well_info COMMAND well_info ${_eclpath}/Gurbat/ECLIPSE.EGRID)
 
-add_executable(well_conn_CF tests/well_conn_CF.c)
+add_executable(well_conn_CF ecl/tests/well_conn_CF.c)
 target_link_libraries(well_conn_CF ecl)
 add_test(NAME well_conn_CF COMMAND well_conn_CF ${_eclpath}/Gurbat/ECLIPSE.X0060)
 
-add_executable(well_conn_load tests/well_conn_load.c)
+add_executable(well_conn_load ecl/tests/well_conn_load.c)
 target_link_libraries(well_conn_load ecl)
 add_test(NAME well_conn_load1 COMMAND well_conn_load ${_eclpath}/Gurbat/ECLIPSE.X0030 F)
 add_test(NAME well_conn_load2 COMMAND well_conn_load ${_eclpath}/10kcase/TEST10K_FLT_LGR_NNC.X0021 F)
@@ -733,17 +733,17 @@ add_test(NAME well_conn_load4 COMMAND well_conn_load ${_eclpath}/AmalgLGRcase/TE
 add_test(NAME well_conn_load5 COMMAND well_conn_load ${_eclpath}/DualPoro/DUALPORO.X0009 F)
 add_test(NAME well_conn_load6 COMMAND well_conn_load ${_eclpath}/0.9.2_LGR/BASE_REF_XY3Z1_T30_WI.X0003 F)
 
-add_executable(well_ts tests/well_ts.c)
+add_executable(well_ts ecl/tests/well_ts.c)
 target_link_libraries(well_ts ecl)
 add_test(NAME well_ts COMMAND well_ts ${_eclpath}/CO2case/BASE_CASE)
 
-add_executable(well_dualp tests/well_dualp.c)
+add_executable(well_dualp ecl/tests/well_dualp.c)
 target_link_libraries(well_dualp ecl)
 add_test(NAME well_dualp COMMAND well_dualp
     ${_eclpath}/Gurbat/ECLIPSE.UNRST
     ${_eclpath}/DualPoro/DUALPORO.X0005)
 
-add_executable(well_lgr_load tests/well_lgr_load.c)
+add_executable(well_lgr_load ecl/tests/well_lgr_load.c)
 target_link_libraries(well_lgr_load ecl)
 
 add_test(NAME well_lgr_load1 COMMAND well_lgr_load ${_eclpath}/0.9.2_LGR/BASE_REF_XY3Z1_T30_WI.EGRID

--- a/lib/ecl/ecl_grid.c
+++ b/lib/ecl/ecl_grid.c
@@ -5033,6 +5033,9 @@ ecl_grid_type * ecl_grid_get_lgr(const ecl_grid_type * main_grid, const char * _
 */
 
 bool ecl_grid_has_lgr(const ecl_grid_type * main_grid, const char * __lgr_name) {
+  if(!__lgr_name)
+    return false;
+
   __assert_main_grid( main_grid );
   {
     char * lgr_name          = util_alloc_strip_copy( __lgr_name );

--- a/python/python/ecl/ecl/ecl_grid.py
+++ b/python/python/ecl/ecl/ecl_grid.py
@@ -79,7 +79,7 @@ class EclGrid(BaseCClass):
     _cell_contains                = EclPrototype("bool ecl_grid_cell_contains_xyz1( ecl_grid , int , double , double , double )")
     _cell_regular                 = EclPrototype("bool ecl_grid_cell_regular1( ecl_grid , int)")
     _num_lgr                      = EclPrototype("int  ecl_grid_get_num_lgr( ecl_grid )")
-    _has_numbered_lgr_            = EclPrototype("bool ecl_grid_has_lgr_nr( ecl_grid , int)")
+    _has_numbered_lgr             = EclPrototype("bool ecl_grid_has_lgr_nr( ecl_grid , int)")
     _has_named_lgr                = EclPrototype("bool ecl_grid_has_lgr( ecl_grid , char* )")
     _grid_value                   = EclPrototype("double ecl_grid_get_property( ecl_grid , ecl_kw , int , int , int)")
     _get_cell_volume              = EclPrototype("double ecl_grid_get_cell_volume1( ecl_grid , int )")
@@ -909,7 +909,7 @@ class EclGrid(BaseCClass):
             return False
 
 
-    def get_lgr( self , lgr ):
+    def get_lgr(self, lgr_key):
         """Get EclGrid instance with LGR content.
 
         Return an EclGrid instance based on the LGR @lgr, the input
@@ -923,17 +923,17 @@ class EclGrid(BaseCClass):
 
         """
         lgr = None
-        if isinstance(lgr, int):
-            if self._has_numbered_lgr( lgr):
-                lgr = self._get_numbered_lgr( lgr )
+        if isinstance(lgr_key, int):
+            if self._has_numbered_lgr(lgr_key):
+                lgr = self._get_numbered_lgr(lgr_key)
         else:
-            if self._has_named_lgr( lgr ):
-                lgr = self._get_named_lgr( lgr )
+            if self._has_named_lgr(lgr_key):
+                lgr = self._get_named_lgr(lgr_key)
 
         if lgr is None:
-            raise KeyError("No such LGR:%s" % lgr)
+            raise KeyError("No such LGR: %s" % lgr_key)
 
-        lgr.setParent( self )
+        lgr.setParent(self)
         return lgr
 
     

--- a/python/tests/well/test_ecl_well.py
+++ b/python/tests/well/test_ecl_well.py
@@ -110,13 +110,13 @@ class EclWellTest(ExtendedTestCase):
 
 
     def test_well_type_enum(self):
-        source_file_path = "libecl_well/include/ert/ecl_well/well_const.h"
+        source_file_path = "lib/include/ert/ecl_well/well_conn.h"
         # The header file has duplicated symbols, so the simple test fails.
         # self.assertEnumIsFullyDefined(WellTypeEnum, "well_type_enum", source_file_path)
 
 
     def test_well_connection_direction_enum(self):
-        source_file_path = "libecl_well/include/ert/ecl_well/well_conn.h"
+        source_file_path = "lib/include/ert/ecl_well/well_conn.h"
         self.assertEnumIsFullyDefined(WellConnectionDirectionEnum, "well_conn_dir_enum", source_file_path)
 
 


### PR DESCRIPTION
Did three things in this PR to fix broken Statoil tests, each in a separate commit:
- Fixed broken paths for C Statoil tests,
- fixed broken header paths for Python Statoil tests and
- fixed the logic of the get_lgr Python Prototype