### PR TITLE
Fix compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,7 @@ check_symbol_exists( tzname time.h HAVE_TZNAME)
 check_include_file(execinfo.h HAVE_EXECINFO)
 check_include_file(getopt.h   ERT_HAVE_GETOPT)
 check_include_file(unistd.h   ERT_HAVE_UNISTD)
+check_include_file(io.h       ERT_HAVE_IO)
 
 check_type_size(time_t SIZE_OF_TIME_T)
 if (${SIZE_OF_TIME_T} EQUAL 8)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -95,6 +95,7 @@ add_library(ecl util/rng.c
                 util/util_env.c
                 util/util_symlink.c
                 util/util_lfs.c
+                util/util_unlink.c
                 util/msg.c
                 util/arg_pack.c
                 util/path_fmt.c

--- a/lib/ecl/fortio.c
+++ b/lib/ecl/fortio.c
@@ -839,7 +839,7 @@ bool fortio_read_at_eof( fortio_type * fortio ) {
 
 void fortio_fwrite_error(fortio_type * fortio) {
   if (fortio->writable)
-    unlink( fortio->filename );
+    util_unlink( fortio->filename );
 }
 
 

--- a/lib/ecl/layer.c
+++ b/lib/ecl/layer.c
@@ -452,7 +452,7 @@ static bool layer_find_edge( const layer_type * layer , int *i , int *j , int va
 bool layer_trace_block_edge( const layer_type * layer , int start_i , int start_j , int value , struct_vector_type * corner_list , int_vector_type * cell_list) {
   int g = layer_get_global_cell_index( layer , start_i , start_j);
   cell_type * cell = &layer->data[g];
-  if ((cell->cell_value == value)) {
+  if (cell->cell_value == value) {
     int i = start_i;
     int j = start_j;
 

--- a/lib/ecl/tests/ecl_grid_cell_contains.c
+++ b/lib/ecl/tests/ecl_grid_cell_contains.c
@@ -116,7 +116,7 @@ void test_contains( const ecl_grid_type * grid ) {
   for (int k=0; k < nz; k++) {
     for (int j=0; j < ny; j++) {
       for (int i=0; i < nx; i++) {
-        if (!ecl_grid_get_cell_twist3( grid , i,j,k) == 0) {
+        if (ecl_grid_get_cell_twist3( grid , i,j,k) != 0) {
           double x,y,z;
           if (get_test_point3( grid , i,j,k , &x,&y,&z)) {
             assert_contains( grid , i , j , k , x , y , z);

--- a/lib/ecl/tests/ecl_grid_cell_contains_wellpath.c
+++ b/lib/ecl/tests/ecl_grid_cell_contains_wellpath.c
@@ -71,7 +71,7 @@ vector_type * load_expected( const ecl_grid_type * grid, const char * filename )
 }
 
 
-int test_well_point(const ecl_grid_type * grid, const point_type * expected) {
+void test_well_point(const ecl_grid_type * grid, const point_type * expected) {
   int g = ecl_grid_get_global_index_from_xyz(grid , expected->x, expected->y , expected->z , 0 );
   if (g != ecl_grid_get_global_index3(grid, expected->i,expected->j, expected->k)) {
     int i,j,k;

--- a/lib/ecl/tests/test_ecl_nnc_data.c
+++ b/lib/ecl/tests/test_ecl_nnc_data.c
@@ -72,7 +72,7 @@ void test_alloc_global_only(bool data_in_file) {
 
             test_assert_true( ecl_file_view_has_kw( view_file, TRANNNC_KW) );
             test_assert_true(nnc_data_size == 3);
-            double * values = ecl_nnc_data_get_values( nnc_geo_data );
+            const double * values = ecl_nnc_data_get_values( nnc_geo_data );
             test_assert_double_equal(values[0] , 0);
             test_assert_double_equal(values[1] , 1.5);
             test_assert_double_equal(values[2] , 3.0);

--- a/lib/include/ert/util/util.h
+++ b/lib/include/ert/util/util.h
@@ -531,9 +531,7 @@ void    util_abort_set_executable( const char * argv0 );
   bool         util_try_lockf(const char *  , mode_t  , int * );
 #endif
 
-
-
-
+#include "util_unlink.h"
 
 #ifdef __cplusplus
 }

--- a/lib/include/ert/util/util_unlink.h
+++ b/lib/include/ert/util/util_unlink.h
@@ -1,0 +1,33 @@
+/*
+   Copyright (C) 2017  Statoil ASA, Norway. 
+    
+   The file 'util_unlink.h' is part of ERT - Ensemble based Reservoir Tool. 
+    
+   ERT is free software: you can redistribute it and/or modify 
+   it under the terms of the GNU General Public License as published by 
+   the Free Software Foundation, either version 3 of the License, or 
+   (at your option) any later version. 
+    
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+   FITNESS FOR A PARTICULAR PURPOSE.   
+    
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+   for more details. 
+*/
+
+
+#ifndef ERT_UTIL_UNLINK_H
+#define ERT_UTIL_UNLINK_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  
+  int util_unlink(const char * filename);
+  
+#ifdef __cplusplus
+}
+#endif
+#endif
+

--- a/lib/util/thread_pool_posix.c
+++ b/lib/util/thread_pool_posix.c
@@ -366,14 +366,14 @@ bool thread_pool_try_join(thread_pool_type * pool, int timeout_seconds) {
 
   pool->join = true;                               /* Signals to the main thread that joining can start. */
   if (pool->max_running > 0) {
-    struct timespec ts;
     time_t timeout_time = time( NULL );
-
     util_inplace_forward_seconds_utc(&timeout_time , timeout_seconds );
-    ts.tv_sec = timeout_time;
-    ts.tv_nsec = 0;
 
 #ifdef HAVE_TIMEDJOIN
+
+    struct timespec ts;
+    ts.tv_sec = timeout_time;
+    ts.tv_nsec = 0;
 
     {
       int join_return = pthread_timedjoin_np( pool->dispatch_thread , NULL , &ts);  /* Wait for the main thread to complete. */

--- a/lib/util/util_unlink.c
+++ b/lib/util/util_unlink.c
@@ -1,0 +1,37 @@
+/*
+   Copyright (C) 2017  Statoil ASA, Norway.
+
+   The file 'util_unlink.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+
+#if defined(ERT_HAVE_UNISTD)
+  #include <unistd.h>
+#elif defined(ERT_HAVE_IO)
+  #include <io.h>
+#else
+  #include <ert/util/util.h>
+#endif
+
+int util_unlink(const char * filename) {
+#if defined(ERT_HAVE_UNISTD)
+ return unlink(filename);
+#elif defined(ERT_HAVE_IO)
+ return _unlink(filename);
+#else
+ util_abort("%s: No unlink functionality available.\n", __func__);
+ return -1;
+#endif
+}


### PR DESCRIPTION
**Task**
_Get rid of compiler warnings._


**Approach**
_These fixes allows compiling libecl with -Werror=all._


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
