### PR TITLE
Default return value for function wrappers are now void*

### DIFF
--- a/python/python/cwrap/prototype.py
+++ b/python/python/cwrap/prototype.py
@@ -160,6 +160,9 @@ class Prototype(object):
 
     @classmethod
     def registerType(cls, type_name, type_class_or_function, is_return_type=True, storage_type=None):
+        if storage_type is None and (inspect.isfunction(type_class_or_function)):
+          storage_type = ctypes.c_void_p
+
         _registerType(type_name,
                       type_class_or_function,
                       is_return_type = is_return_type,

--- a/python/tests/cwrap/test_metawrap.py
+++ b/python/tests/cwrap/test_metawrap.py
@@ -113,7 +113,6 @@ class MetaWrapTest(ExtendedTestCase):
         def stringObj(c_ptr):
             char_ptr = ctypes.c_char_p(c_ptr)
             python_string = char_ptr.value
-            TestUtilPrototype.lib.free(c_ptr)
             return python_string.decode('ascii')
 
         Prototype.registerType("string_obj", stringObj)


### PR DESCRIPTION
#### Task
_The cwrap-test fails on some 64-bits architectures due to the default return value of ctypes being an int. This is now changed for function wrappers, as it already is for basecclass, to a void pointer._

#### Approach
_When registering a new return type for which the wrapper is a function, the default storage_type is now a void-pointer._

#### Pre un-WIP checklist
- [x] All Statoil tests passes locally