### PR TITLE
Back compat subst list getitem

### DIFF
--- a/python/python/ecl/util/substitution_list.py
+++ b/python/python/ecl/util/substitution_list.py
@@ -14,8 +14,8 @@ class SubstitutionList(BaseCClass):
     _has_key = UtilPrototype("bool subst_list_has_key(subst_list, char*)")
     _get_doc = UtilPrototype("char* subst_list_get_doc_string(subst_list, char*)")
     _append_copy = UtilPrototype("void subst_list_append_copy(subst_list, char*, char*, char*)")
-    
-    
+
+
     def __init__(self):
         c_ptr = self._alloc(0)
         super(SubstitutionList, self).__init__(c_ptr)
@@ -26,13 +26,13 @@ class SubstitutionList(BaseCClass):
     def addItem(self, key, value, doc_string=""):
         self._append_copy(key, value, doc_string)
 
-        
+
     def keys(self):
         key_list = []
         for i in range(len(self)):
             key_list.append( self._iget_key( i ))
         return key_list
-    
+
 
     def __iter__(self):
         index = 0
@@ -43,7 +43,7 @@ class SubstitutionList(BaseCClass):
 
     def __contains__(self, key):
         return self._has_key( key )
-    
+
     def __getitem__(self, key):
         if key in self:
             return self._get_value( key )
@@ -56,7 +56,7 @@ class SubstitutionList(BaseCClass):
         else:
             raise KeyError("No such key:%s" % key)
 
-        
+
     def indexForKey(self, key):
         if not key in self:
             raise KeyError("Key '%s' not in substitution list!" % key)

--- a/python/python/ecl/util/substitution_list.py
+++ b/python/python/ecl/util/substitution_list.py
@@ -42,6 +42,8 @@ class SubstitutionList(BaseCClass):
             yield (key , self[key], self.doc(key))
 
     def __contains__(self, key):
+        if not isinstance(key, str):
+            return False
         return self._has_key( key )
 
     def __getitem__(self, key):
@@ -49,6 +51,10 @@ class SubstitutionList(BaseCClass):
             return self._get_value( key )
         else:
             raise KeyError("No such key:%s" % key)
+
+
+    def get(self, key, default=None):
+        return self[key] if key in self else default
 
     def doc(self,key):
         if key in self:
@@ -69,3 +75,10 @@ class SubstitutionList(BaseCClass):
 
     def free(self):
         self._free()
+
+
+    def __repr__(self):
+        return self._create_repr('len=%d' % len(self))
+
+    def __str__(self):
+        return 'SubstitutionList{%s}' % ", ".join(map(str, self.keys()))

--- a/python/tests/util/test_substitution_list.py
+++ b/python/tests/util/test_substitution_list.py
@@ -11,6 +11,9 @@ class SubstitutionListTest(ExtendedTestCase):
         self.assertEqual(len(subst_list), 1)
 
         with self.assertRaises(KeyError):
+            item = subst_list[2]
+
+        with self.assertRaises(KeyError):
             item = subst_list["NoSuchKey"]
 
         with self.assertRaises(KeyError):
@@ -26,4 +29,13 @@ class SubstitutionListTest(ExtendedTestCase):
         keys = subst_list.keys( )
         self.assertEqual(keys[0] , "Key")
         self.assertEqual(keys[1] , "Key2")
-        
+
+        self.assertIn('Key', str(subst_list))
+        self.assertIn('SubstitutionList', repr(subst_list))
+        self.assertIn('2', repr(subst_list))
+
+        self.assertEqual(1729, subst_list.get('nosuchkey', 1729))
+        self.assertIsNone(subst_list.get('nosuchkey'))
+        self.assertIsNone(subst_list.get(513))
+        for key in ('Key', 'Key2'):
+            self.assertEqual(subst_list[key], subst_list.get(key))

--- a/python/tests/util/test_substitution_list.py
+++ b/python/tests/util/test_substitution_list.py
@@ -19,7 +19,7 @@ class SubstitutionListTest(ExtendedTestCase):
         self.assertTrue("Key" in subst_list)
         self.assertEqual(subst_list["Key"] , "Value")
         self.assertEqual(subst_list.doc("Key") , "Doc String")
-        
+
         subst_list.addItem("Key2", "Value2", "Doc String2")
         self.assertEqual(len(subst_list), 2)
 


### PR DESCRIPTION
**Task**
Fix bug ERT-1316 where internal scripts rely on legacy versions of `SubstitutionList.__contains__` and `...._getitem_`.

**Approach**
Added a `.get` in the style of `dict`s get function.  Updated internal scripts to try to use `get` if it exists, else fall back to legacy use of `SubstitutionList`.

**Beware**: this PR also checks that any **key** is an instance `str`, else returns `False` in any `contains` or `getitem` call (the latter will throw `KeyError`).


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
