### PR TITLE
Fortio write failure

### DIFF
--- a/lib/ecl/fortio.c
+++ b/lib/ecl/fortio.c
@@ -831,6 +831,17 @@ bool fortio_read_at_eof( fortio_type * fortio ) {
 
 }
 
+/*
+  When this function is called the underlying file is unlinked, and
+  the entry will be removed from the filsystem. Subsequent calls which
+  write to this file will still (superficially) succeed.
+*/
+
+void fortio_fwrite_error(fortio_type * fortio) {
+  if (fortio->writable)
+    unlink( fortio->filename );
+}
+
 
 /*****************************************************************/
 void          fortio_fflush(fortio_type * fortio) { fflush( fortio->stream); }

--- a/lib/ecl/fortio.c
+++ b/lib/ecl/fortio.c
@@ -88,7 +88,7 @@ struct fortio_struct {
     Observe that the semantics of the fortio_fseek() function depends
     on whether the file is writable.
   */
-  bool               readable;
+  bool               writable;
   offset_type        read_size;
 };
 
@@ -96,15 +96,16 @@ struct fortio_struct {
 UTIL_IS_INSTANCE_FUNCTION( fortio , FORTIO_ID );
 UTIL_SAFE_CAST_FUNCTION( fortio, FORTIO_ID );
 
-static fortio_type * fortio_alloc__(const char *filename , bool fmt_file , bool endian_flip_header , bool stream_owner , bool readable) {
+static fortio_type * fortio_alloc__(const char *filename , bool fmt_file , bool endian_flip_header , bool stream_owner , bool writable) {
   fortio_type * fortio       = util_malloc(sizeof * fortio );
   UTIL_TYPE_ID_INIT( fortio, FORTIO_ID );
   fortio->filename           = util_alloc_string_copy(filename);
   fortio->endian_flip_header = endian_flip_header;
   fortio->fmt_file           = fmt_file;
   fortio->stream_owner       = stream_owner;
-  fortio->read_size          = 0;
-  fortio->readable           = readable;
+  fortio->writable           = writable;
+  fortio->read_size = 0;
+
   return fortio;
 }
 
@@ -207,10 +208,9 @@ static void fortio_init_size(fortio_type * fortio) {
 
 
 
-fortio_type * fortio_alloc_FILE_wrapper(const char *filename , bool endian_flip_header , bool fmt_file , bool readable , FILE * stream) {
-  fortio_type * fortio = fortio_alloc__(filename , fmt_file , endian_flip_header , false , readable);
+fortio_type * fortio_alloc_FILE_wrapper(const char *filename , bool endian_flip_header , bool fmt_file , bool writable , FILE * stream) {
+  fortio_type * fortio = fortio_alloc__(filename , fmt_file , endian_flip_header , false , writable);
   fortio->stream = stream;
-  fortio_init_size( fortio );
   return fortio;
 }
 
@@ -291,7 +291,7 @@ static FILE * fortio_fopen_append( const char * filename , bool fmt_file ) {
 fortio_type * fortio_open_reader(const char *filename , bool fmt_file , bool endian_flip_header) {
   FILE * stream = fortio_fopen_read( filename , fmt_file );
   if (stream) {
-    fortio_type *fortio = fortio_alloc__(filename , fmt_file , endian_flip_header , true , true);
+    fortio_type *fortio = fortio_alloc__(filename , fmt_file , endian_flip_header , true , false);
     fortio->stream = stream;
     fortio->fopen_mode = fortio_fopen_read_mode( fmt_file );
     fortio_init_size( fortio );
@@ -306,7 +306,7 @@ fortio_type * fortio_open_reader(const char *filename , bool fmt_file , bool end
 fortio_type * fortio_open_writer(const char *filename , bool fmt_file , bool endian_flip_header ) {
   FILE * stream = fortio_fopen_write( filename , fmt_file );
   if (stream) {
-    fortio_type *fortio = fortio_alloc__(filename , fmt_file , endian_flip_header, true , false);
+    fortio_type *fortio = fortio_alloc__(filename , fmt_file , endian_flip_header, true , true);
     fortio->stream = stream;
     fortio->fopen_mode = fortio_fopen_write_mode( fmt_file );
     fortio_init_size( fortio );
@@ -333,7 +333,7 @@ fortio_type * fortio_open_readwrite(const char *filename , bool fmt_file , bool 
 fortio_type * fortio_open_append(const char *filename , bool fmt_file , bool endian_flip_header) {
   FILE * stream = fortio_fopen_append( filename , fmt_file );
   if (stream) {
-    fortio_type *fortio = fortio_alloc__(filename , fmt_file , endian_flip_header , true , false);
+    fortio_type *fortio = fortio_alloc__(filename , fmt_file , endian_flip_header , true , true);
 
     fortio->stream = stream;
     fortio->fopen_mode = fortio_fopen_append_mode( fmt_file );
@@ -760,16 +760,17 @@ static bool fortio_fseek__(fortio_type * fortio , offset_type offset , int whenc
   The semantics of this function depends on the readbale flag of the
   fortio structure:
 
-    readable == false: Ordinary fseek() semantics.
+    writable == true: Ordinary fseek() semantics which can potentially
+       grow the file.
 
-    readable == true: The function will only seek within the range of
+    writable == false: The function will only seek within the range of
        the file, and fail if you try to seek beyond the EOF marker.
 
 */
 
 
 bool fortio_fseek( fortio_type * fortio , offset_type offset , int whence) {
-  if (!fortio->readable)
+  if (fortio->writable)
     return fortio_fseek__( fortio , offset , whence );
   else {
     offset_type new_offset = 0;

--- a/lib/ecl/tests/ecl_fortio.c
+++ b/lib/ecl/tests/ecl_fortio.c
@@ -276,6 +276,25 @@ void test_fseek() {
 
 
 
+void test_write_failure() {
+  test_work_area_type * work_area = test_work_area_alloc("fortio_fseek" );
+  {
+    fortio_type * fortio = fortio_open_writer("PRESSURE" , false , true);
+    void * buffer = util_malloc( 100 );
+
+    fortio_fwrite_record( fortio , buffer , 100);
+    test_assert_true( util_file_exists( "PRESSURE"));
+    fortio_fwrite_error( fortio );
+    test_assert_false( util_file_exists( "PRESSURE"));
+    fortio_fwrite_record( fortio , buffer , 100);
+    free( buffer );
+    fortio_fclose( fortio );
+    test_assert_false( util_file_exists( "PRESSURE"));
+
+  }
+  test_work_area_free( work_area );
+}
+
 
 int main( int argc , char ** argv) {
   util_install_signals();
@@ -303,6 +322,8 @@ int main( int argc , char ** argv) {
       test_write( "path/file.x" , true );
       test_work_area_free( work_area );
     }
+
+    test_write_failure();
 
     exit(0);
   }

--- a/lib/include/ert/ecl/fortio.h
+++ b/lib/include/ert/ecl/fortio.h
@@ -80,6 +80,7 @@ typedef struct fortio_struct fortio_type;
   bool               fortio_stream_is_open( const fortio_type * fortio );
   bool               fortio_assert_stream_open( fortio_type * fortio );
   bool               fortio_read_at_eof( fortio_type * fortio );
+  void               fortio_fwrite_error(fortio_type * fortio);
 
 UTIL_IS_INSTANCE_HEADER( fortio );
 UTIL_SAFE_CAST_HEADER( fortio );


### PR DESCRIPTION
**Task**
Possible to mark a writable fortio instance as "failed" - it will be removed when closing the fortio instance.


**Approach**
Call to `unlink( )`


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
