### PR TITLE
Allowing kw of more than 9 chars

### DIFF
--- a/lib/ecl/ecl_kw.c
+++ b/lib/ecl/ecl_kw.c
@@ -1715,17 +1715,13 @@ void ecl_kw_fwrite_header(const ecl_kw_type *ecl_kw , fortio_type *fortio) {
 
 
 bool ecl_kw_fwrite(const ecl_kw_type *ecl_kw , fortio_type *fortio) {
-  bool verify_kw_header_len = true;
-
-  if (  strlen(ecl_kw_get_header(ecl_kw)) > ECL_STRING8_LENGTH   ) {
-     verify_kw_header_len = false;
+  if (strlen(ecl_kw_get_header( ecl_kw)) > ECL_STRING8_LENGTH) {
      fortio_fwrite_error(fortio);
+     return false;
   }
-  else {  
-     ecl_kw_fwrite_header(ecl_kw ,  fortio);
-     ecl_kw_fwrite_data(ecl_kw   ,  fortio);
-  }
-  return verify_kw_header_len;
+  ecl_kw_fwrite_header(ecl_kw ,  fortio);
+  ecl_kw_fwrite_data(ecl_kw   ,  fortio);
+  return true;
 }
 
 

--- a/lib/ecl/ecl_kw.c
+++ b/lib/ecl/ecl_kw.c
@@ -1717,8 +1717,10 @@ void ecl_kw_fwrite_header(const ecl_kw_type *ecl_kw , fortio_type *fortio) {
 bool ecl_kw_fwrite(const ecl_kw_type *ecl_kw , fortio_type *fortio) {
   bool verify_kw_header_len = true;
 
-  if (  strlen(ecl_kw_get_header(ecl_kw)) > ECL_STRING8_LENGTH   )
+  if (  strlen(ecl_kw_get_header(ecl_kw)) > ECL_STRING8_LENGTH   ) {
      verify_kw_header_len = false;
+     fortio_fwrite_error(fortio);
+  }
   else {  
      ecl_kw_fwrite_header(ecl_kw ,  fortio);
      ecl_kw_fwrite_data(ecl_kw   ,  fortio);

--- a/lib/ecl/ecl_kw.c
+++ b/lib/ecl/ecl_kw.c
@@ -474,9 +474,6 @@ static void ecl_kw_set_shared_ref(ecl_kw_type * ecl_kw , void *data_ptr) {
 
 static void ecl_kw_initialize(ecl_kw_type * ecl_kw , const char *header ,  int size , ecl_data_type data_type) {
   ecl_kw_set_data_type(ecl_kw, data_type);
-  if (strlen(header) > ECL_STRING8_LENGTH)
-    util_abort("%s: Fatal error: ecl_header_name:%s is longer than eight characters - aborting \n",__func__,header);
-
   ecl_kw_set_header_name(ecl_kw , header);
   ecl_kw->size = size;
 }
@@ -1474,11 +1471,17 @@ void ecl_kw_free_data(ecl_kw_type *ecl_kw) {
 
 void ecl_kw_set_header_name(ecl_kw_type * ecl_kw , const char * header) {
   ecl_kw->header8 = realloc(ecl_kw->header8 , ECL_STRING8_LENGTH + 1);
-  sprintf(ecl_kw->header8 , "%-8s" , header);
+  if (strlen(header) <= 8) {
+     sprintf(ecl_kw->header8 , "%-8s" , header);
 
-  /* Internalizing a header without the trailing spaces as well. */
-  util_safe_free( ecl_kw->header );
-  ecl_kw->header = util_alloc_strip_copy( ecl_kw->header8 );
+     /* Internalizing a header without the trailing spaces as well. */
+     util_safe_free( ecl_kw->header );
+     ecl_kw->header = util_alloc_strip_copy( ecl_kw->header8 );
+  }
+  else {
+     ecl_kw->header = util_alloc_copy(header, strlen( header ) + 1);
+  }
+
 }
 
 
@@ -1711,9 +1714,16 @@ void ecl_kw_fwrite_header(const ecl_kw_type *ecl_kw , fortio_type *fortio) {
 }
 
 
-void ecl_kw_fwrite(const ecl_kw_type *ecl_kw , fortio_type *fortio) {
-  ecl_kw_fwrite_header(ecl_kw ,  fortio);
-  ecl_kw_fwrite_data(ecl_kw   ,  fortio);
+bool ecl_kw_fwrite(const ecl_kw_type *ecl_kw , fortio_type *fortio) {
+  bool verify_kw_header_len = true;
+
+  if (  strlen(ecl_kw_get_header(ecl_kw)) > ECL_STRING8_LENGTH   )
+     verify_kw_header_len = false;
+  else {  
+     ecl_kw_fwrite_header(ecl_kw ,  fortio);
+     ecl_kw_fwrite_data(ecl_kw   ,  fortio);
+  }
+  return verify_kw_header_len;
 }
 
 

--- a/lib/ecl/ecl_kw_grdecl.c
+++ b/lib/ecl/ecl_kw_grdecl.c
@@ -25,6 +25,7 @@
 #include <ert/ecl/ecl_type.h>
 #include <ert/ecl/ecl_util.h>
 
+#define MAX_GRDECL_KW_SIZE 512
 
 /*
   This file is devoted to different routines for reading and writing
@@ -517,6 +518,9 @@ static char * fscanf_alloc_grdecl_data( const char * header , bool strict , ecl_
 */
 
 static ecl_kw_type * __ecl_kw_fscanf_alloc_grdecl__(FILE * stream , const char * header , bool strict , int size , ecl_data_type data_type) {
+  if (strlen(header) > MAX_GRDECL_KW_SIZE)
+    util_abort("%s cannot read KW of more than %d bytes. strlen(header) == %d\n", __func__, MAX_GRDECL_KW_SIZE, strlen(header) );
+
   if (!ecl_type_is_numeric(data_type))
     util_abort("%s: sorry only types FLOAT, INT and DOUBLE supported\n",__func__);
 
@@ -525,7 +529,7 @@ static ecl_kw_type * __ecl_kw_fscanf_alloc_grdecl__(FILE * stream , const char *
       return NULL;  /* Could not find it. */
 
   {
-    char file_header[9];
+    char file_header[MAX_GRDECL_KW_SIZE];
     if (fscanf(stream , "%s" , file_header) == 1) {
       int kw_size;
       char * data = fscanf_alloc_grdecl_data( file_header , strict , data_type , &kw_size , stream );

--- a/lib/ecl/fortio.c
+++ b/lib/ecl/fortio.c
@@ -831,6 +831,17 @@ bool fortio_read_at_eof( fortio_type * fortio ) {
 
 }
 
+/*
+  When this function is called the underlying file is unlinked, and
+  the entry will be removed from the filsystem. Subsequent calls which
+  write to this file will still (superficially) succeed.
+*/
+
+void fortio_fwrite_error(fortio_type * fortio) {
+  if (fortio->writable)
+    unlink( fortio->filename );
+}
+
 
 /*****************************************************************/
 void          fortio_fflush(fortio_type * fortio) { fflush( fortio->stream); }

--- a/lib/ecl/fortio.c
+++ b/lib/ecl/fortio.c
@@ -88,7 +88,7 @@ struct fortio_struct {
     Observe that the semantics of the fortio_fseek() function depends
     on whether the file is writable.
   */
-  bool               readable;
+  bool               writable;
   offset_type        read_size;
 };
 
@@ -96,15 +96,16 @@ struct fortio_struct {
 UTIL_IS_INSTANCE_FUNCTION( fortio , FORTIO_ID );
 UTIL_SAFE_CAST_FUNCTION( fortio, FORTIO_ID );
 
-static fortio_type * fortio_alloc__(const char *filename , bool fmt_file , bool endian_flip_header , bool stream_owner , bool readable) {
+static fortio_type * fortio_alloc__(const char *filename , bool fmt_file , bool endian_flip_header , bool stream_owner , bool writable) {
   fortio_type * fortio       = util_malloc(sizeof * fortio );
   UTIL_TYPE_ID_INIT( fortio, FORTIO_ID );
   fortio->filename           = util_alloc_string_copy(filename);
   fortio->endian_flip_header = endian_flip_header;
   fortio->fmt_file           = fmt_file;
   fortio->stream_owner       = stream_owner;
-  fortio->read_size          = 0;
-  fortio->readable           = readable;
+  fortio->writable           = writable;
+  fortio->read_size = 0;
+
   return fortio;
 }
 
@@ -207,10 +208,9 @@ static void fortio_init_size(fortio_type * fortio) {
 
 
 
-fortio_type * fortio_alloc_FILE_wrapper(const char *filename , bool endian_flip_header , bool fmt_file , bool readable , FILE * stream) {
-  fortio_type * fortio = fortio_alloc__(filename , fmt_file , endian_flip_header , false , readable);
+fortio_type * fortio_alloc_FILE_wrapper(const char *filename , bool endian_flip_header , bool fmt_file , bool writable , FILE * stream) {
+  fortio_type * fortio = fortio_alloc__(filename , fmt_file , endian_flip_header , false , writable);
   fortio->stream = stream;
-  fortio_init_size( fortio );
   return fortio;
 }
 
@@ -291,7 +291,7 @@ static FILE * fortio_fopen_append( const char * filename , bool fmt_file ) {
 fortio_type * fortio_open_reader(const char *filename , bool fmt_file , bool endian_flip_header) {
   FILE * stream = fortio_fopen_read( filename , fmt_file );
   if (stream) {
-    fortio_type *fortio = fortio_alloc__(filename , fmt_file , endian_flip_header , true , true);
+    fortio_type *fortio = fortio_alloc__(filename , fmt_file , endian_flip_header , true , false);
     fortio->stream = stream;
     fortio->fopen_mode = fortio_fopen_read_mode( fmt_file );
     fortio_init_size( fortio );
@@ -306,7 +306,7 @@ fortio_type * fortio_open_reader(const char *filename , bool fmt_file , bool end
 fortio_type * fortio_open_writer(const char *filename , bool fmt_file , bool endian_flip_header ) {
   FILE * stream = fortio_fopen_write( filename , fmt_file );
   if (stream) {
-    fortio_type *fortio = fortio_alloc__(filename , fmt_file , endian_flip_header, true , false);
+    fortio_type *fortio = fortio_alloc__(filename , fmt_file , endian_flip_header, true , true);
     fortio->stream = stream;
     fortio->fopen_mode = fortio_fopen_write_mode( fmt_file );
     fortio_init_size( fortio );
@@ -333,7 +333,7 @@ fortio_type * fortio_open_readwrite(const char *filename , bool fmt_file , bool 
 fortio_type * fortio_open_append(const char *filename , bool fmt_file , bool endian_flip_header) {
   FILE * stream = fortio_fopen_append( filename , fmt_file );
   if (stream) {
-    fortio_type *fortio = fortio_alloc__(filename , fmt_file , endian_flip_header , true , false);
+    fortio_type *fortio = fortio_alloc__(filename , fmt_file , endian_flip_header , true , true);
 
     fortio->stream = stream;
     fortio->fopen_mode = fortio_fopen_append_mode( fmt_file );
@@ -760,16 +760,17 @@ static bool fortio_fseek__(fortio_type * fortio , offset_type offset , int whenc
   The semantics of this function depends on the readbale flag of the
   fortio structure:
 
-    readable == false: Ordinary fseek() semantics.
+    writable == true: Ordinary fseek() semantics which can potentially
+       grow the file.
 
-    readable == true: The function will only seek within the range of
+    writable == false: The function will only seek within the range of
        the file, and fail if you try to seek beyond the EOF marker.
 
 */
 
 
 bool fortio_fseek( fortio_type * fortio , offset_type offset , int whence) {
-  if (!fortio->readable)
+  if (fortio->writable)
     return fortio_fseek__( fortio , offset , whence );
   else {
     offset_type new_offset = 0;

--- a/lib/ecl/tests/ecl_fortio.c
+++ b/lib/ecl/tests/ecl_fortio.c
@@ -276,6 +276,25 @@ void test_fseek() {
 
 
 
+void test_write_failure() {
+  test_work_area_type * work_area = test_work_area_alloc("fortio_fseek" );
+  {
+    fortio_type * fortio = fortio_open_writer("PRESSURE" , false , true);
+    void * buffer = util_malloc( 100 );
+
+    fortio_fwrite_record( fortio , buffer , 100);
+    test_assert_true( util_file_exists( "PRESSURE"));
+    fortio_fwrite_error( fortio );
+    test_assert_false( util_file_exists( "PRESSURE"));
+    fortio_fwrite_record( fortio , buffer , 100);
+    free( buffer );
+    fortio_fclose( fortio );
+    test_assert_false( util_file_exists( "PRESSURE"));
+
+  }
+  test_work_area_free( work_area );
+}
+
 
 int main( int argc , char ** argv) {
   util_install_signals();
@@ -303,6 +322,8 @@ int main( int argc , char ** argv) {
       test_write( "path/file.x" , true );
       test_work_area_free( work_area );
     }
+
+    test_write_failure();
 
     exit(0);
   }

--- a/lib/ecl/tests/ecl_kw_fread.c
+++ b/lib/ecl/tests/ecl_kw_fread.c
@@ -80,27 +80,37 @@ void test_fread_alloc() {
 void test_kw_io_charlength() {
   test_work_area_type * work_area = test_work_area_alloc("ecl_kw_io_charlength");
   { 
-    const char * KW = "ABCDEFGHIJTTTTTTTTTTTTTTTTTTTTTTABCDEFGHIJKLMNOP";
-    ecl_kw_type * ecl_kw_out = ecl_kw_alloc(KW , 5, ECL_FLOAT);
-    for (int i=0; i < ecl_kw_get_size( ecl_kw_out); i++)
-       ecl_kw_iset_float( ecl_kw_out , i , i*1.5 );
+    const char * KW0 = "QWERTYUI";
+    const char * KW1 = "ABCDEFGHIJTTTTTTTTTTTTTTTTTTTTTTABCDEFGHIJKLMNOP";
+    ecl_kw_type * ecl_kw_out0 = ecl_kw_alloc(KW0 , 5, ECL_FLOAT);
+    ecl_kw_type * ecl_kw_out1 = ecl_kw_alloc(KW1 , 5, ECL_FLOAT);
+    for (int i=0; i < ecl_kw_get_size( ecl_kw_out1); i++) {
+       ecl_kw_iset_float( ecl_kw_out0 , i , i*1.5 );
+       ecl_kw_iset_float( ecl_kw_out1 , i , i*1.5 );
+    }
 
     {
        fortio_type * f = fortio_open_writer( "TEST1" , false, ECL_ENDIAN_FLIP );
-       test_assert_false(ecl_kw_fwrite( ecl_kw_out, f ));
+       test_assert_true( ecl_kw_fwrite( ecl_kw_out0, f ));
+       test_assert_false(ecl_kw_fwrite( ecl_kw_out1, f ));
        fortio_fclose( f );
+    }
+
+    {
+       FILE * file = fopen("TEST1", "r");
+       test_assert_true(file == NULL);
     }
    
     {
        FILE * file = util_fopen("TEST2", "w");
-       ecl_kw_fprintf_grdecl(ecl_kw_out , file);
+       ecl_kw_fprintf_grdecl(ecl_kw_out1 , file);
        fclose(file);
     }
     
     {
        FILE * file = util_fopen("TEST2", "r");
-       ecl_kw_type * ecl_kw_in = ecl_kw_fscanf_alloc_grdecl( file , KW , -1 , ECL_FLOAT);
-       test_assert_string_equal(KW, ecl_kw_get_header(ecl_kw_in) );
+       ecl_kw_type * ecl_kw_in = ecl_kw_fscanf_alloc_grdecl( file , KW1 , -1 , ECL_FLOAT);
+       test_assert_string_equal(KW1, ecl_kw_get_header(ecl_kw_in) );
        test_assert_int_equal(5, ecl_kw_get_size( ecl_kw_in) );
 
        test_assert_double_equal(ecl_kw_iget_as_double(ecl_kw_in, 0), 0.0);
@@ -109,8 +119,8 @@ void test_kw_io_charlength() {
        fclose(file);
     }
     
-
-    ecl_kw_free( ecl_kw_out );
+    ecl_kw_free( ecl_kw_out0 );
+    ecl_kw_free( ecl_kw_out1 );
   }
   test_work_area_free( work_area );
 }

--- a/lib/ecl/tests/ecl_kw_fread.c
+++ b/lib/ecl/tests/ecl_kw_fread.c
@@ -74,9 +74,33 @@ void test_fread_alloc() {
   test_work_area_free( work_area );
 }
 
+void test_kw_io_charlength() {
+  test_work_area_type * work_area = test_work_area_alloc("ecl_kw_io_charlength");
+  {
+    //0: ecl_kw_alloc shall accept HEADER of more than 8 chars in length
+   
+    //1: write ecl_kw to TEST.INIT, assert return fail (false)
+
+    //2: write ecl_kw to TEST.ECLGRID, assert return success (true)
+
+    //3: a) rename TEST.INIT to TEST.ECLGRID, try to read, assert return success (true)
+    //   b) assert correct float values
+
+    //Part1:
+    {
+       //ecl_kw_type * ecl_kw = ecl_kw_alloc_long_str("ABCDEFGHIJ" , 5, ECL_FLOAT);
+     
+
+       //ecl_kw_free( ecl_kw );
+    }
+  }
+  test_work_area_free( work_area );
+}
+
 
 int main(int argc , char ** argv) {
   test_fread_alloc();
+  test_kw_io_charlength();
   exit(0);
 }
 

--- a/lib/ecl/tests/ecl_kw_fread.c
+++ b/lib/ecl/tests/ecl_kw_fread.c
@@ -97,8 +97,7 @@ void test_kw_io_charlength() {
     }
 
     {
-       FILE * file = fopen("TEST1", "r");
-       test_assert_true(file == NULL);
+       test_assert_false( util_file_exists( "TEST1"));
     }
    
     {

--- a/lib/include/ert/ecl/ecl_kw.h
+++ b/lib/include/ert/ecl/ecl_kw.h
@@ -105,7 +105,7 @@ extern "C" {
   void           ecl_kw_get_memcpy_double_data(const ecl_kw_type *ecl_kw , double *target);
   void           ecl_kw_get_memcpy_int_data(const ecl_kw_type *ecl_kw , int *target);
   void           ecl_kw_set_memcpy_data(ecl_kw_type * , const void *);
-  void           ecl_kw_fwrite(const ecl_kw_type *,  fortio_type *);
+  bool           ecl_kw_fwrite(const ecl_kw_type *,  fortio_type *);
   void           ecl_kw_iget(const ecl_kw_type *, int , void *);
   void           ecl_kw_iset(ecl_kw_type *ecl_kw , int i , const void *iptr);
   void           ecl_kw_iset_char_ptr( ecl_kw_type * ecl_kw , int index, const char * s);

--- a/lib/include/ert/ecl/fortio.h
+++ b/lib/include/ert/ecl/fortio.h
@@ -80,6 +80,7 @@ typedef struct fortio_struct fortio_type;
   bool               fortio_stream_is_open( const fortio_type * fortio );
   bool               fortio_assert_stream_open( fortio_type * fortio );
   bool               fortio_read_at_eof( fortio_type * fortio );
+  void               fortio_fwrite_error(fortio_type * fortio);
 
 UTIL_IS_INSTANCE_HEADER( fortio );
 UTIL_SAFE_CAST_HEADER( fortio );


### PR DESCRIPTION
**Task**

When reading grdecl files it should be allowed with keywords of more than 8 characters. If a keyword has more than 8 characters writing to a fortio file should fail.



**Approach**
Changes have been made in ecl_kw.c and ecl_kw_grdecl.c. ecl_kw_alloc can use headers more than 8 chars long. It is possible to read (grdecl) kw of more than 8 chars. 


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [ ] Have completed graphical integration test steps
