### PR TITLE
WIP: Writing keywords with ecl_file on OS X fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: c
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - os: osx
   include:
     - os: osx
       osx_image: xcode7.3

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -391,6 +391,7 @@ foreach (name   ecl_alloc_cpgrid
                 well_segment
                 well_segment_conn
                 well_segment_collection
+                ecl_file
         )
         add_executable(${name} ecl/tests/${name}.c)
         target_link_libraries(${name} ecl)
@@ -632,10 +633,10 @@ add_test(NAME ecl_sum_report_step_compatible4 COMMAND ecl_sum_report_step_compat
 add_test(NAME ecl_sum_report_step_compatible5 COMMAND ecl_sum_report_step_compatible ${_eclpath}/Gurbat/ECLIPSE ${_eclpath}/modGurbat/enkf/ECLIPSE TRUE)
 add_test(NAME ecl_sum_report_step_compatible6 COMMAND ecl_sum_report_step_equal      ${_eclpath}/Snorre/SNORRE  ${_eclpath}/Snorre2/SNORRE2 FALSE)
 
-add_executable(ecl_file ecl/tests/ecl_file.c)
-target_link_libraries(ecl_file ecl)
-add_test(NAME ecl_file
-         COMMAND ecl_file ${_eclpath}/Gurbat/ECLIPSE.UNRST ECLIPSE.UNRST)
+add_executable(ecl_file_statoil ecl/tests/ecl_file_statoil.c)
+target_link_libraries(ecl_file_statoil ecl)
+add_test(NAME ecl_file_statoil
+         COMMAND ecl_file_statoil ${_eclpath}/Gurbat/ECLIPSE.UNRST ECLIPSE.UNRST)
 
 add_executable(ecl_fmt ecl/tests/ecl_fmt.c)
 target_link_libraries(ecl_fmt  ecl)

--- a/lib/ecl/ecl_file_kw.c
+++ b/lib/ecl/ecl_file_kw.c
@@ -318,6 +318,7 @@ void ecl_file_kw_inplace_fwrite( ecl_file_kw_type * file_kw , fortio_type * fort
   ecl_file_kw_assert_kw( file_kw );
   fortio_fseek( fortio , file_kw->file_offset , SEEK_SET );
   ecl_kw_fskip_header( fortio );
+  fortio_fclean(fortio);
   ecl_kw_fwrite_data( file_kw->kw , fortio );
 }
 

--- a/lib/ecl/fortio.c
+++ b/lib/ecl/fortio.c
@@ -488,6 +488,17 @@ void fortio_data_fseek(fortio_type* fortio, offset_type data_offset, size_t data
     }
 }
 
+int fortio_fclean(fortio_type * fortio) {
+  long current_pos = ftell(fortio->stream);
+  if(current_pos == -1)
+    return -1;
+
+  int flush_status = fflush(fortio->stream);
+  if(flush_status != 0)
+    return flush_status;
+
+  return fseek(fortio->stream, current_pos, SEEK_SET);
+}
 
 bool fortio_complete_read(fortio_type *fortio , int record_size) {
   int trailer;

--- a/lib/ecl/tests/ecl_file.c
+++ b/lib/ecl/tests/ecl_file.c
@@ -30,107 +30,33 @@
 #include <ert/ecl/ecl_grid.h>
 #include <ert/ecl/ecl_endian_flip.h>
 
+void test_writable() {
+  test_work_area_type * work_area = test_work_area_alloc("ecl_file_writable");
+  const char * data_file_name = "test_file";
 
-void test_flags( const char * filename) {
-  int FLAG1 = 1;
-  int FLAG2 = 2;
-  int FLAG3 = 4;
-  int FLAG4 = 8;
+  size_t data_size = 10;
+  ecl_kw_type * kw = ecl_kw_alloc("TEST_KW", data_size, ECL_INT);
+  for(int i = 0; i < data_size; ++i)
+    ecl_kw_iset_int(kw, i, ((i*37)+11)%data_size);
 
-  int FLAGS = FLAG1 + FLAG2 + FLAG3;
+  fortio_type * fortio = fortio_open_writer(data_file_name, false, true);
+  ecl_kw_fwrite(kw, fortio); 
+  fortio_fclose(fortio);
 
+  for(int i = 0; i < 2; ++i) {
+    ecl_file_type * ecl_file = ecl_file_open(data_file_name, ECL_FILE_WRITABLE);
+    ecl_kw_type * loaded_kw = ecl_file_view_iget_kw(
+                                  ecl_file_get_global_view(ecl_file),
+                                  0);
+    test_assert_true(ecl_kw_equal(kw, loaded_kw));
 
-  ecl_file_type * ecl_file = ecl_file_open( filename , FLAGS );
-
-  test_assert_int_equal( ecl_file_get_flags( ecl_file ) , FLAGS );
-  test_assert_true( ecl_file_flags_set( ecl_file , FLAG1 ));
-  test_assert_true( ecl_file_flags_set( ecl_file , FLAG1 | FLAG2));
-  test_assert_true( ecl_file_flags_set( ecl_file , FLAG1 | FLAG3 ));
-  test_assert_true( ecl_file_flags_set( ecl_file , FLAG1 | FLAG3 | FLAG2 ));
-  test_assert_false( ecl_file_flags_set( ecl_file , FLAG1 | FLAG3 | FLAG4 ));
-  ecl_file_close( ecl_file );
-}
-
-
-void test_close_stream2(const char * src_file , const char * target_file ) {
-  util_copy_file( src_file , target_file );
-  ecl_file_type * ecl_file = ecl_file_open( target_file , ECL_FILE_CLOSE_STREAM );
-
-  ecl_file_load_all( ecl_file );
-  unlink( target_file );
-  ecl_kw_type * kw2 = ecl_file_iget_kw( ecl_file , 2 );
-  test_assert_not_NULL( kw2 );
-  ecl_file_close( ecl_file );
-}
-
-
-void test_loadall(const char * src_file , const char * target_file ) {
-  util_copy_file( src_file , target_file );
-  {
-    ecl_file_type * ecl_file = ecl_file_open( target_file , ECL_FILE_CLOSE_STREAM );
-
-    test_assert_true( ecl_file_load_all( ecl_file ) );
-    ecl_file_close( ecl_file );
+    ecl_file_save_kw(ecl_file, loaded_kw);
+    ecl_file_close(ecl_file);
   }
 
-  {
-    ecl_file_type * ecl_file = ecl_file_open( target_file , ECL_FILE_CLOSE_STREAM );
-    unlink( target_file );
-
-    test_assert_false( ecl_file_load_all( ecl_file ) );
-    ecl_file_close( ecl_file );
-  }
-}
-
-
-
-void test_close_stream1(const char * src_file , const char * target_file ) {
-  util_copy_file( src_file , target_file );
-
-  ecl_file_type * ecl_file = ecl_file_open( target_file , ECL_FILE_CLOSE_STREAM );
-  ecl_kw_type * kw0 = ecl_file_iget_kw( ecl_file , 0 );
-  ecl_kw_type * kw1 = ecl_file_iget_kw( ecl_file , 1 );
-  unlink( target_file );
-  ecl_kw_type * kw1b = ecl_file_iget_kw( ecl_file , 1 );
-
-  test_assert_not_NULL( kw0 );
-  test_assert_not_NULL( kw1 );
-  test_assert_ptr_equal( kw1 , kw1b );
-
-  ecl_kw_type * kw2 = ecl_file_iget_kw( ecl_file , 2 );
-  test_assert_NULL( kw2 );
-
-  test_assert_false( ecl_file_writable( ecl_file ));
-
-  ecl_file_close( ecl_file );
-
-}
-
-
-void test_writable(const char * src_file ) {
-  test_work_area_type * work_area = test_work_area_alloc("ecl_file_writable" );
-  char * fname = util_split_alloc_filename( src_file );
-
-  test_work_area_copy_file( work_area , src_file );
-  {
-    test_flags( fname );
-    ecl_file_type * ecl_file = ecl_file_open( fname , ECL_FILE_WRITABLE);
-    ecl_kw_type * swat = ecl_file_iget_named_kw( ecl_file , "SWAT" , 0 );
-    ecl_kw_type * swat0 = ecl_kw_alloc_copy( swat );
-    test_assert_true( ecl_kw_equal( swat , swat0 ));
-    ecl_kw_iset_float( swat , 0 , 1000.0 );
-    ecl_file_save_kw( ecl_file , swat );
-    test_assert_true( ecl_file_writable( ecl_file ));
-    ecl_file_close( ecl_file );
-
-    ecl_file = ecl_file_open( fname , 0);
-    swat = ecl_file_iget_named_kw( ecl_file , "SWAT" , 0 );
-    test_assert_true( util_double_approx_equal( ecl_kw_iget_float( swat , 0 ) , 1000 ));
-  }
+  ecl_kw_free(kw);
   test_work_area_free( work_area );
 }
-
-
 
 void test_truncated() {
   test_work_area_type * work_area = test_work_area_alloc("ecl_file_truncated" );
@@ -160,9 +86,7 @@ void test_truncated() {
 
 
 int main( int argc , char ** argv) {
-  const char * src_file = argv[1];
-  const char * target_file = argv[2];
-
+  /*
   {
     test_work_area_type * work_area = test_work_area_alloc("ecl_file");
 
@@ -175,6 +99,8 @@ int main( int argc , char ** argv) {
 
     test_work_area_free( work_area );
   }
+  */
+  test_writable();
   test_truncated();
   exit(0);
 }

--- a/lib/ecl/tests/ecl_file.c
+++ b/lib/ecl/tests/ecl_file.c
@@ -30,11 +30,10 @@
 #include <ert/ecl/ecl_grid.h>
 #include <ert/ecl/ecl_endian_flip.h>
 
-void test_writable() {
+void test_writable(size_t data_size) {
   test_work_area_type * work_area = test_work_area_alloc("ecl_file_writable");
   const char * data_file_name = "test_file";
 
-  size_t data_size = 10;
   ecl_kw_type * kw = ecl_kw_alloc("TEST_KW", data_size, ECL_INT);
   for(int i = 0; i < data_size; ++i)
     ecl_kw_iset_int(kw, i, ((i*37)+11)%data_size);
@@ -43,7 +42,7 @@ void test_writable() {
   ecl_kw_fwrite(kw, fortio); 
   fortio_fclose(fortio);
 
-  for(int i = 0; i < 2; ++i) {
+  for(int i = 0; i < 4; ++i) {
     ecl_file_type * ecl_file = ecl_file_open(data_file_name, ECL_FILE_WRITABLE);
     ecl_kw_type * loaded_kw = ecl_file_view_iget_kw(
                                   ecl_file_get_global_view(ecl_file),
@@ -86,21 +85,8 @@ void test_truncated() {
 
 
 int main( int argc , char ** argv) {
-  /*
-  {
-    test_work_area_type * work_area = test_work_area_alloc("ecl_file");
-
-    test_work_area_copy_file( work_area , src_file );
-    test_loadall(src_file , target_file );
-
-    test_close_stream1( src_file , target_file);
-    test_close_stream2( src_file , target_file);
-    test_writable( src_file );
-
-    test_work_area_free( work_area );
-  }
-  */
-  test_writable();
+  test_writable(10);
+  test_writable(1337);
   test_truncated();
   exit(0);
 }

--- a/lib/ecl/tests/ecl_file_statoil.c
+++ b/lib/ecl/tests/ecl_file_statoil.c
@@ -1,0 +1,180 @@
+
+/*
+   Copyright (C) 2013  Statoil ASA, Norway.
+
+   The file 'ecl_file.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+#include <stdlib.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#include <ert/util/test_util.h>
+#include <ert/util/util.h>
+#include <ert/util/test_work_area.h>
+
+#include <ert/ecl/ecl_util.h>
+#include <ert/ecl/ecl_file.h>
+#include <ert/ecl/ecl_file_view.h>
+#include <ert/ecl/ecl_grid.h>
+#include <ert/ecl/ecl_endian_flip.h>
+
+
+void test_flags( const char * filename) {
+  int FLAG1 = 1;
+  int FLAG2 = 2;
+  int FLAG3 = 4;
+  int FLAG4 = 8;
+
+  int FLAGS = FLAG1 + FLAG2 + FLAG3;
+
+
+  ecl_file_type * ecl_file = ecl_file_open( filename , FLAGS );
+
+  test_assert_int_equal( ecl_file_get_flags( ecl_file ) , FLAGS );
+  test_assert_true( ecl_file_flags_set( ecl_file , FLAG1 ));
+  test_assert_true( ecl_file_flags_set( ecl_file , FLAG1 | FLAG2));
+  test_assert_true( ecl_file_flags_set( ecl_file , FLAG1 | FLAG3 ));
+  test_assert_true( ecl_file_flags_set( ecl_file , FLAG1 | FLAG3 | FLAG2 ));
+  test_assert_false( ecl_file_flags_set( ecl_file , FLAG1 | FLAG3 | FLAG4 ));
+  ecl_file_close( ecl_file );
+}
+
+
+void test_close_stream2(const char * src_file , const char * target_file ) {
+  util_copy_file( src_file , target_file );
+  ecl_file_type * ecl_file = ecl_file_open( target_file , ECL_FILE_CLOSE_STREAM );
+
+  ecl_file_load_all( ecl_file );
+  unlink( target_file );
+  ecl_kw_type * kw2 = ecl_file_iget_kw( ecl_file , 2 );
+  test_assert_not_NULL( kw2 );
+  ecl_file_close( ecl_file );
+}
+
+
+void test_loadall(const char * src_file , const char * target_file ) {
+  util_copy_file( src_file , target_file );
+  {
+    ecl_file_type * ecl_file = ecl_file_open( target_file , ECL_FILE_CLOSE_STREAM );
+
+    test_assert_true( ecl_file_load_all( ecl_file ) );
+    ecl_file_close( ecl_file );
+  }
+
+  {
+    ecl_file_type * ecl_file = ecl_file_open( target_file , ECL_FILE_CLOSE_STREAM );
+    unlink( target_file );
+
+    test_assert_false( ecl_file_load_all( ecl_file ) );
+    ecl_file_close( ecl_file );
+  }
+}
+
+
+
+void test_close_stream1(const char * src_file , const char * target_file ) {
+  util_copy_file( src_file , target_file );
+
+  ecl_file_type * ecl_file = ecl_file_open( target_file , ECL_FILE_CLOSE_STREAM );
+  ecl_kw_type * kw0 = ecl_file_iget_kw( ecl_file , 0 );
+  ecl_kw_type * kw1 = ecl_file_iget_kw( ecl_file , 1 );
+  unlink( target_file );
+  ecl_kw_type * kw1b = ecl_file_iget_kw( ecl_file , 1 );
+
+  test_assert_not_NULL( kw0 );
+  test_assert_not_NULL( kw1 );
+  test_assert_ptr_equal( kw1 , kw1b );
+
+  ecl_kw_type * kw2 = ecl_file_iget_kw( ecl_file , 2 );
+  test_assert_NULL( kw2 );
+
+  test_assert_false( ecl_file_writable( ecl_file ));
+
+  ecl_file_close( ecl_file );
+
+}
+
+
+void test_writable(const char * src_file ) {
+  test_work_area_type * work_area = test_work_area_alloc("ecl_file_writable" );
+  char * fname = util_split_alloc_filename( src_file );
+
+  test_work_area_copy_file( work_area , src_file );
+  {
+    test_flags( fname );
+    ecl_file_type * ecl_file = ecl_file_open( fname , ECL_FILE_WRITABLE);
+    ecl_kw_type * swat = ecl_file_iget_named_kw( ecl_file , "SWAT" , 0 );
+    ecl_kw_type * swat0 = ecl_kw_alloc_copy( swat );
+    test_assert_true( ecl_kw_equal( swat , swat0 ));
+    ecl_kw_iset_float( swat , 0 , 1000.0 );
+    ecl_file_save_kw( ecl_file , swat );
+    test_assert_true( ecl_file_writable( ecl_file ));
+    ecl_file_close( ecl_file );
+
+    ecl_file = ecl_file_open( fname , 0);
+    swat = ecl_file_iget_named_kw( ecl_file , "SWAT" , 1 );
+    test_assert_true( util_double_approx_equal( ecl_kw_iget_float( swat , 0 ) , 1000 ));
+  }
+  test_work_area_free( work_area );
+}
+
+
+
+void test_truncated() {
+  test_work_area_type * work_area = test_work_area_alloc("ecl_file_truncated" );
+  {
+    ecl_grid_type * grid = ecl_grid_alloc_rectangular(20,20,20,1,1,1,NULL);
+    ecl_grid_fwrite_EGRID2( grid , "TEST.EGRID", ECL_METRIC_UNITS );
+    ecl_grid_free( grid );
+  }
+  {
+    ecl_file_type * ecl_file = ecl_file_open("TEST.EGRID" , 0 );
+    test_assert_true( ecl_file_is_instance( ecl_file ) );
+    ecl_file_close( ecl_file );
+  }
+
+  {
+    offset_type file_size = util_file_size( "TEST.EGRID");
+    FILE * stream = util_fopen("TEST.EGRID" , "r+");
+    util_ftruncate( stream , file_size / 2 );
+    fclose( stream );
+  }
+  {
+    ecl_file_type * ecl_file = ecl_file_open("TEST.EGRID" , 0 );
+    test_assert_NULL( ecl_file );
+  }
+  test_work_area_free( work_area );
+}
+
+
+int main( int argc , char ** argv) {
+  const char * src_file = argv[1];
+  const char * target_file = argv[2];
+
+  {
+    test_work_area_type * work_area = test_work_area_alloc("ecl_file");
+
+    test_work_area_copy_file( work_area , src_file );
+    test_loadall(src_file , target_file );
+
+    test_close_stream1( src_file , target_file);
+    test_close_stream2( src_file , target_file);
+    test_writable( src_file );
+
+    test_work_area_free( work_area );
+  }
+  test_truncated();
+  exit(0);
+}

--- a/lib/ecl/tests/ecl_file_statoil.c
+++ b/lib/ecl/tests/ecl_file_statoil.c
@@ -1,8 +1,8 @@
 
 /*
-   Copyright (C) 2013  Statoil ASA, Norway.
+   Copyright (C) 2017  Statoil ASA, Norway.
 
-   The file 'ecl_file.c' is part of ERT - Ensemble based Reservoir Tool.
+   The file 'ecl_file_statoil.c' is part of ERT - Ensemble based Reservoir Tool.
 
    ERT is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -124,7 +124,7 @@ void test_writable(const char * src_file ) {
     ecl_file_close( ecl_file );
 
     ecl_file = ecl_file_open( fname , 0);
-    swat = ecl_file_iget_named_kw( ecl_file , "SWAT" , 1 );
+    swat = ecl_file_iget_named_kw( ecl_file , "SWAT" , 0 );
     test_assert_true( util_double_approx_equal( ecl_kw_iget_float( swat , 0 ) , 1000 ));
   }
   test_work_area_free( work_area );

--- a/lib/include/ert/ecl/fortio.h
+++ b/lib/include/ert/ecl/fortio.h
@@ -73,6 +73,7 @@ typedef struct fortio_struct fortio_type;
   void               fortio_data_fseek(fortio_type* fortio, offset_type data_offset, size_t data_element, const int element_size, const int element_count, const int block_size);
   int                fortio_fileno( fortio_type * fortio );
   bool               fortio_ftruncate( fortio_type * fortio , offset_type size);
+  int                fortio_fclean(fortio_type * fortio);
 
   bool               fortio_fclose_stream( fortio_type * fortio );
   bool               fortio_fopen_stream( fortio_type * fortio );

--- a/python/tests/ecl/test_ecl_file.py
+++ b/python/tests/ecl/test_ecl_file.py
@@ -79,7 +79,37 @@ class EclFileTest(ExtendedTestCase):
                 self.assertTrue( ecl_file.has_kw("KW2"))
                 self.assertEqual(ecl_file[1], ecl_file[-1])
 
+    def test_save_kw(self):
+        with TestAreaContext("python/ecl_file/save_kw"):
+            data = range(1000)
+            kw = EclKW("MY_KEY",  len(data), EclDataType.ECL_INT)
+            for index, val in enumerate(data):
+                kw[index] = val
 
+            clean_dump = "my_clean_file"
+            fortio = FortIO(clean_dump, FortIO.WRITE_MODE)
+            kw.fwrite(fortio)
+            fortio.close()
+
+            test_file = "my_dump_file"
+            fortio = FortIO(test_file, FortIO.WRITE_MODE)
+            kw.fwrite(fortio)
+            fortio.close()
+
+            self.assertFilesAreEqual(clean_dump, test_file)
+
+            ecl_file = EclFile(test_file, flags=EclFileFlagEnum.ECL_FILE_WRITABLE)
+            loaded_kw = ecl_file["MY_KEY"][0]
+            self.assertTrue(kw.equal(loaded_kw))
+
+            ecl_file.save_kw(loaded_kw)
+            ecl_file.close()
+
+            self.assertFilesAreEqual(clean_dump, test_file)
+
+            ecl_file = EclFile(test_file)
+            loaded_kw = ecl_file["MY_KEY"][0]
+            self.assertTrue(kw.equal(loaded_kw))
 
     def test_gc(self):
         kw1 = EclKW("KW1" , 100 , EclDataType.ECL_INT)


### PR DESCRIPTION
#### Task
_The EclKW test fails on OS X._

#### Approach
_It turned out to be an problem with ecl_file/fortio in C. The problem occurred in ecl_file_save_kw and the solution was to flush the fortio stream after skipping the header, but before writing the data._

**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [ ] Have completed graphical integration test steps
