### PR TITLE
Smspec cmp + correct padding of ecl_kw string keywords

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -279,6 +279,11 @@ foreach (name   ert_util_alloc_file_components
     add_test(NAME ${name} COMMAND ${name})
 endforeach ()
 
+add_executable(ecl_smspec_node ecl/tests/ecl_smspec_node.c)
+target_link_libraries( ecl_smspec_node ecl)
+add_test(NAME ecl_smspec_node COMMAND ecl_smspec_node)
+
+
 add_executable(ert_util_work_area util/tests/ert_util_work_area.c)
 target_link_libraries(ert_util_work_area ecl)
 add_test(NAME ert_util_work_area

--- a/lib/ecl/Smspec.cpp
+++ b/lib/ecl/Smspec.cpp
@@ -21,6 +21,10 @@ namespace ERT {
         return *this;
     }
 
+    int smspec_node::cmp( const smspec_node& node1, const smspec_node& node2) {
+        return smspec_node_cmp( node1.get() , node2.get() );
+    }
+
     static const int dummy_dims[ 3 ] = { -1, -1, -1 };
     const auto default_join = ":";
 

--- a/lib/ecl/ecl_kw.c
+++ b/lib/ecl/ecl_kw.c
@@ -850,9 +850,11 @@ void ecl_kw_iset_char_ptr( ecl_kw_type * ecl_kw , int index, const char * s) {
 }
 
 /**
- * This function will verify that the given string is of approperiate length
- * (0 <= lenght <= data_type.element_size). If so, the elements of @s will be
- * written to the @ecl_kw string array starting at @index.
+ This function will verify that the given string is of approperiate
+ length (0 <= lenght <= data_type.element_size). If so, the elements
+ of @s will be written to the @ecl_kw string array starting at
+ @index. If the input string is shorter than the type length the
+ string will be padded with trailing spaces.
  */
 void ecl_kw_iset_string_ptr( ecl_kw_type * ecl_kw, int index, const char * s) {
   if(!ecl_type_is_alpha(ecl_kw_get_data_type(ecl_kw))) {
@@ -866,11 +868,18 @@ void ecl_kw_iset_string_ptr( ecl_kw_type * ecl_kw, int index, const char * s) {
   if(input_len > type_len)
     util_abort("%s: String of length %d cannot hold input string of length %d\n", __func__, type_len, input_len);
 
-  char * ecl_string = (char *) ecl_kw_iget_ptr(ecl_kw, index);
-  for(int i = 0; i < input_len; ++i)
-    ecl_string[i] = s[i];
+  {
+    char * ecl_string = (char *) ecl_kw_iget_ptr(ecl_kw, index);
+    int i;
 
-  ecl_string[input_len] = '\0';
+    for(i = 0; i < input_len; ++i)
+      ecl_string[i] = s[i];
+
+    for (i=input_len; i < type_len; ++i)
+      ecl_string[i] = ' ';
+
+    ecl_string[type_len] = '\0';
+  }
 }
 
 

--- a/lib/ecl/ecl_smspec.c
+++ b/lib/ecl/ecl_smspec.c
@@ -1874,3 +1874,14 @@ void ecl_smspec_update_wgname( ecl_smspec_type * smspec , smspec_node_type * nod
 char * ecl_smspec_alloc_well_key( const ecl_smspec_type * smspec , const char * keyword , const char * wgname) {
   return smspec_alloc_well_key( smspec->key_join_string , keyword , wgname );
 }
+
+
+void ecl_smspec_sort( ecl_smspec_type * smspec ) {
+  vector_sort( smspec->smspec_nodes , smspec_node_cmp__);
+
+  for (int i=0; i < vector_get_size( smspec->smspec_nodes ); i++) {
+    smspec_node_type * node = vector_iget( smspec->smspec_nodes , i );
+    smspec_node_set_params_index( node , i );
+  }
+
+}

--- a/lib/ecl/ecl_smspec.c
+++ b/lib/ecl/ecl_smspec.c
@@ -346,12 +346,15 @@ void ecl_smspec_lock( ecl_smspec_type * smspec ) {
 static ecl_data_type get_wgnames_type(const ecl_smspec_type * smspec) {
   size_t max_len = 0;
   for(int i = 0; i < ecl_smspec_num_nodes(smspec); ++i) {
-    const char * name = smspec_node_get_wgname(ecl_smspec_iget_node(smspec, i));
-    if(name != NULL)
+    const smspec_node_type * node = ecl_smspec_iget_node(smspec, i);
+    if (smspec_node_is_valid( node )) {
+      const char * name = smspec_node_get_wgname( node );
+      if(name)
         max_len = util_size_t_max(max_len, strlen(name));
+    }
   }
 
-  return max_len <= 8 ? ECL_CHAR : ECL_STRING(max_len);
+  return max_len <= ECL_STRING8_LENGTH ? ECL_CHAR : ECL_STRING(max_len);
 }
 
 // DIMENS
@@ -447,7 +450,7 @@ static void ecl_smspec_fortio_fwrite( const ecl_smspec_type * smspec , fortio_ty
           ecl_kw_iset_string8( units_kw , i , smspec_node_get_unit( smspec_node ));
           {
             const char * wgname = DUMMY_WELL;
-            if (smspec_node_get_wgname( smspec_node ) != NULL)
+            if (smspec_node_get_wgname( smspec_node ))
               wgname = smspec_node_get_wgname( smspec_node );
             ecl_kw_iset_string_ptr( wgnames_kw , i , wgname);
           }

--- a/lib/ecl/smspec_node.c
+++ b/lib/ecl/smspec_node.c
@@ -74,32 +74,9 @@ struct smspec_node_struct {
 };
 
 
-static bool string_equal(const char * s1 , const char * s2)
-{
-  if ((s1 == NULL) && (s2 == NULL))
-    return true;
-  else
-    return util_string_equal( s1 , s2 );
-}
 
 bool smspec_node_equal( const smspec_node_type * node1,  const smspec_node_type * node2) {
-  if ((node1->params_index == node2->params_index) &&
-      (node1->num == node2->num) &&
-      (node1->var_type == node2->var_type) &&
-      (string_equal( node1->keyword, node2->keyword)) &&
-      (string_equal( node1->wgname, node2->wgname)) &&
-      (string_equal( node1->unit, node2->unit)) &&
-      (string_equal( node1->lgr_name, node2->lgr_name)))
-    {
-      if (node1->lgr_ijk)
-        return ((node1->lgr_ijk[0] == node2->lgr_ijk[0]) &&
-                (node1->lgr_ijk[1] == node2->lgr_ijk[1]) &&
-                (node1->lgr_ijk[2] == node2->lgr_ijk[2]));
-
-      return true;
-    }
-
-  return false;
+  return smspec_node_cmp( node1 , node2 ) == 0;
 }
 
 
@@ -129,6 +106,7 @@ bool smspec_node_equal( const smspec_node_type * node1,  const smspec_node_type 
 #define ECL_SUM_KEYFMT_LOCAL_WELL             "%s%s%s%s%s"
 
 UTIL_SAFE_CAST_FUNCTION( smspec_node , SMSPEC_TYPE_ID )
+static UTIL_SAFE_CAST_FUNCTION_CONST( smspec_node , SMSPEC_TYPE_ID )
 
 
 char * smspec_alloc_block_num_key( const char * join_string , const char * keyword , int num) {
@@ -1184,4 +1162,8 @@ int smspec_node_cmp( const smspec_node_type * node1, const smspec_node_type * no
   }
 }
 
+int smspec_node_cmp__( const void * node1, const void * node2) {
+  return smspec_node_cmp( smspec_node_safe_cast_const( node1 ),
+                          smspec_node_safe_cast_const( node2 ));
+}
 

--- a/lib/ecl/smspec_node.c
+++ b/lib/ecl/smspec_node.c
@@ -370,7 +370,6 @@ smspec_node_type * smspec_node_alloc_new(int params_index, float default_value) 
   smspec_node_set_default( node , default_value );
 
   node->wgname        = NULL;
-  node->num           = SMSPEC_NUMS_INVALID;
   node->ijk           = NULL;
 
   node->gen_key1      = NULL;
@@ -413,6 +412,21 @@ static void smspec_node_set_lgr_ijk( smspec_node_type * index , int lgr_i , int 
 }
 
 
+static void smspec_node_init_num( smspec_node_type * node , ecl_smspec_var_type var_type) {
+  switch( node->var_type ) {
+  case(ECL_SMSPEC_WELL_VAR):
+    node->num = SMSPEC_NUMS_WELL;
+    break;
+  case(ECL_SMSPEC_GROUP_VAR):
+    node->num = SMSPEC_NUMS_GROUP;
+    break;
+  case(ECL_SMSPEC_FIELD_VAR):
+    node->num = SMSPEC_NUMS_FIELD;
+    break;
+  default:
+    node->num = SMSPEC_NUMS_INVALID;
+  }
+}
 static void smspec_node_set_num( smspec_node_type * index , const int grid_dims[3] , int num) {
   if (num == SMSPEC_NUMS_INVALID)
     util_abort("%s: explicitly trying to set nums == SMSPEC_NUMS_INVALID - seems like a bug?!\n",__func__);
@@ -548,6 +562,7 @@ static void smspec_node_common_init( smspec_node_type * node , ecl_smspec_var_ty
     smspec_node_set_keyword( node , keyword);
     node->var_type = var_type;
     smspec_node_set_flags( node );
+    smspec_node_init_num( node , var_type );
   } else
     util_abort("%s: trying to re-init smspec node with keyword:%s - invalid \n",__func__ , keyword );
 }

--- a/lib/ecl/tests/ecl_smspec.c
+++ b/lib/ecl/tests/ecl_smspec.c
@@ -23,6 +23,20 @@
 
 #include <ert/ecl/ecl_smspec.h>
 
+void test_sort( ecl_smspec_type * smspec )
+{
+  int num_nodes = ecl_smspec_num_nodes( smspec );
+  ecl_smspec_sort( smspec );
+  test_assert_int_equal( num_nodes, ecl_smspec_num_nodes( smspec ));
+
+  for (int i=1; i < ecl_smspec_num_nodes( smspec ); i++) {
+    const smspec_node_type * node1 = ecl_smspec_iget_node( smspec, i - 1 );
+    const smspec_node_type * node2 = ecl_smspec_iget_node( smspec, i );
+    test_assert_true( smspec_node_cmp( node1 , node2 ) <= 0 );
+
+    test_assert_int_equal( smspec_node_get_params_index( node1 ) , i - 1 );
+  }
+}
 
 
 int main(int argc, char ** argv) {
@@ -37,6 +51,8 @@ int main(int argc, char ** argv) {
   test_assert_false( ecl_smspec_equal( smspec1 , smspec2 ));
   test_assert_false( ecl_smspec_equal( smspec2 , smspec1 ));
 
+  test_sort( smspec1 );
+  test_sort( smspec2 );
   ecl_smspec_free( smspec1 );
   ecl_smspec_free( smspec2 );
 }

--- a/lib/ecl/tests/ecl_smspec_node.c
+++ b/lib/ecl/tests/ecl_smspec_node.c
@@ -75,6 +75,7 @@ void test_cmp_well() {
   smspec_node_type * well_node1_2 = smspec_node_alloc( ECL_SMSPEC_WELL_VAR , "W2" , "WOPR" , "UNIT" , ":" , dims , 10 , 0 , 0 );
   smspec_node_type * well_node2_1 = smspec_node_alloc( ECL_SMSPEC_WELL_VAR , "W1" , "WWCT" , "UNIT" , ":" , dims , 10 , 0 , 0 );
   smspec_node_type * well_node2_2 = smspec_node_alloc( ECL_SMSPEC_WELL_VAR , "W2" , "WWWT" , "UNIT" , ":" , dims , 10 , 0 , 0 );
+  smspec_node_type * well_node_dummy = smspec_node_alloc( ECL_SMSPEC_WELL_VAR , DUMMY_WELL , "WOPR" , "UNIT" , ":" , dims , 10 , 0 , 0 );
 
   test_assert_int_equal( smspec_node_cmp( well_node1_1 , well_node1_1 ), 0);
   test_assert_int_equal( smspec_node_cmp( well_node2_2 , well_node2_2 ), 0);
@@ -86,11 +87,15 @@ void test_cmp_well() {
   test_assert_true( smspec_node_cmp( well_node1_2, well_node1_1) > 0 );
   test_assert_true( smspec_node_cmp( well_node1_2, well_node2_1) < 0 );
 
+  test_assert_true( smspec_node_cmp( well_node1_1, well_node_dummy) < 0 );
+  test_assert_false( smspec_node_is_valid( well_node_dummy ));
+  test_assert_true( smspec_node_is_valid( well_node1_1 ));
 
   smspec_node_free( well_node1_1 );
   smspec_node_free( well_node2_1 );
   smspec_node_free( well_node1_2 );
   smspec_node_free( well_node2_2 );
+  smspec_node_free( well_node_dummy );
 }
 
 

--- a/lib/ecl/tests/ecl_smspec_node.c
+++ b/lib/ecl/tests/ecl_smspec_node.c
@@ -1,0 +1,124 @@
+/*
+   Copyright (C) 2017  Statoil ASA, Norway.
+
+   This file is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include <ert/util/util.h>
+#include <ert/util/test_util.h>
+
+#include <ert/ecl/smspec_node.h>
+
+
+void test_cmp_types() {
+  const int dims[3] = {10,10,10};
+  smspec_node_type * field_node = smspec_node_alloc( ECL_SMSPEC_FIELD_VAR , NULL , "FOPT" , "UNIT" , ":" , dims , 0 , 0 , 0 );
+  smspec_node_type * region_node = smspec_node_alloc( ECL_SMSPEC_REGION_VAR , NULL , "RPR" , "UNIT" , ":" , dims , 10 , 0 , 0 );
+  smspec_node_type * group_node = smspec_node_alloc( ECL_SMSPEC_GROUP_VAR , "G1" , "GOPR" , "UNIT" , ":" , dims , 10 , 0 , 0 );
+  smspec_node_type * well_node = smspec_node_alloc( ECL_SMSPEC_WELL_VAR , "W1" , "WOPR" , "UNIT" , ":" , dims , 10 , 0 , 0 );
+  smspec_node_type * block_node = smspec_node_alloc( ECL_SMSPEC_BLOCK_VAR , NULL , "BPR" , "UNIT" , ":" , dims , 10 , 0 , 0 );
+  smspec_node_type * aquifer_node = smspec_node_alloc( ECL_SMSPEC_AQUIFER_VAR , NULL , "AAQP" , "UNIT" , ":" , dims , 10 , 0 , 0 );
+  smspec_node_type * segment_node = smspec_node_alloc( ECL_SMSPEC_SEGMENT_VAR , "W1" , "SGOR" , "UNIT" , ":" , dims , 10 , 0 , 0 );
+  smspec_node_type * misc_node1 = smspec_node_alloc( ECL_SMSPEC_MISC_VAR , NULL , "TIME" , "UNIT" , ":", dims, 10 , 0, 0);
+  smspec_node_type * misc_node2 = smspec_node_alloc( ECL_SMSPEC_MISC_VAR , NULL , "TCPU" , "UNIT" , ":", dims, 10 , 0, 0);
+
+  test_assert_int_equal( smspec_node_cmp( field_node , field_node ), 0);
+  test_assert_int_equal( smspec_node_cmp( region_node , region_node ), 0);
+  test_assert_int_equal( smspec_node_cmp( well_node , well_node ), 0);
+  test_assert_int_equal( smspec_node_cmp( group_node , group_node ), 0);
+  test_assert_int_equal( smspec_node_cmp( block_node , block_node ), 0);
+
+  test_assert_true( smspec_node_cmp( misc_node1 , field_node ) < 0 );
+  test_assert_true( smspec_node_cmp( field_node , region_node ) < 0 );
+  test_assert_true( smspec_node_cmp( region_node , group_node ) < 0 );
+  test_assert_true( smspec_node_cmp( group_node , well_node ) < 0 );
+  test_assert_true( smspec_node_cmp( well_node , segment_node ) < 0 );
+  test_assert_true( smspec_node_cmp( segment_node , block_node ) < 0 );
+  test_assert_true( smspec_node_cmp( block_node , aquifer_node) < 0 );
+  test_assert_true( smspec_node_cmp( aquifer_node , misc_node2 ) < 0 );
+
+  test_assert_true( smspec_node_cmp( field_node, misc_node1) > 0 );
+  test_assert_true( smspec_node_cmp( misc_node2, aquifer_node) > 0 );
+  test_assert_true( smspec_node_cmp( misc_node1, misc_node2) < 0 );
+  test_assert_true( smspec_node_cmp( misc_node2, misc_node1) > 0 );
+
+
+  smspec_node_free( segment_node );
+  smspec_node_free( aquifer_node );
+  smspec_node_free( block_node );
+  smspec_node_free( group_node );
+  smspec_node_free( well_node );
+  smspec_node_free( region_node );
+  smspec_node_free( field_node );
+  smspec_node_free( misc_node1 );
+  smspec_node_free( misc_node2 );
+}
+
+void test_cmp_well() {
+  const int dims[3] = {10,10,10};
+  smspec_node_type * well_node1_1 = smspec_node_alloc( ECL_SMSPEC_WELL_VAR , "W1" , "WOPR" , "UNIT" , ":" , dims , 10 , 0 , 0 );
+  smspec_node_type * well_node1_2 = smspec_node_alloc( ECL_SMSPEC_WELL_VAR , "W2" , "WOPR" , "UNIT" , ":" , dims , 10 , 0 , 0 );
+  smspec_node_type * well_node2_1 = smspec_node_alloc( ECL_SMSPEC_WELL_VAR , "W1" , "WWCT" , "UNIT" , ":" , dims , 10 , 0 , 0 );
+  smspec_node_type * well_node2_2 = smspec_node_alloc( ECL_SMSPEC_WELL_VAR , "W2" , "WWWT" , "UNIT" , ":" , dims , 10 , 0 , 0 );
+
+  test_assert_int_equal( smspec_node_cmp( well_node1_1 , well_node1_1 ), 0);
+  test_assert_int_equal( smspec_node_cmp( well_node2_2 , well_node2_2 ), 0);
+
+  test_assert_true( smspec_node_cmp( well_node1_1, well_node1_2) < 0 );
+  test_assert_true( smspec_node_cmp( well_node1_1, well_node2_1) < 0 );
+  test_assert_true( smspec_node_cmp( well_node1_1, well_node2_2) < 0 );
+
+  test_assert_true( smspec_node_cmp( well_node1_2, well_node1_1) > 0 );
+  test_assert_true( smspec_node_cmp( well_node1_2, well_node2_1) < 0 );
+
+
+  smspec_node_free( well_node1_1 );
+  smspec_node_free( well_node2_1 );
+  smspec_node_free( well_node1_2 );
+  smspec_node_free( well_node2_2 );
+}
+
+
+
+void test_cmp_region() {
+  const int dims[3] = {10,10,10};
+  smspec_node_type * region_node1_1 = smspec_node_alloc( ECL_SMSPEC_REGION_VAR , NULL , "ROIP" ,  "UNIT" , ":" , dims , 10 , 0 , 0 );
+  smspec_node_type * region_node1_2 = smspec_node_alloc( ECL_SMSPEC_REGION_VAR , NULL , "ROIP" ,  "UNIT" , ":" , dims , 11 , 0 , 0 );
+  smspec_node_type * region_node2_1 = smspec_node_alloc( ECL_SMSPEC_REGION_VAR , NULL , "RPR" ,   "UNIT" , ":" , dims , 10 , 0 , 0 );
+  smspec_node_type * region_node2_2 = smspec_node_alloc( ECL_SMSPEC_REGION_VAR , NULL , "RPR" ,   "UNIT" , ":" , dims , 12 , 0 , 0 );
+
+  test_assert_true( smspec_node_cmp( region_node1_1, region_node1_2) < 0 );
+  test_assert_true( smspec_node_cmp( region_node1_1, region_node2_1) < 0 );
+  test_assert_true( smspec_node_cmp( region_node1_1, region_node2_2) < 0 );
+
+  test_assert_true( smspec_node_cmp( region_node1_2, region_node1_1) > 0 );
+  test_assert_true( smspec_node_cmp( region_node1_2, region_node2_1) < 0 );
+
+  smspec_node_free( region_node1_1 );
+  smspec_node_free( region_node2_1 );
+  smspec_node_free( region_node1_2 );
+  smspec_node_free( region_node2_2 );
+}
+
+
+int main(int argc, char ** argv) {
+  util_install_signals();
+  test_cmp_types();
+  test_cmp_well();
+  test_cmp_region( );
+}

--- a/lib/include/ert/ecl/Smspec.hpp
+++ b/lib/include/ert/ecl/Smspec.hpp
@@ -17,6 +17,7 @@ namespace ERT {
             smspec_node& operator=( const smspec_node& );
             smspec_node& operator=( smspec_node&& );
 
+            static int cmp( const smspec_node& node1, const smspec_node& node2);
             smspec_node(
                     ecl_smspec_var_type,
                     const std::string& wgname,

--- a/lib/include/ert/ecl/ecl_smspec.h
+++ b/lib/include/ert/ecl/ecl_smspec.h
@@ -143,6 +143,7 @@ typedef struct ecl_smspec_struct ecl_smspec_type;
   char                     * ecl_smspec_alloc_well_key( const ecl_smspec_type * smspec , const char * keyword , const char * wgname);
   bool                       ecl_smspec_equal( const ecl_smspec_type * self , const ecl_smspec_type * other);
 
+  void                       ecl_smspec_sort( ecl_smspec_type * smspec );
 
 #ifdef __cplusplus
 }

--- a/lib/include/ert/ecl/smspec_node.h
+++ b/lib/include/ert/ecl/smspec_node.h
@@ -76,17 +76,15 @@ typedef enum {ECL_SMSPEC_INVALID_VAR            =  0 ,
 
   bool smspec_node_equal( const smspec_node_type * node1,  const smspec_node_type * node2);
 
-  
-  bool smspec_node_init( smspec_node_type * smspec_node, 
-                         ecl_smspec_var_type var_type , 
-                         const char * wgname  , 
-                         const char * keyword , 
-                         const char * unit    , 
-                         const char * key_join_string , 
-                         const int grid_dims[3] , 
+  void smspec_node_init( smspec_node_type * smspec_node,
+                         ecl_smspec_var_type var_type ,
+                         const char * wgname  ,
+                         const char * keyword ,
+                         const char * unit    ,
+                         const char * key_join_string ,
+                         const int grid_dims[3] ,
                          int num);
 
-  
   smspec_node_type * smspec_node_alloc( ecl_smspec_var_type var_type , 
                                         const char * wgname  , 
                                         const char * keyword , 
@@ -124,6 +122,7 @@ typedef enum {ECL_SMSPEC_INVALID_VAR            =  0 ,
   bool                smspec_node_is_rate( const smspec_node_type * smspec_node );
   bool                smspec_node_is_total( const smspec_node_type * smspec_node );
   bool                smspec_node_is_historical( const smspec_node_type * smspec_node );
+  bool                smspec_node_is_valid( const smspec_node_type * smspec_node );
   bool                smspec_node_need_nums( const smspec_node_type * smspec_node );
   void                smspec_node_fprintf( const smspec_node_type * smspec_node , FILE * stream);
 

--- a/lib/include/ert/ecl/smspec_node.h
+++ b/lib/include/ert/ecl/smspec_node.h
@@ -57,6 +57,9 @@ typedef enum {ECL_SMSPEC_INVALID_VAR            =  0 ,
 
 
 #define SMSPEC_NUMS_INVALID   -991199
+#define SMSPEC_NUMS_WELL       1
+#define SMSPEC_NUMS_GROUP      2
+#define SMSPEC_NUMS_FIELD      0
 
   typedef struct smspec_node_struct smspec_node_type;
 

--- a/lib/include/ert/ecl/smspec_node.h
+++ b/lib/include/ert/ecl/smspec_node.h
@@ -137,6 +137,7 @@ typedef enum {ECL_SMSPEC_INVALID_VAR            =  0 ,
   int smspec_node_get_R2( const smspec_node_type * smpsec_node );
 
   int smspec_node_cmp( const smspec_node_type * node1, const smspec_node_type * node2);
+  int smspec_node_cmp__( const void * node1, const void * node2);
 
 #ifdef __cplusplus
 }

--- a/lib/include/ert/ecl/smspec_node.h
+++ b/lib/include/ert/ecl/smspec_node.h
@@ -40,19 +40,19 @@ extern "C" {
 
 
 typedef enum {ECL_SMSPEC_INVALID_VAR            =  0 ,
-              ECL_SMSPEC_AQUIFER_VAR            =  1 ,   
-              ECL_SMSPEC_WELL_VAR               =  2 ,   /* X */
-              ECL_SMSPEC_REGION_VAR             =  3 ,   /* X */
-              ECL_SMSPEC_FIELD_VAR              =  4 ,   /* X */
-              ECL_SMSPEC_GROUP_VAR              =  5 ,   /* X */
+              ECL_SMSPEC_FIELD_VAR              =  1 ,   /* X */
+              ECL_SMSPEC_REGION_VAR             =  2 ,   /* X */
+              ECL_SMSPEC_GROUP_VAR              =  3 ,   /* X */
+              ECL_SMSPEC_WELL_VAR               =  4 ,   /* X */
+              ECL_SMSPEC_SEGMENT_VAR            =  5 ,   /* X */ 
               ECL_SMSPEC_BLOCK_VAR              =  6 ,   /* X */
-              ECL_SMSPEC_COMPLETION_VAR         =  7 ,   /* X */ 
-              ECL_SMSPEC_LOCAL_BLOCK_VAR        =  8 ,   /* X */
-              ECL_SMSPEC_LOCAL_COMPLETION_VAR   =  9 ,   /* X */
-              ECL_SMSPEC_LOCAL_WELL_VAR         = 10 ,   /* X */
-              ECL_SMSPEC_NETWORK_VAR            = 11 ,
-              ECL_SMSPEC_REGION_2_REGION_VAR    = 12 ,
-              ECL_SMSPEC_SEGMENT_VAR            = 13 ,   /* X */ 
+              ECL_SMSPEC_AQUIFER_VAR            =  7 ,
+              ECL_SMSPEC_COMPLETION_VAR         =  8 ,   /* X */ 
+              ECL_SMSPEC_NETWORK_VAR            =  9 ,
+              ECL_SMSPEC_REGION_2_REGION_VAR    = 10 ,
+              ECL_SMSPEC_LOCAL_BLOCK_VAR        = 11 ,   /* X */
+              ECL_SMSPEC_LOCAL_COMPLETION_VAR   = 12 ,   /* X */
+              ECL_SMSPEC_LOCAL_WELL_VAR         = 13 ,   /* X */
               ECL_SMSPEC_MISC_VAR               = 14     /* X */}  ecl_smspec_var_type;
 
 
@@ -136,6 +136,8 @@ typedef enum {ECL_SMSPEC_INVALID_VAR            =  0 ,
 
   int smspec_node_get_R1( const smspec_node_type * smpsec_node );
   int smspec_node_get_R2( const smspec_node_type * smpsec_node );
+
+  int smspec_node_cmp( const smspec_node_type * node1, const smspec_node_type * node2);
 
 #ifdef __cplusplus
 }

--- a/lib/include/ert/ecl/smspec_node.h
+++ b/lib/include/ert/ecl/smspec_node.h
@@ -21,6 +21,7 @@
 #define ERT_SMSPEC_NODE_H
 
 #include <stdbool.h>
+#include <stdio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/lib/include/ert/util/vector.h
+++ b/lib/include/ert/util/vector.h
@@ -76,6 +76,7 @@ extern "C" {
   void        * vector_pop_front(vector_type * );
   void          vector_sort(vector_type * vector , vector_cmp_ftype * cmp);
   int_vector_type * vector_alloc_sort_perm(const vector_type * vector , vector_cmp_ftype * cmp);
+  void          vector_permute(vector_type * vector , const int_vector_type * perm_vector);
   void          vector_inplace_reverse(vector_type * vector);
   vector_type * vector_alloc_copy(const vector_type * src , bool deep_copy);
 

--- a/lib/util/tests/ert_util_vector_test.c
+++ b/lib/util/tests/ert_util_vector_test.c
@@ -107,8 +107,17 @@ void test_sort() {
     test_assert_string_equal( "3" , vector_iget(v2 , 3 ));
     test_assert_string_equal( "4" , vector_iget(v2 , 4 ));
 
+    vector_permute( v1 , sort_map );
+
+    test_assert_string_equal( "0" , vector_iget(v1 , 0 ));
+    test_assert_string_equal( "1" , vector_iget(v1 , 1 ));
+    test_assert_string_equal( "2" , vector_iget(v1 , 2 ));
+    test_assert_string_equal( "3" , vector_iget(v1 , 3 ));
+    test_assert_string_equal( "4" , vector_iget(v1 , 4 ));
     int_vector_free( sort_map );
   }
+  vector_free( v1 );
+  vector_free( v2 );
 }
 
 void test_find( ) {

--- a/lib/util/vector.c
+++ b/lib/util/vector.c
@@ -597,6 +597,15 @@ int_vector_type * vector_alloc_sort_perm(const vector_type * vector , vector_cmp
 }
 
 
+void vector_permute(vector_type * vector , const int_vector_type * perm_vector) {
+  node_data_type ** new_data = util_calloc( vector->size , sizeof * new_data );
+  for (int index = 0; index < vector->size; index++) {
+    int perm_index = int_vector_iget( perm_vector , index );
+    new_data[index] = vector->data[ perm_index ];
+  }
+  free(vector->data);
+  vector->data = new_data;
+}
 
 
 

--- a/python/python/ecl/ecl/ecl_smspec_node.py
+++ b/python/python/ecl/ecl/ecl_smspec_node.py
@@ -41,12 +41,35 @@ class EclSMSPECNode(BaseCClass):
     _gen_key1           = EclPrototype("char* smspec_node_get_gen_key1( smspec_node )")
     _gen_key2           = EclPrototype("char* smspec_node_get_gen_key2( smspec_node )")
     _var_type           = EclPrototype("ecl_sum_var_type smspec_node_get_var_type( smspec_node )")
-
+    _cmp                = EclPrototype("int smspec_node_cmp( smspec_node , smspec_node)")
 
     def __init__(self):
         super(EclSMSPECNode, self).__init__(0) # null pointer
         raise NotImplementedError("Class can not be instantiated directly!")
 
+    def cmp(self, other):
+        if isinstance(other, EclSMSPECNode):
+            return self._cmp( other )
+        else:
+            raise TypeError("Other argument must be of type EclSMSPECNode")
+    
+
+    def __lt__(self , other):
+        return self.cmp( other ) < 0
+
+
+    def __gt__(self , other):
+        return self.cmp( other ) > 0
+
+
+    def __eq__(self , other):
+        return self.cmp( other ) == 0
+
+
+    def __hash__(self , other):
+        return hash(self._gen_key1( ))
+
+        
     @property
     def unit(self):
         """

--- a/python/python/ecl/ecl/ecl_sum_var_type.py
+++ b/python/python/ecl/ecl/ecl_sum_var_type.py
@@ -21,34 +21,36 @@ from ecl.ecl import ECL_LIB
 class EclSumVarType(BaseCEnum):
     TYPE_NAME = "ecl_sum_var_type"
     ECL_SMSPEC_INVALID_VAR            = None
-    ECL_SMSPEC_AQUIFER_VAR            = None
-    ECL_SMSPEC_WELL_VAR               = None
-    ECL_SMSPEC_REGION_VAR             = None
     ECL_SMSPEC_FIELD_VAR              = None
+    ECL_SMSPEC_REGION_VAR             = None
     ECL_SMSPEC_GROUP_VAR              = None
+    ECL_SMSPEC_WELL_VAR               = None
+    ECL_SMSPEC_SEGMENT_VAR            = None
     ECL_SMSPEC_BLOCK_VAR              = None
+    ECL_SMSPEC_AQUIFER_VAR            = None
     ECL_SMSPEC_COMPLETION_VAR         = None
+    ECL_SMSPEC_NETWORK_VAR            = None
+    ECL_SMSPEC_REGION_2_REGION_VAR    = None
     ECL_SMSPEC_LOCAL_BLOCK_VAR        = None
     ECL_SMSPEC_LOCAL_COMPLETION_VAR   = None
     ECL_SMSPEC_LOCAL_WELL_VAR         = None
-    ECL_SMSPEC_NETWORK_VAR            = None
-    ECL_SMSPEC_REGION_2_REGION_VAR    = None
-    ECL_SMSPEC_SEGMENT_VAR            = None
     ECL_SMSPEC_MISC_VAR               = None
 
-
-EclSumVarType.addEnum("ECL_SMSPEC_INVALID_VAR",  0)
-EclSumVarType.addEnum("ECL_SMSPEC_AQUIFER_VAR",  1)
-EclSumVarType.addEnum("ECL_SMSPEC_WELL_VAR",  2)
-EclSumVarType.addEnum("ECL_SMSPEC_REGION_VAR",  3)
-EclSumVarType.addEnum("ECL_SMSPEC_FIELD_VAR",  4)
-EclSumVarType.addEnum("ECL_SMSPEC_GROUP_VAR",  5)
-EclSumVarType.addEnum("ECL_SMSPEC_BLOCK_VAR",  6)
-EclSumVarType.addEnum("ECL_SMSPEC_COMPLETION_VAR",  7)
-EclSumVarType.addEnum("ECL_SMSPEC_LOCAL_BLOCK_VAR",  8)
-EclSumVarType.addEnum("ECL_SMSPEC_LOCAL_COMPLETION_VAR",  9)
-EclSumVarType.addEnum("ECL_SMSPEC_LOCAL_WELL_VAR", 10)
-EclSumVarType.addEnum("ECL_SMSPEC_NETWORK_VAR", 11)
-EclSumVarType.addEnum("ECL_SMSPEC_REGION_2_REGION_VAR", 12)
-EclSumVarType.addEnum("ECL_SMSPEC_SEGMENT_VAR", 13)
+    
+EclSumVarType.addEnum("ECL_SMSPEC_INVALID_VAR", 0)
+EclSumVarType.addEnum("ECL_SMSPEC_FIELD_VAR", 1)
+EclSumVarType.addEnum("ECL_SMSPEC_REGION_VAR", 2)
+EclSumVarType.addEnum("ECL_SMSPEC_GROUP_VAR", 3)
+EclSumVarType.addEnum("ECL_SMSPEC_WELL_VAR", 4)
+EclSumVarType.addEnum("ECL_SMSPEC_SEGMENT_VAR", 5)
+EclSumVarType.addEnum("ECL_SMSPEC_BLOCK_VAR", 6)
+EclSumVarType.addEnum("ECL_SMSPEC_AQUIFER_VAR", 7)
+EclSumVarType.addEnum("ECL_SMSPEC_COMPLETION_VAR", 8)
+EclSumVarType.addEnum("ECL_SMSPEC_NETWORK_VAR", 9)
+EclSumVarType.addEnum("ECL_SMSPEC_REGION_2_REGION_VAR", 10)
+EclSumVarType.addEnum("ECL_SMSPEC_LOCAL_BLOCK_VAR", 11)
+EclSumVarType.addEnum("ECL_SMSPEC_LOCAL_COMPLETION_VAR", 12)
+EclSumVarType.addEnum("ECL_SMSPEC_LOCAL_WELL_VAR", 13)
 EclSumVarType.addEnum("ECL_SMSPEC_MISC_VAR", 14)
+    
+

--- a/python/tests/ecl/test_ecl_kw.py
+++ b/python/tests/ecl/test_ecl_kw.py
@@ -454,3 +454,13 @@ class KWTest(ExtendedTestCase):
                     loaded_kw = EclKW.fread(fortio)
 
                 self.assertEqual(kw, loaded_kw)
+
+                
+    def test_string_padding(self):
+        kw = EclKW("TEST_KW" , 1 , EclDataType.ECL_STRING(4))
+        kw[0] = "AB"
+        self.assertEqual( kw[0] , "AB  " )
+
+        kw = EclKW("TEST_KW" , 1 , EclDataType.ECL_CHAR)
+        kw[0] = "ABCD"
+        self.assertEqual( kw[0] , "ABCD    " )

--- a/python/tests/ecl/test_sum.py
+++ b/python/tests/ecl/test_sum.py
@@ -70,19 +70,25 @@ class SumTest(ExtendedTestCase):
                                      ("AARQ" , None , 10),
                                      ("RGPT" , None  ,1)])
 
-        node = case.smspec_node( "FOPT" )
-        self.assertEqual( node.varType( ) , EclSumVarType.ECL_SMSPEC_FIELD_VAR )
+        node1 = case.smspec_node( "FOPT" )
+        self.assertEqual( node1.varType( ) , EclSumVarType.ECL_SMSPEC_FIELD_VAR )
 
-        node = case.smspec_node( "AARQ:10" )
-        self.assertEqual( node.varType( ) , EclSumVarType.ECL_SMSPEC_AQUIFER_VAR )
-        self.assertEqual( node.getNum( ) , 10 )
+        node2 = case.smspec_node( "AARQ:10" )
+        self.assertEqual( node2.varType( ) , EclSumVarType.ECL_SMSPEC_AQUIFER_VAR )
+        self.assertEqual( node2.getNum( ) , 10 )
 
-        node = case.smspec_node("RGPT:1")
-        self.assertEqual( node.varType( ) , EclSumVarType.ECL_SMSPEC_REGION_VAR )
-        self.assertEqual( node.getNum( ) , 1 )
-        self.assertTrue( node.isTotal( ))
+        node3 = case.smspec_node("RGPT:1")
+        self.assertEqual( node3.varType( ) , EclSumVarType.ECL_SMSPEC_REGION_VAR )
+        self.assertEqual( node3.getNum( ) , 1 )
+        self.assertTrue( node3.isTotal( ))
 
+        self.assertLess( node1, node3 )
+        self.assertGreater( node2, node3 )
+        self.assertEqual( node1, node1 )
+        self.assertNotEqual( node1, node2 )
         
+        with self.assertRaises(TypeError):
+            a = node1 < 1
         
     def test_csv_export(self):
         case = createEclSum("CSV" , [("FOPT", None , 0) , ("FOPR" , None , 0)])


### PR DESCRIPTION
**Task**
This was mostly a wild goose chase trying to find a problem with the summary files generated by OPM. The third commit turned out to be the crucial one. The sorting is also valuable - although not as essential.

**Approach**
1. Make sure every item in ecl_kw of type `ECL_STRING` is space padded to correct length.
2. Implemented function to compare smspec node instances.

**Pre un-WIP checklist**
- [x] Statoil tests pass locally
