### PR TITLE
Make log.h includes self-sufficient

### DIFF
--- a/lib/include/ert/util/log.h
+++ b/lib/include/ert/util/log.h
@@ -25,6 +25,7 @@ extern "C" {
 
 #include <stdbool.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 //Same as pythons default log levels, but with different numeric values.
 typedef enum {


### PR DESCRIPTION
**Task**
_util/log.h cannot be included as is, without first including stdio._


**Approach**
_Include stdio.h in util/log.h_


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
