### PR TITLE
Removed from API util_fread_from_buffer

### DIFF
--- a/lib/include/ert/util/buffer.h
+++ b/lib/include/ert/util/buffer.h
@@ -48,9 +48,7 @@ extern "C" {
 
   void               buffer_free_container( buffer_type * buffer );
   void               buffer_free( buffer_type * buffer);
-  size_t             buffer_safe_fread(buffer_type * buffer , void * target_ptr , size_t item_size , size_t items);
   size_t             buffer_fread(buffer_type * buffer , void * target_ptr , size_t item_size , size_t items);
-  size_t             buffer_safe_fwrite(buffer_type * buffer , const void * src_ptr , size_t item_size , size_t items);
   size_t             buffer_fwrite(buffer_type * buffer , const void * src_ptr , size_t item_size , size_t items);
   void               buffer_summarize(const buffer_type * buffer , const char *);
 

--- a/lib/include/ert/util/util.h
+++ b/lib/include/ert/util/util.h
@@ -285,9 +285,6 @@ typedef enum {left_pad   = 0,
 
   bool         util_is_first_day_in_month_utc( time_t t);
 
-
-  void     util_fread_from_buffer(void *  , size_t  , size_t , char ** );
-
   unsigned int util_dev_urandom_seed( );
   unsigned int util_clock_seed( void );
   void         util_fread_dev_random(int , char * );

--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -4595,15 +4595,6 @@ void util_fread(void *ptr , size_t element_size , size_t items, FILE * stream , 
 }
 
 
-
-void util_fread_from_buffer(void * ptr , size_t element_size , size_t items , char ** buffer) {
-  int bytes = element_size * items;
-  memcpy( ptr , *buffer , bytes);
-  *buffer += bytes;
-}
-
-
-
 #undef ABORT_READ
 #undef ABORT_WRITE
 


### PR DESCRIPTION
**Task**

The symbol `util_fread_from_buffer` is only used one place in all of the ert ecosystem, from `enkf_util_assert_something`.

That does not warrant its existence.  The implementation was three lines, and they have been moved up to call site.

This depends on  Statoil/libres#76.

**Pre un-WIP checklist**
- [X] Statoil tests pass locally
- [X] libres Statoil tests pass locally
