### PR TITLE
Added legacy wrappers for ecl faults.

### DIFF
--- a/python/python/legacy/ert/CMakeLists.txt
+++ b/python/python/legacy/ert/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(PYTHON_SOURCES
     __init__.py
     ecl/__init__.py
+    ecl/faults/__init__.py
     geo/__init__.py
     well/__init__.py
     util/__init__.py

--- a/python/python/legacy/ert/ecl/faults/__init__.py
+++ b/python/python/legacy/ert/ecl/faults/__init__.py
@@ -1,0 +1,7 @@
+from ecl.ecl.faults import Layer
+from ecl.ecl.faults import FaultCollection
+from ecl.ecl.faults import Fault
+from ecl.ecl.faults import FaultLine
+from ecl.ecl.faults import FaultSegment , SegmentMap
+from ecl.ecl.faults import FaultBlock , FaultBlockCell
+from ecl.ecl.faults import FaultBlockLayer

--- a/python/tests/legacy/test_ecl.py
+++ b/python/tests/legacy/test_ecl.py
@@ -25,6 +25,14 @@ from ert.ecl import EclNPV , NPVPriceVector
 from ert.ecl import EclCmp
 from ert.ecl import EclGridGenerator
 
+from ert.ecl.faults import Layer
+from ert.ecl.faults import FaultCollection
+from ert.ecl.faults import Fault
+from ert.ecl.faults import FaultLine
+from ert.ecl.faults import FaultSegment , SegmentMap
+from ert.ecl.faults import FaultBlock , FaultBlockCell
+from ert.ecl.faults import FaultBlockLayer
+
 
 from ecl.test import ExtendedTestCase
 


### PR DESCRIPTION
#### Task
Added legacy wrappers for the `faults` package in `ecl`.

#### Approach
Standard approach for legacy wrappers.

#### Pre un-WIP checklist
- [x] All Statoil tests passes locally
