### PR TITLE
WIP: Ecl sum alloc shall write RESTART_KW

### DIFF
--- a/lib/ecl/ecl_smspec.c
+++ b/lib/ecl/ecl_smspec.c
@@ -502,8 +502,8 @@ ecl_smspec_type * ecl_smspec_alloc_writer( const char * key_join_string , const 
   if (restart_case != NULL) {
      if (strlen(restart_case) <= (SUMMARY_RESTART_SIZE * ECL_STRING8_LENGTH))
         ecl_smspec->restart_case = util_alloc_string_copy( restart_case );
-     else
-        printf("Error in function %s: restart_case name is too long. Restart_case_name set to NULL.\n", __func__);
+     else 
+        return NULL;
   }
   ecl_smspec->grid_dims[0] = nx;
   ecl_smspec->grid_dims[1] = ny;

--- a/lib/ecl/ecl_smspec.c
+++ b/lib/ecl/ecl_smspec.c
@@ -366,11 +366,11 @@ static void ecl_smspec_fortio_fwrite( const ecl_smspec_type * smspec , fortio_ty
   int num_nodes           = ecl_smspec_num_nodes( smspec );
   {
     ecl_kw_type * restart_kw = ecl_kw_alloc( RESTART_KW , SUMMARY_RESTART_SIZE , ECL_CHAR );
-    const char * restart_case = smspec->restart_case;
+    const char * restart_case = smspec->write_restart_case;
     if (restart_case != NULL) {
        int restart_case_len = strlen(restart_case);
        if (restart_case_len > 64)
-          util_abort("%s: Restart case name, %s, is too long.\n", __func__, restart_case);
+          util_abort("%s: Restart case name, %s, is too long w/ %d chars.\n", __func__, restart_case, restart_case_len);
        else {                     
           for (int i = 0; i < SUMMARY_RESTART_SIZE; i++) {
              char str[9];
@@ -515,11 +515,11 @@ void ecl_smspec_fwrite( const ecl_smspec_type * smspec , const char * ecl_case ,
   free( filename );
 }
 
-ecl_smspec_type * ecl_smspec_alloc_writer( const char * key_join_string , const char * restart_case, time_t sim_start , bool time_in_days , int nx , int ny , int nz) {
+ecl_smspec_type * ecl_smspec_alloc_writer( const char * key_join_string , const char * write_restart_case, time_t sim_start , bool time_in_days , int nx , int ny , int nz) {
   ecl_smspec_type * ecl_smspec = ecl_smspec_alloc_empty( true , key_join_string );
   
-  if (restart_case != NULL)
-     ecl_smspec->restart_case = util_alloc_copy(restart_case, strlen( restart_case ) + 1);
+  if (write_restart_case != NULL)
+     ecl_smspec->write_restart_case = util_alloc_copy(write_restart_case, strlen( write_restart_case ) + 1);
   ecl_smspec->grid_dims[0] = nx;
   ecl_smspec->grid_dims[1] = ny;
   ecl_smspec->grid_dims[2] = nz;

--- a/lib/ecl/ecl_smspec.c
+++ b/lib/ecl/ecl_smspec.c
@@ -369,29 +369,19 @@ static void ecl_smspec_fortio_fwrite( const ecl_smspec_type * smspec , fortio_ty
     
     if (smspec->write_restart_case != NULL) {
        int restart_case_len = strlen(smspec->write_restart_case);                           
-       for (int i = 0; i < SUMMARY_RESTART_SIZE; i++) {
-          char str[ECL_STRING8_LENGTH + 1];
-          
-          for (int j = 0; j <= ECL_STRING8_LENGTH; j++) {
-             int index = ECL_STRING8_LENGTH * i + j;
-             if (j == ECL_STRING8_LENGTH) {
-                str[ECL_STRING8_LENGTH] = '\0';
-                break;
-             }
-             if (index < restart_case_len)
-                str[j] = smspec->write_restart_case[index];
-             else {
-                str[j] = '\0'; 
-                break;
-             }
-          }
-          ecl_kw_iset_string8( restart_kw, i, str);  
-       }              
-       
+     
+       int offset = 0;
+       for (int i = 0; i < SUMMARY_RESTART_SIZE ; i++) {
+          if (offset < restart_case_len)
+              ecl_kw_iset_string8( restart_kw , i , &smspec->write_restart_case[ offset ]);
+          else
+              ecl_kw_iset_string8( restart_kw , i , "");
+          offset += ECL_STRING8_LENGTH;
+       } 
     }
     else
        for (int i=0; i < SUMMARY_RESTART_SIZE; i++)
-          ecl_kw_iset_string8( restart_kw , i , "");
+           ecl_kw_iset_string8( restart_kw , i , "");
 
     ecl_kw_fwrite( restart_kw , fortio );
     ecl_kw_free( restart_kw );

--- a/lib/ecl/ecl_smspec.c
+++ b/lib/ecl/ecl_smspec.c
@@ -366,14 +366,27 @@ static void ecl_smspec_fortio_fwrite( const ecl_smspec_type * smspec , fortio_ty
     ecl_kw_type * restart_kw = ecl_kw_alloc( RESTART_KW , SUMMARY_RESTART_SIZE , ECL_CHAR );
     const char * restart_case = smspec->restart_case;
     if (restart_case != NULL) {
-       if (strlen(restart_case) > 64)
+       int restart_case_len = strlen(restart_case);
+       if (restart_case_len > 64)
           util_abort("%s: Restart case name, %s, is too long.\n", __func__, restart_case);
-       else {
+       else {                     
           for (int i = 0; i < SUMMARY_RESTART_SIZE; i++) {
              char str[9];
-             str[8] = '\0';
-             for (int j = 0; j < 8; j++)
-                str[j] = restart_case[8 * i + j];
+             
+             for (int j = 0; j < 9; j++) {
+                int index = 8 * i + j;
+                if (j == 8) {
+                   str[8] = '\0';
+                   break;
+                }
+                if (index < restart_case_len)
+                   str[j] = restart_case[index];
+                else {
+                   str[j] = '\0'; 
+                   break;
+                }
+             }
+
              ecl_kw_iset_string8( restart_kw, i, str);  
           }              
        }
@@ -1005,7 +1018,7 @@ static void ecl_smspec_load_restart( ecl_smspec_type * ecl_smspec , const ecl_fi
     char * restart_base;
     int i;
     tmp_base[0] = '\0';
-    for (i=0; i < ecl_kw_get_size( restart_kw ); i++)
+    for (i=0; i < ecl_kw_get_size( restart_kw ); i++) 
       strcat( tmp_base , ecl_kw_iget_ptr( restart_kw , i ));
 
     restart_base = util_alloc_strip_copy( tmp_base );

--- a/lib/ecl/ecl_smspec.c
+++ b/lib/ecl/ecl_smspec.c
@@ -141,7 +141,6 @@ struct ecl_smspec_struct {
   float_vector_type * params_default;
 
   char              * restart_case;
-  char              * write_restart_case;
 };
 
 
@@ -275,7 +274,6 @@ static ecl_smspec_type * ecl_smspec_alloc_empty(bool write_mode , const char * k
 
   ecl_smspec->index_map = int_vector_alloc(0,0);
   ecl_smspec->restart_case = NULL;
-  ecl_smspec->write_restart_case = NULL;
   ecl_smspec->params_default = float_vector_alloc(0 , PARAMS_GLOBAL_DEFAULT);
   ecl_smspec->write_mode = write_mode;
   ecl_smspec->need_nums = false;
@@ -366,22 +364,19 @@ static void ecl_smspec_fortio_fwrite( const ecl_smspec_type * smspec , fortio_ty
   int num_nodes           = ecl_smspec_num_nodes( smspec );
   {
     ecl_kw_type * restart_kw = ecl_kw_alloc( RESTART_KW , SUMMARY_RESTART_SIZE , ECL_CHAR );
-    
-    if (smspec->write_restart_case != NULL) {
-       int restart_case_len = strlen(smspec->write_restart_case);                           
+    for (int i=0; i < SUMMARY_RESTART_SIZE; i++)
+           ecl_kw_iset_string8( restart_kw , i , "");
+
+    if (smspec->restart_case != NULL) {
+       int restart_case_len = strlen(smspec->restart_case);                           
      
        int offset = 0;
        for (int i = 0; i < SUMMARY_RESTART_SIZE ; i++) {
           if (offset < restart_case_len)
-              ecl_kw_iset_string8( restart_kw , i , &smspec->write_restart_case[ offset ]);
-          else
-              ecl_kw_iset_string8( restart_kw , i , "");
+              ecl_kw_iset_string8( restart_kw , i , &smspec->restart_case[ offset ]);
           offset += ECL_STRING8_LENGTH;
        } 
     }
-    else
-       for (int i=0; i < SUMMARY_RESTART_SIZE; i++)
-           ecl_kw_iset_string8( restart_kw , i , "");
 
     ecl_kw_fwrite( restart_kw , fortio );
     ecl_kw_free( restart_kw );
@@ -501,12 +496,12 @@ void ecl_smspec_fwrite( const ecl_smspec_type * smspec , const char * ecl_case ,
   free( filename );
 }
 
-ecl_smspec_type * ecl_smspec_alloc_writer( const char * key_join_string , const char * write_restart_case, time_t sim_start , bool time_in_days , int nx , int ny , int nz) {
+ecl_smspec_type * ecl_smspec_alloc_writer( const char * key_join_string , const char * restart_case, time_t sim_start , bool time_in_days , int nx , int ny , int nz) {
   ecl_smspec_type * ecl_smspec = ecl_smspec_alloc_empty( true , key_join_string );
   
-  if (write_restart_case != NULL) {
-     if (strlen(write_restart_case) <= (SUMMARY_RESTART_SIZE * ECL_STRING8_LENGTH))
-        ecl_smspec->write_restart_case = util_alloc_string_copy( write_restart_case );
+  if (restart_case != NULL) {
+     if (strlen(restart_case) <= (SUMMARY_RESTART_SIZE * ECL_STRING8_LENGTH))
+        ecl_smspec->restart_case = util_alloc_string_copy( restart_case );
      else
         printf("Error in function %s: restart_case name is too long. Restart_case_name set to NULL.\n", __func__);
   }
@@ -1675,7 +1670,6 @@ void ecl_smspec_free(ecl_smspec_type *ecl_smspec) {
   float_vector_free( ecl_smspec->params_default );
   vector_free( ecl_smspec->smspec_nodes );
   free( ecl_smspec->restart_case );
-  free( ecl_smspec->write_restart_case );
   free( ecl_smspec );
 }
 

--- a/lib/ecl/ecl_smspec.c
+++ b/lib/ecl/ecl_smspec.c
@@ -366,11 +366,11 @@ static void ecl_smspec_fortio_fwrite( const ecl_smspec_type * smspec , fortio_ty
   int num_nodes           = ecl_smspec_num_nodes( smspec );
   {
     ecl_kw_type * restart_kw = ecl_kw_alloc( RESTART_KW , SUMMARY_RESTART_SIZE , ECL_CHAR );
-    const char * restart_case = smspec->write_restart_case;
-    if (restart_case != NULL) {
-       int restart_case_len = strlen(restart_case);
+    
+    if (smspec->write_restart_case != NULL) {
+       int restart_case_len = strlen(smspec->write_restart_case);
        if (restart_case_len > 64)
-          util_abort("%s: Restart case name, %s, is too long w/ %d chars.\n", __func__, restart_case, restart_case_len);
+          util_abort("%s: Restart case name, %s, is too long w/ %d chars.\n", __func__, smspec->write_restart_case, restart_case_len);
        else {                     
           for (int i = 0; i < SUMMARY_RESTART_SIZE; i++) {
              char str[9];
@@ -382,7 +382,7 @@ static void ecl_smspec_fortio_fwrite( const ecl_smspec_type * smspec , fortio_ty
                    break;
                 }
                 if (index < restart_case_len)
-                   str[j] = restart_case[index];
+                   str[j] = smspec->write_restart_case[index];
                 else {
                    str[j] = '\0'; 
                    break;

--- a/lib/ecl/ecl_smspec.c
+++ b/lib/ecl/ecl_smspec.c
@@ -141,6 +141,7 @@ struct ecl_smspec_struct {
   float_vector_type * params_default;
 
   char              * restart_case;
+  char              * write_restart_case;
 };
 
 
@@ -274,6 +275,7 @@ static ecl_smspec_type * ecl_smspec_alloc_empty(bool write_mode , const char * k
 
   ecl_smspec->index_map = int_vector_alloc(0,0);
   ecl_smspec->restart_case = NULL;
+  ecl_smspec->write_restart_case = NULL;
   ecl_smspec->params_default = float_vector_alloc(0 , PARAMS_GLOBAL_DEFAULT);
   ecl_smspec->write_mode = write_mode;
   ecl_smspec->need_nums = false;
@@ -1683,6 +1685,7 @@ void ecl_smspec_free(ecl_smspec_type *ecl_smspec) {
   float_vector_free( ecl_smspec->params_default );
   vector_free( ecl_smspec->smspec_nodes );
   free( ecl_smspec->restart_case );
+  free( ecl_smspec->write_restart_case );
   free( ecl_smspec );
 }
 

--- a/lib/ecl/ecl_sum.c
+++ b/lib/ecl/ecl_sum.c
@@ -304,16 +304,13 @@ ecl_sum_tstep_type * ecl_sum_add_tstep( ecl_sum_type * ecl_sum , int report_step
 
 
 ecl_sum_type * ecl_sum_alloc_restart_writer( const char * ecl_case , const char * restart_case , bool fmt_output , bool unified , const char * key_join_string , time_t sim_start , bool time_in_days , int nx , int ny , int nz) {
+  
   ecl_sum_type * ecl_sum = ecl_sum_alloc__( ecl_case , key_join_string );
   ecl_sum_set_unified( ecl_sum , unified );
   ecl_sum_set_fmt_case( ecl_sum , fmt_output );
 
-  ecl_sum->smspec = ecl_smspec_alloc_writer( key_join_string , sim_start , time_in_days , nx , ny , nz );
+  ecl_sum->smspec = ecl_smspec_alloc_writer( key_join_string , restart_case, sim_start , time_in_days , nx , ny , nz );
   ecl_sum->data   = ecl_sum_data_alloc_writer( ecl_sum->smspec );
-
-  //tar inn navn på sim, ecl_case, skal skrive den 
-  //ta inn et case til, car restart case, 
-  //når den skriver summary fil, inne i filen skal det være stå restart_case.
 
   return ecl_sum;
 }

--- a/lib/ecl/ecl_sum.c
+++ b/lib/ecl/ecl_sum.c
@@ -303,7 +303,7 @@ ecl_sum_tstep_type * ecl_sum_add_tstep( ecl_sum_type * ecl_sum , int report_step
 }
 
 
-ecl_sum_type * ecl_sum_alloc_writer( const char * ecl_case , bool fmt_output , bool unified , const char * key_join_string , time_t sim_start , bool time_in_days , int nx , int ny , int nz) {
+ecl_sum_type * ecl_sum_alloc_restart_writer( const char * ecl_case , const char * restart_case , bool fmt_output , bool unified , const char * key_join_string , time_t sim_start , bool time_in_days , int nx , int ny , int nz) {
   ecl_sum_type * ecl_sum = ecl_sum_alloc__( ecl_case , key_join_string );
   ecl_sum_set_unified( ecl_sum , unified );
   ecl_sum_set_fmt_case( ecl_sum , fmt_output );
@@ -311,10 +311,16 @@ ecl_sum_type * ecl_sum_alloc_writer( const char * ecl_case , bool fmt_output , b
   ecl_sum->smspec = ecl_smspec_alloc_writer( key_join_string , sim_start , time_in_days , nx , ny , nz );
   ecl_sum->data   = ecl_sum_data_alloc_writer( ecl_sum->smspec );
 
+  //tar inn navn på sim, ecl_case, skal skrive den 
+  //ta inn et case til, car restart case, 
+  //når den skriver summary fil, inne i filen skal det være stå restart_case.
+
   return ecl_sum;
 }
 
-
+ecl_sum_type * ecl_sum_alloc_writer( const char * ecl_case , bool fmt_output , bool unified , const char * key_join_string , time_t sim_start , bool time_in_days , int nx , int ny , int nz) {
+  return ecl_sum_alloc_restart_writer(ecl_case, NULL, fmt_output, unified, key_join_string, sim_start, time_in_days, nx, ny, nz);
+}
 
 void ecl_sum_fwrite( const ecl_sum_type * ecl_sum ) {
   ecl_sum_fwrite_smspec( ecl_sum );

--- a/lib/ecl/tests/ecl_sum_writer.c
+++ b/lib/ecl/tests/ecl_sum_writer.c
@@ -140,7 +140,6 @@ void test_ecl_sum_alloc_restart_writer() {
       const char * name1 = "CASE1";
       const char * name2 = "CASE2";
       time_t start_time = util_make_date_utc( 1,1,2010 );
-      time_t end_time = start_time;
       int nx = 10;
       int ny = 11;
       int nz = 12;
@@ -178,7 +177,7 @@ void test_ecl_sum_alloc_restart_writer() {
 
 
 void test_long_restart_names() {
-   char restart_case[65] = "";
+   char restart_case[65] = { 0 };
    for (int n = 0; n < 8; n++) {
       char s[9];
       sprintf(s, "WWWWGGG%d", n);

--- a/lib/ecl/tests/ecl_sum_writer.c
+++ b/lib/ecl/tests/ecl_sum_writer.c
@@ -148,20 +148,14 @@ void test_ecl_sum_alloc_restart_writer() {
       int num_ministep = 10;
       double ministep_length = 36000; // Seconds
 
-      printf(" ************************ %s: %d\n", __func__, 1);
-
       int sim_seconds = write_summary( name1 , start_time , nx , ny , nz , num_dates , num_ministep , ministep_length);  
       sim_seconds = write_restart_summary( name2 , name1 , num_dates, sim_seconds, start_time , nx , ny , nz , num_dates , num_ministep , ministep_length);
-
-      printf(" ************************ %s: %d\n", __func__, 2);
 
       ecl_sum_type * case1 = ecl_sum_fread_alloc_case( name1 , ":" );
       ecl_sum_type * case2 = ecl_sum_fread_alloc_case( name2 , ":" );
       test_assert_true( ecl_sum_is_instance(case2) );
 
       test_assert_true( ecl_sum_has_key( case2 , "FOPT" ));
-
-      printf(" ************************ %s: %d\n", __func__, 3);
 
       ecl_file_type * restart_file = ecl_file_open( "CASE2.SMSPEC" , 0 );
       ecl_file_view_type * view_file = ecl_file_get_global_view( restart_file );    
@@ -170,8 +164,6 @@ void test_ecl_sum_alloc_restart_writer() {
       test_assert_int_equal(8, ecl_kw_get_size(kw));
       test_assert_string_equal( "CASE1   ", ecl_kw_iget_ptr( kw , 0 ) );
       test_assert_string_equal( "        ", ecl_kw_iget_ptr( kw , 1 ) );
-
-      printf(" ************************ %s: %d\n", __func__, 4);
 
       for (int time_index=0; time_index < ecl_sum_get_data_length( case1 ); time_index++) 
          test_assert_double_equal(  ecl_sum_get_general_var( case1 , time_index , "FOPT"), ecl_sum_get_general_var( case2 , time_index , "FOPT"));
@@ -192,19 +184,13 @@ void test_long_restart_names() {
       sprintf(s, "WWWWGGG%d", n);
       strcat(restart_case, s);
    }
-   printf(" ************************ %s: %d\n", __func__, 1);
    const char * name = "THE_CASE";
    test_work_area_type * work_area = test_work_area_alloc("sum_write_restart_long_name");
-
-   printf(" ************************ %s: %d\n", __func__, 2);
-
    {
        time_t start_time = util_make_date_utc( 1,1,2010 );
        ecl_sum_type * ecl_sum = ecl_sum_alloc_restart_writer( name , restart_case , false , true , ":" , start_time , true , 3, 3, 3);
        ecl_sum_fwrite( ecl_sum );
        ecl_sum_free(ecl_sum);
-    
-       printf(" ************************ %s: %d\n", __func__, 3);
              
        ecl_file_type * smspec_file = ecl_file_open( "THE_CASE.SMSPEC" , 0 );
        ecl_file_view_type * view_file = ecl_file_get_global_view( smspec_file );    
@@ -212,14 +198,10 @@ void test_long_restart_names() {
        ecl_kw_type * kw = ecl_file_view_iget_kw(view_file, 0);
        test_assert_int_equal(8, ecl_kw_get_size(kw));
 
-       printf(" ************************ %s: %d\n", __func__, 4);
-
        for (int n = 0; n < 8; n++) {
          char s[9]; sprintf(s, "WWWWGGG%d", n);
          test_assert_string_equal(s, ecl_kw_iget_char_ptr(kw, n) );
        }
-
-       printf(" ************************ %s: %d\n", __func__, 5);
 
    }
    test_work_area_free( work_area );

--- a/lib/ecl/tests/ecl_sum_writer.c
+++ b/lib/ecl/tests/ecl_sum_writer.c
@@ -202,8 +202,10 @@ void test_long_restart_names() {
          char s[9]; sprintf(s, "WWWWGGG%d", n);
          test_assert_string_equal(s, ecl_kw_iget_char_ptr(kw, n) );
        }
-
+       strcat(restart_case, "A");
+       test_assert_NULL( ecl_smspec_alloc_writer( ":" , restart_case, start_time, true, 3, 3 ,3) );
    }
+
    test_work_area_free( work_area );
   
 }

--- a/lib/ecl/tests/ecl_sum_writer.c
+++ b/lib/ecl/tests/ecl_sum_writer.c
@@ -101,6 +101,8 @@ void test_write_read( ) {
   }
 }
 
+void test_ecl_sum_alloc_restart_writer() {
+}
 
 
 int main( int argc , char ** argv) {

--- a/lib/ecl/tests/ecl_sum_writer.c
+++ b/lib/ecl/tests/ecl_sum_writer.c
@@ -201,8 +201,8 @@ void test_long_restart_names() {
          char s[9]; sprintf(s, "WWWWGGG%d", n);
          test_assert_string_equal(s, ecl_kw_iget_char_ptr(kw, n) );
        }
-       strcat(restart_case, "A");
-       test_assert_NULL( ecl_smspec_alloc_writer( ":" , restart_case, start_time, true, 3, 3 ,3) );
+       
+       test_assert_NULL( ecl_smspec_alloc_writer( ":" , "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ", start_time, true, 3, 3 ,3) );
    }
 
    test_work_area_free( work_area );

--- a/lib/ecl/tests/ecl_sum_writer.c
+++ b/lib/ecl/tests/ecl_sum_writer.c
@@ -210,10 +210,7 @@ void test_long_restart_names() {
 
 int main( int argc , char ** argv) {
   test_write_read();
-  printf(" ******************* HERE MAIN 1\n");
   test_ecl_sum_alloc_restart_writer();
-  printf(" ******************* HERE MAIN 2\n");
   test_long_restart_names();
-  printf(" ******************* HERE MAIN 3\n");
   exit(0);
 }

--- a/lib/ecl/tests/ecl_sum_writer.c
+++ b/lib/ecl/tests/ecl_sum_writer.c
@@ -148,14 +148,20 @@ void test_ecl_sum_alloc_restart_writer() {
       int num_ministep = 10;
       double ministep_length = 36000; // Seconds
 
+      printf(" ************************ %s: %d\n", __func__, 1);
+
       int sim_seconds = write_summary( name1 , start_time , nx , ny , nz , num_dates , num_ministep , ministep_length);  
       sim_seconds = write_restart_summary( name2 , name1 , num_dates, sim_seconds, start_time , nx , ny , nz , num_dates , num_ministep , ministep_length);
+
+      printf(" ************************ %s: %d\n", __func__, 2);
 
       ecl_sum_type * case1 = ecl_sum_fread_alloc_case( name1 , ":" );
       ecl_sum_type * case2 = ecl_sum_fread_alloc_case( name2 , ":" );
       test_assert_true( ecl_sum_is_instance(case2) );
 
       test_assert_true( ecl_sum_has_key( case2 , "FOPT" ));
+
+      printf(" ************************ %s: %d\n", __func__, 3);
 
       ecl_file_type * restart_file = ecl_file_open( "CASE2.SMSPEC" , 0 );
       ecl_file_view_type * view_file = ecl_file_get_global_view( restart_file );    
@@ -164,6 +170,8 @@ void test_ecl_sum_alloc_restart_writer() {
       test_assert_int_equal(8, ecl_kw_get_size(kw));
       test_assert_string_equal( "CASE1   ", ecl_kw_iget_ptr( kw , 0 ) );
       test_assert_string_equal( "        ", ecl_kw_iget_ptr( kw , 1 ) );
+
+      printf(" ************************ %s: %d\n", __func__, 4);
 
       for (int time_index=0; time_index < ecl_sum_get_data_length( case1 ); time_index++) 
          test_assert_double_equal(  ecl_sum_get_general_var( case1 , time_index , "FOPT"), ecl_sum_get_general_var( case2 , time_index , "FOPT"));
@@ -184,13 +192,19 @@ void test_long_restart_names() {
       sprintf(s, "WWWWGGG%d", n);
       strcat(restart_case, s);
    }
+   printf(" ************************ %s: %d\n", __func__, 1);
    const char * name = "THE_CASE";
    test_work_area_type * work_area = test_work_area_alloc("sum_write_restart_long_name");
+
+   printf(" ************************ %s: %d\n", __func__, 2);
+
    {
        time_t start_time = util_make_date_utc( 1,1,2010 );
        ecl_sum_type * ecl_sum = ecl_sum_alloc_restart_writer( name , restart_case , false , true , ":" , start_time , true , 3, 3, 3);
        ecl_sum_fwrite( ecl_sum );
        ecl_sum_free(ecl_sum);
+    
+       printf(" ************************ %s: %d\n", __func__, 3);
              
        ecl_file_type * smspec_file = ecl_file_open( "THE_CASE.SMSPEC" , 0 );
        ecl_file_view_type * view_file = ecl_file_get_global_view( smspec_file );    
@@ -198,10 +212,14 @@ void test_long_restart_names() {
        ecl_kw_type * kw = ecl_file_view_iget_kw(view_file, 0);
        test_assert_int_equal(8, ecl_kw_get_size(kw));
 
+       printf(" ************************ %s: %d\n", __func__, 4);
+
        for (int n = 0; n < 8; n++) {
          char s[9]; sprintf(s, "WWWWGGG%d", n);
          test_assert_string_equal(s, ecl_kw_iget_char_ptr(kw, n) );
        }
+
+       printf(" ************************ %s: %d\n", __func__, 5);
 
    }
    test_work_area_free( work_area );
@@ -210,7 +228,10 @@ void test_long_restart_names() {
 
 int main( int argc , char ** argv) {
   test_write_read();
+  printf(" ******************* HERE MAIN 1\n");
   test_ecl_sum_alloc_restart_writer();
+  printf(" ******************* HERE MAIN 2\n");
   test_long_restart_names();
+  printf(" ******************* HERE MAIN 3\n");
   exit(0);
 }

--- a/lib/include/ert/ecl/ecl_smspec.h
+++ b/lib/include/ert/ecl/ecl_smspec.h
@@ -54,7 +54,7 @@ typedef struct ecl_smspec_struct ecl_smspec_type;
   bool                ecl_smspec_needs_wgname( ecl_smspec_var_type var_type );
   const char        * ecl_smspec_get_var_type_name( ecl_smspec_var_type var_type );
   ecl_smspec_var_type ecl_smspec_identify_var_type(const char * var);
-  ecl_smspec_type   * ecl_smspec_alloc_writer( const char * key_join_string , time_t sim_start , bool time_in_days , int nx , int ny , int nz);
+  ecl_smspec_type   * ecl_smspec_alloc_writer( const char * key_join_string , const char * restart_case, time_t sim_start , bool time_in_days , int nx , int ny , int nz);
   void                ecl_smspec_fwrite( const ecl_smspec_type * smspec , const char * ecl_case , bool fmt_file );
 
   ecl_smspec_type *        ecl_smspec_fread_alloc(const char *header_file, const char * key_join_string , bool include_restart);

--- a/lib/include/ert/ecl/ecl_sum.h
+++ b/lib/include/ert/ecl/ecl_sum.h
@@ -192,6 +192,7 @@ typedef struct ecl_sum_struct       ecl_sum_type;
   int                   ecl_sum_iget_report_end( const ecl_sum_type * ecl_sum , int report_step );
   int                   ecl_sum_iget_report_start( const ecl_sum_type * ecl_sum , int report_step );
 
+  ecl_sum_type * ecl_sum_alloc_restart_writer( const char * ecl_case , const char * restart_case , bool fmt_output , bool unified , const char * key_join_string , time_t sim_start , bool time_in_days , int nx , int ny , int nz);
   ecl_sum_type        * ecl_sum_alloc_writer( const char * ecl_case , bool fmt_output , bool unified , const char * key_join_string , time_t sim_start , bool time_in_days , int nx , int ny , int nz);
   void                  ecl_sum_set_case( ecl_sum_type * ecl_sum , const char * ecl_case);
   void                  ecl_sum_fwrite( const ecl_sum_type * ecl_sum );

--- a/python/python/ecl/ecl/ecl_sum.py
+++ b/python/python/ecl/ecl/ecl_sum.py
@@ -84,7 +84,7 @@ def date2num( dt ):
 class EclSum(BaseCClass):
     TYPE_NAME = "ecl_sum"
     _fread_alloc                   = EclPrototype("void*     ecl_sum_fread_alloc_case__( char* , char* , bool)" , bind = False )
-    _create_writer                 = EclPrototype("ecl_sum_obj  ecl_sum_alloc_writer( char* , bool , bool , char* , time_t , bool , int , int , int)" , bind = False)
+    _create_restart_writer         = EclPrototype("ecl_sum_obj  ecl_sum_alloc_restart_writer( char* , char* , bool , bool , char* , time_t , bool , int , int , int)" , bind = False)
     _iiget                         = EclPrototype("double   ecl_sum_iget( ecl_sum , int , int)")
     _free                          = EclPrototype("void     ecl_sum_free( ecl_sum )")
     _data_length                   = EclPrototype("int      ecl_sum_get_data_length( ecl_sum )")
@@ -190,8 +190,15 @@ class EclSum(BaseCClass):
         The writer is not generally usable.
         @rtype: EclSum
         """
-        return EclSum._create_writer( case , fmt_output , unified , key_join_string , CTime(start_time) , time_in_days , nx , ny , nz)
+        return EclSum._create_restart_writer( case , None, fmt_output , unified , key_join_string , CTime(start_time) , time_in_days , nx , ny , nz)
 
+    @staticmethod
+    def restart_writer(case , restart_case, start_time , nx,ny,nz , fmt_output = False , unified = True , time_in_days = True , key_join_string = ":"):
+        """
+        The writer is not generally usable.
+        @rtype: EclSum
+        """
+        return EclSum._create_restart_writer( case , restart_case , fmt_output , unified , key_join_string , CTime(start_time) , time_in_days , nx , ny , nz)
 
     def addVariable(self , variable , wgname = None , num = 0 , unit = "None" , default_value = 0):
         return self._add_variable(variable , wgname , num , unit , default_value).setParent( parent = self )


### PR DESCRIPTION
**Task**
Smspec files may contain a restart keyword linking a restart case back to a previous case. There is functionality in libecl for writing smspec files, but these recently used empty RESTART_KW. 
Now, RESTART_KW will be written to disc by ecl_smspec_fwrite (called from ecl_sum) containing link to the previous case. 


**Approach**
Parameter const car * restart_case has been allowed as input to ecl_sum_alloc_restart_write. This is used in the function ecl_smspec_fortio_fwrit, writing restart_case to disc (restart_case will be part of RESTART_KW).


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
