### PR TITLE
Set ERT_ROOT env variable before running tests.

### DIFF
--- a/python/cmake/Modules/add_python_test.cmake
+++ b/python/cmake/Modules/add_python_test.cmake
@@ -34,5 +34,5 @@ macro( addPythonTest TEST_CLASS )
         set_property(TEST ${TEST_NAME} PROPERTY LABELS "Python")
     endif()
 
-    set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT "CTEST_PYTHONPATH=${CTEST_PYTHONPATH}")
+    set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT "CTEST_PYTHONPATH=${CTEST_PYTHONPATH};ERT_ROOT=${ERT_ROOT}")
 endmacro( )


### PR DESCRIPTION
**Task**
Set ERT_ROOT variable before running Python tests. This should die anyway...

**Approach**
Set env variable property from cmake.

**Pre un-WIP checklist**
- [x] Statoil tests pass locally

