### PR TITLE
Exported header should not include build_config.h

### DIFF
--- a/lib/include/ert/util/util_unlink.h
+++ b/lib/include/ert/util/util_unlink.h
@@ -20,18 +20,13 @@
 #ifndef ERT_UTIL_UNLINK_H
 #define ERT_UTIL_UNLINK_H
 
-#include "ert/util/build_config.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#if defined(HAVE_POSIX_UNLINK) || defined(HAVE_WINDOWS_UNLINK)
-
   int util_unlink(const char * filename);
 
-#endif
-  
 #ifdef __cplusplus
 }
 #endif

--- a/lib/util/util_unlink.c
+++ b/lib/util/util_unlink.c
@@ -34,4 +34,8 @@ int util_unlink(const char * filename) {
  return unlink(filename);
 }
 
+#else
+
+#error "No unlinke implementation on this platform"
+
 #endif


### PR DESCRIPTION
**Task**
The exported header `util_unlink.h` included the private header `build_config.h`


**Approach**
Moved #define symbols.


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
