### PR TITLE
Removed extra (wrong) link line for openmp

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -204,7 +204,6 @@ endif()
 
 if (ERT_USE_OPENMP)
     target_compile_options(ecl PUBLIC ${OpenMP_C_FLAGS})
-    target_link_libraries( ecl PUBLIC ${OpenMP_C_FLAGS})
     target_link_libraries( ecl PUBLIC ${OpenMP_EXE_LINKER_FLAGS})
 endif ()
 


### PR DESCRIPTION
**Task**
Build fails when OpenMP is enabled.

**Approach**
Removed line from CMakeLists.txt


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
