### PR TITLE
WIP: New travis build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,20 +53,6 @@ install:
 - conda info -a  # Useful for debugging any issues with conda
 - conda install pylint numpy pandas
 
-before_script:
-- mkdir build
-- cd build
-- cmake -DBUILD_TESTS=ON
-        -DBUILD_PYTHON=ON
-        -DERT_BUILD_CXX=ON
-        -DBUILD_APPLICATIONS=ON
-        -DBUILD_ECL_SUMMARY=ON
-        -DCMAKE_INSTALL_PREFIX=install
-        -DINSTALL_ERT_LEGACY=ON
-        ..
-
 script:
-- make
-- ctest --output-on-failure -E ert_util_ping
-- make install
-- bin/test_install
+  - wget https://raw.githubusercontent.com/Statoil/ert/master/travis/build_total.py
+  - python build_total.py ecl

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ install:
 - conda info -a  # Useful for debugging any issues with conda
 - conda install pylint numpy pandas
 
-script:
+before_script:
   - wget https://raw.githubusercontent.com/Statoil/ert/master/travis/build_total.py
+
+script:
   - python build_total.py ecl


### PR DESCRIPTION
#### Task
Create a build script to take into account optional keywords ecl=n1, ert=n3 (n3 must be number and keyword on start of line). This will 1) create clones of ecl and ert master, then optionally merge pr n1 into libecl and pr n3 into ert. The (optionally) merged repositories will used for the build. Testing is done for all reposititories. 

#### Approach
All building is done through the python script build_total.py in the Statoil/ert repository. This file is downloaded by wget into the travis libecl directory and executed with argument 'ecl'.

#### Pre un-WIP checklist
- [ ] All Statoil tests passes locally

ert=13
