### PR TITLE
Initialize var to remove incompatible pointer type

### DIFF
--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -303,7 +303,7 @@ void util_fread_dev_urandom(int buffer_size , char * buffer) {
 
 
 unsigned int util_dev_urandom_seed( ) {
-  unsigned int seed;
+  unsigned int seed = 0u;
   util_fread_dev_urandom( sizeof seed, &seed );
   return seed;
 }


### PR DESCRIPTION
**Task**

Jenkins is complaining about errors.  Initialize an `unsigned int`.