### PR TITLE
Added support for parallelizing the running of tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,9 @@ os:
   - linux
   - osx
 
+osx_image: xcode7.3
 sudo: false
 dist: trusty
-osx_image: xcode7.3
-
 
 env:
   global:
@@ -44,28 +43,27 @@ addons:
 
 
 install:
-- if [[ "$CC" == "gcc" ]]; then export CXX="g++-4.8"; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    export CONDA_OS=MacOSX;
-  else
-    export CONDA_OS=Linux;
-  fi
-- export TRAVIS_PYTHON_VERSION="2.7"
-# We do this conditionally because it saves us some downloading if the version is the same.
-- if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-    wget https://repo.continuum.io/miniconda/Miniconda2-latest-${CONDA_OS}-x86_64.sh -O miniconda.sh;
-  else
-    wget https://repo.continuum.io/miniconda/Miniconda3-latest-${CONDA_OS}-x86_64.sh -O miniconda.sh;
-  fi
-- bash miniconda.sh -b -p $HOME/miniconda
-- export CONDA_HOME="$HOME/miniconda"
-- export PATH="$CONDA_HOME/bin:$PATH"
-- hash -r
-- conda config --set always_yes yes --set changeps1 no
-- conda update -q conda
-- conda info -a  # Useful for debugging any issues with conda
-- conda install pylint numpy pandas
-- echo ${TEST_SUITE}
+  - if [[ "$CC" == "gcc" ]]; then export CXX="g++-4.8"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      export CONDA_OS=MacOSX;
+    else
+      export CONDA_OS=Linux;
+    fi
+  - export TRAVIS_PYTHON_VERSION="2.7"
+  # We do this conditionally because it saves us some downloading if the version is the same.
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-${CONDA_OS}-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-${CONDA_OS}-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export CONDA_HOME="$HOME/miniconda"
+  - export PATH="$CONDA_HOME/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a  # Useful for debugging any issues with conda
+  - conda install pylint numpy pandas
 
 before_script:
   - wget https://raw.githubusercontent.com/Statoil/ert/master/travis/build_total.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ env:
   global:
     - ERT_SHOW_BACKTRACE=1
   matrix:
-    - TEST_SUITE=-LE SLOW  # Run all tests not labeled as slow
-    - TEST_SUITE=-L SLOW_1 # Run all tests labeled as SLOW in group 1
-    - TEST_SUITE=-L SLOW_2 # Run all tests labeled as SLOW in group 2
+    - TEST_SUITE="-LE SLOW"  # Run all tests not labeled as slow
+    - TEST_SUITE="-L SLOW_1" # Run all tests labeled as SLOW in group 1
+    - TEST_SUITE="-L SLOW_2" # Run all tests labeled as SLOW in group 2
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,33 @@
 language: c
 
+compiler:
+  - gcc
+  - clang
+
+os:
+  - linux
+  - osx
+
+sudo: false
+dist: trusty
+osx_image: xcode7.3
+
+
+env:
+  global:
+    - ERT_SHOW_BACKTRACE=1
+  matrix:
+    - TEST_SUITE=-LE SLOW  # Run all tests not labeled as slow
+    - TEST_SUITE=-L SLOW_1 # Run all tests labeled as SLOW in group 1
+    - TEST_SUITE=-L SLOW_2 # Run all tests labeled as SLOW in group 2
+
 matrix:
   fast_finish: true
-  include:
+  exclude:
     - os: osx
-      osx_image: xcode7.3
-      compiler: clang
-    - os: linux
-      sudo: false
       compiler: gcc
-      dist: trusty
+    - os: linux
+      compiler: clang
 
 addons:
   apt:
@@ -24,9 +42,6 @@ addons:
     - cmake
     - cmake-data
 
-env:
-  global:
-  - ERT_SHOW_BACKTRACE=1
 
 install:
 - if [[ "$CC" == "gcc" ]]; then export CXX="g++-4.8"; fi
@@ -50,9 +65,10 @@ install:
 - conda update -q conda
 - conda info -a  # Useful for debugging any issues with conda
 - conda install pylint numpy pandas
+- echo ${TEST_SUITE}
 
 before_script:
   - wget https://raw.githubusercontent.com/Statoil/ert/master/travis/build_total.py
 
 script:
-  - python build_total.py ecl
+  - python build_total.py ecl ${TEST_SUITE}

--- a/python/tests/ecl/CMakeLists.txt
+++ b/python/tests/ecl/CMakeLists.txt
@@ -47,9 +47,9 @@ set(TEST_SOURCES
 add_python_package("python.tests.ecl"  ${PYTHON_INSTALL_PREFIX}/tests/ecl "${TEST_SOURCES}" False)
 
 addPythonTest(tests.ecl.test_fk_user_data.FKTest)
-addPythonTest(tests.ecl.test_grid.GridTest )
-addPythonTest(tests.ecl.test_grid_generator.GridGeneratorTest )
-addPythonTest(tests.ecl.test_ecl_kw.KWTest)
+addPythonTest(tests.ecl.test_grid.GridTest LABELS SLOW_1)
+addPythonTest(tests.ecl.test_grid_generator.GridGeneratorTest LABELS SLOW_2)
+addPythonTest(tests.ecl.test_ecl_kw.KWTest LABELS SLOW_2)
 addPythonTest(tests.ecl.test_kw_function.KWFunctionTest)
 addPythonTest(tests.ecl.test_ecl_3dkw.Ecl3DKWTest )
 addPythonTest(tests.ecl.test_rft.RFTTest)


### PR DESCRIPTION
**Task**
Travis does not have more than one core available for running build and test, but it is, however, possible to run multiple builds in parallel. This PR adds tags to the build and test process so that Travis can run them simultaneously. 

