### PR TITLE
util: don't crash when a NULL buffer is passed to sscanf methods

### DIFF
--- a/lib/include/ert/util/util.h
+++ b/lib/include/ert/util/util.h
@@ -231,7 +231,7 @@ typedef enum {left_pad   = 0,
   bool         util_fscanf_int(FILE * , int * );
   bool         util_fscanf_bool(FILE * stream , bool * value);
   bool         util_sscanf_bool(const char * , bool *);
-  bool         util_sscanf_octal_int(const char * buffer , unsigned int * value);
+  bool         util_sscanf_octal_int(const char * buffer , int * value);
   int          util_strcmp_int( const char * s1 , const char * s2);
   int          util_strcmp_float( const char * s1 , const char * s2);
   bool         util_sscanf_int(const char * , int * );

--- a/lib/util/tests/ert_util_sscan_test.c
+++ b/lib/util/tests/ert_util_sscan_test.c
@@ -16,6 +16,10 @@
    for more details. 
 */
 
+#include <float.h>
+#include <limits.h>
+#include <math.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/types.h>
@@ -25,8 +29,208 @@
 
 
 
+void test_sscanf_bool() {
+  char const* expected_true = "1\0___""T\0___""True\0""tRuE";
+  int const expected_true_step = 5;
+  char const* const expected_true_end = expected_true + 4 * expected_true_step;
 
-void test_sscan_percent() {
+  char const* expected_false = "0\0____""F\0____""False\0""fALse";
+  int const expected_false_step = 6;
+  char const* const expected_false_end = expected_false + 4 * expected_false_step;
+
+  char const* expected_fail = "\0___""t\0___""f\0___""Tru\0""asd";
+  int const expected_fail_step = 4;
+  char const* const expected_fail_end = expected_fail + 5 * expected_fail_step;
+
+  bool value = false;
+
+  for(; expected_true < expected_true_end; expected_true += expected_true_step) {
+    value = false;
+    test_assert_true( util_sscanf_bool( expected_true, &value) );
+    test_assert_bool_equal(value, true);
+  }
+
+  for(; expected_false < expected_false_end; expected_false += expected_false_step) {
+    value = true;
+    test_assert_true( util_sscanf_bool( expected_false, &value) );
+    test_assert_bool_equal(value, false);
+  }
+
+  for(; expected_fail < expected_fail_end; expected_fail += expected_fail_step) {
+    value = true;
+    test_assert_false( util_sscanf_bool( expected_fail, &value) );
+    test_assert_bool_equal(value, false);
+  }
+
+  // Test null buffer
+  value = true;
+  test_assert_false( util_sscanf_bool(NULL, &value) );
+  test_assert_bool_equal(value, false);
+
+  test_assert_false( util_sscanf_bool(NULL, NULL) );
+}
+
+void test_sscanf_bytesize() {
+  size_t value = 0u;
+  test_assert_true(util_sscanf_bytesize("1KB", &value));
+  test_assert_size_t_equal(value, 1024);
+
+  test_assert_true(util_sscanf_bytesize("12   mB", &value));
+  test_assert_size_t_equal(value, 12 * 1024 * 1024);
+
+  test_assert_true(util_sscanf_bytesize("-47", &value));
+  test_assert_size_t_equal(value, (size_t )(-47)); // documentation says overflows are not checked for
+
+  value = 0u;
+  test_assert_false(util_sscanf_bytesize("3.7 MB", &value)); // no decimals allowed
+  test_assert_size_t_equal(value, 0u);
+  test_assert_false(util_sscanf_bytesize("14 TB", &value));  // TB not supported yet
+  test_assert_size_t_equal(value, 0u);
+
+  // Test NULL buffer
+  test_assert_false(util_sscanf_bytesize(NULL, &value));
+  test_assert_size_t_equal(value, 0); // documentation says the value is set to 0 on parsing error
+
+  test_assert_false(util_sscanf_bytesize(NULL, NULL));
+}
+
+
+
+void test_sscanf_double() {
+  double value = 1.0;
+  test_assert_true( util_sscanf_double("0.0", &value) );
+  test_assert_double_equal(value, 0.0);
+
+  test_assert_true(util_sscanf_double("47.35", &value));
+  test_assert_double_equal(value, 47.35);
+
+  test_assert_true( util_sscanf_double("-0.0", &value) );
+  test_assert_double_equal(value, 0.0);
+
+  test_assert_true(util_sscanf_double("-54.1341", &value));
+  test_assert_double_equal(value, -54.1341);
+
+  test_assert_true(util_sscanf_double("-.1341", &value));
+  test_assert_double_equal(value, -0.1341);
+
+  test_assert_true(util_sscanf_double("+.284", &value));
+  test_assert_double_equal(value, 0.284);
+
+  test_assert_true(util_sscanf_double("-.45e-2", &value));
+  test_assert_double_equal(value, -0.0045);
+
+  test_assert_true(util_sscanf_double("0xFF", &value));
+  test_assert_double_equal(value, 255);
+
+  test_assert_true(util_sscanf_double("INF", &value));
+  test_assert_double_equal(value, INFINITY);
+
+  test_assert_true(util_sscanf_double("NaN", &value));
+  test_assert_true(isnan(value));
+
+  // double max and min
+  char buffer[30];
+  snprintf(buffer, 30, "-%.20g", DBL_MAX);
+  test_assert_true(util_sscanf_double(buffer, &value));
+  test_assert_double_equal(value, -DBL_MAX);
+
+  snprintf(buffer, 30, "%.20g", DBL_MIN);
+  test_assert_true(util_sscanf_double(buffer, &value));
+  test_assert_double_equal(value, DBL_MIN);
+
+  // Garbage characters
+  value = 15.3;
+  test_assert_false(util_sscanf_double("0x12GWS", &value));
+  test_assert_double_equal(value, 15.3);
+
+  test_assert_false(util_sscanf_double("--.+", &value));
+  test_assert_double_equal(value, 15.3);
+
+  // NULL buffer
+  value = 15.3;
+  test_assert_false( util_sscanf_double(NULL, &value) );
+  test_assert_double_equal(value, 15.3);
+
+  test_assert_false( util_sscanf_double(NULL, NULL) );
+
+}
+
+void test_sscanf_int() {
+  int value = 1;
+  test_assert_true( util_sscanf_int("0", &value) );
+  test_assert_int_equal(value, 0);
+
+  test_assert_true( util_sscanf_int("241", &value) );
+  test_assert_int_equal(value, 241);
+
+  test_assert_true( util_sscanf_int("-0", &value) );
+  test_assert_int_equal(value, 0);
+
+  test_assert_true( util_sscanf_int("-852", &value) );
+  test_assert_int_equal(value, -852);
+
+  value = 1;
+  test_assert_false( util_sscanf_int("+-+-+-", &value) );
+  test_assert_int_equal(value, 1);
+
+  test_assert_false( util_sscanf_int("7.5", &value) );
+  test_assert_int_equal(value, 1);
+
+  // max and min
+  char buffer[30];
+  snprintf(buffer, 30, "-%d", INT_MAX);
+  test_assert_true(util_sscanf_int(buffer, &value));
+  test_assert_int_equal(value, -INT_MAX);
+
+  snprintf(buffer, 30, "%d", INT_MIN);
+  test_assert_true(util_sscanf_int(buffer, &value));
+  test_assert_int_equal(value, INT_MIN);
+
+
+  // NULL buffer
+  value = 9;
+  test_assert_false( util_sscanf_int(NULL, &value) );
+  test_assert_int_equal(value, 9);
+
+  test_assert_false( util_sscanf_int(NULL, NULL) );
+}
+
+
+void test_sscanf_octal_int() {
+  int value = 1;
+
+  test_assert_true(util_sscanf_octal_int("0", &value));
+  test_assert_int_equal(value, 0);
+
+  test_assert_true(util_sscanf_octal_int("241", &value));
+  test_assert_int_equal(value, 2 * 64 + 4 * 8 + 1);
+
+  test_assert_true(util_sscanf_octal_int("-0", &value));
+  test_assert_int_equal(value, 0);
+
+  test_assert_true(util_sscanf_octal_int("-1742", &value));
+  test_assert_int_equal(value, -(512 + 7 * 64 + 4 * 8 + 2));
+
+  value = 1;
+  test_assert_false(util_sscanf_octal_int("--5++", &value));
+  test_assert_int_equal(value, 1);
+
+  test_assert_false(util_sscanf_octal_int("89", &value));
+  test_assert_int_equal(value, 1);
+
+  test_assert_false(util_sscanf_octal_int("7.5", &value));
+  test_assert_int_equal(value, 1);
+
+  // NULL buffer
+  value = 3;
+  test_assert_false(util_sscanf_octal_int(NULL, &value));
+  test_assert_int_equal(value, 3);
+
+  test_assert_false(util_sscanf_octal_int(NULL, NULL));
+}
+
+
+void test_sscanf_percent() {
   {
     const char * MIN_REALIZATIONS = "10%";
     double value = 0.0;
@@ -62,10 +266,20 @@ void test_sscan_percent() {
     test_assert_double_equal(0.0, value);
   }
 
+  {
+    double value = 12.5;
+    test_assert_false(util_sscanf_percent(NULL, &value));
+    test_assert_double_equal(12.5, value);
+  }
+
+  {
+    test_assert_false(util_sscanf_percent(NULL, NULL));
+  }
+
 }
 
 
-void test_date(time_t expected , const char * date_string, bool expected_return) {
+void check_iso_date(time_t expected , const char * date_string, bool expected_return) {
   time_t t;
   bool valid = util_sscanf_isodate(date_string, &t);
 
@@ -77,9 +291,9 @@ void test_date(time_t expected , const char * date_string, bool expected_return)
 }
 
 
-void test_scan_iso_date() {
+void test_sscanf_isodate() {
   time_t expected = util_make_date_utc(10,  11 , 2011);
-  test_date( expected , "2011-11-10", true);
+  check_iso_date( expected , "2011-11-10", true);
 
   test_assert_false( util_sscanf_isodate( "2017.10.07" , NULL ));
   test_assert_false( util_sscanf_isodate( "2017-10.7" , NULL ));
@@ -88,12 +302,36 @@ void test_scan_iso_date() {
   /* Invalid numeric values */
   test_assert_false( util_sscanf_isodate( "2017-15-07" , NULL ));
   test_assert_false( util_sscanf_isodate( "2017-10-47" , NULL ));
+
+  // Test NULL buffer
+  check_iso_date( expected , NULL, false);
+  test_assert_false(util_sscanf_isodate(NULL, NULL));
+}
+
+void test_sscanf_date_utc() {
+  time_t value = 0;
+  test_assert_true(util_sscanf_date_utc("16.07^1997", &value));
+  test_assert_time_t_equal(value, util_make_date_utc(16, 7, 1997));
+
+  value = util_make_date_utc(10, 11, 2011);
+  test_assert_false(util_sscanf_date_utc(NULL, &value));
+  test_assert_time_t_equal(value, -1);
+
+  test_assert_false(util_sscanf_date_utc(NULL, NULL));
 }
 
 
 
+
 int main(int argc , char ** argv) {
-  test_sscan_percent();
-  test_scan_iso_date();
+  test_sscanf_bool();
+  test_sscanf_bytesize();
+  test_sscanf_date_utc();
+  test_sscanf_double();
+  test_sscanf_int();
+  test_sscanf_isodate();
+  test_sscanf_octal_int();
+  test_sscanf_percent();
+
   exit(0);
 }

--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -1481,6 +1481,9 @@ char * util_fscanf_alloc_token(FILE * stream) {
 */
 
 bool util_sscanf_double(const char * buffer , double * value) {
+  if(!buffer)
+    return false;
+
   bool value_OK = false;
   char * error_ptr;
 
@@ -1504,7 +1507,10 @@ bool util_sscanf_double(const char * buffer , double * value) {
    Base 8
 */
 
-bool util_sscanf_octal_int(const char * buffer , unsigned int * value) {
+bool util_sscanf_octal_int(const char * buffer , int * value) {
+  if(!buffer)
+    return false;
+
   bool value_OK = false;
   char * error_ptr;
 
@@ -1530,10 +1536,13 @@ bool util_sscanf_octal_int(const char * buffer , unsigned int * value) {
 /**
    Takes a char buffer as input, and parses it as an integer. Returns
    true if the parsing succeeded, and false otherwise. If parsing
-   succeded, the integer value is returned by reference.
+   succeeded, the integer value is returned by reference.
 */
 
 bool util_sscanf_int(const char * buffer , int * value) {
+  if(!buffer)
+      return false;
+
   bool value_OK = false;
   char * error_ptr;
 
@@ -1548,7 +1557,7 @@ bool util_sscanf_int(const char * buffer , int * value) {
 
   if (error_ptr[0] == '\0') {
     value_OK = true;
-    if (value != NULL)
+    if(value != NULL)
       *value = tmp_value;
   }
   return value_OK;
@@ -1651,7 +1660,7 @@ const char * util_skip_sep(const char * s, const char * sep_set, bool *OK) {
 
 /**
    This function will parse string containing an integer, and an
-   optional suffix. The valid suffizes are KB,MB and GB (any case is
+   optional suffix. The valid suffixes are KB,MB and GB (any case is
    allowed); if no suffix is appended the buffer is assumed to contain
    a memory size already specified in bytes.
 
@@ -1676,6 +1685,12 @@ const char * util_skip_sep(const char * s, const char * sep_set, bool *OK) {
 
 
 bool util_sscanf_bytesize(const char * buffer, size_t *size) {
+  if(!buffer) {
+    if(size)
+      *size = 0;
+    return false;
+  }
+
   size_t value;
   char * suffix_ptr;
   size_t KB_factor = 1024;
@@ -1689,7 +1704,7 @@ bool util_sscanf_bytesize(const char * buffer, size_t *size) {
     while (isspace(suffix_ptr[0]))
       suffix_ptr++;
     {
-      char * upper = util_alloc_string_copy(suffix_ptr);
+      char * upper = util_alloc_strupr_copy(suffix_ptr);
       if (strcmp(upper,"KB") == 0)
         factor = KB_factor;
       else if (strcmp(upper,"MB") == 0)
@@ -1928,16 +1943,20 @@ int util_strcmp_int( const char * s1 , const char * s2) {
 
 
 /**
-    Succesfully parses:
+    Successfully parses:
 
       1 , T (not 't') , True (with any case) => true
       0 , F (not 'f') , False(with any case) => false
 
-    Else the parsing fails.
+    Otherwise, set _value to false and return false.
 */
-
-
 bool util_sscanf_bool(const char * buffer , bool * _value) {
+  if(!buffer) {
+    if(_value)
+      *_value = false;
+    return false;
+  }
+
   bool parse_OK = false;
   bool value    = false; /* Compiler shut up */
 
@@ -3144,9 +3163,11 @@ bool util_is_first_day_in_month_utc( time_t t) {
 bool util_sscanf_isodate(const char * date_token , time_t * t) {
   int day, month, year;
 
-  if (sscanf(date_token , "%d-%d-%d" , &year , &month , &day) == 3)
+  if (date_token && sscanf(date_token , "%d-%d-%d" , &year , &month , &day) == 3)
     return util_make_datetime_utc__(0,0,0,day , month , year , false, t);
 
+  if (t)
+    *t = -1;
   return false;
 }
 
@@ -3160,7 +3181,7 @@ bool util_sscanf_date_utc(const char * date_token , time_t * t) {
   int day   , month , year;
   char sep1 , sep2;
 
-  if (sscanf(date_token , "%d%c%d%c%d" , &day , &sep1 , &month , &sep2 , &year) == 5) {
+  if (date_token && sscanf(date_token , "%d%c%d%c%d" , &day , &sep1 , &month , &sep2 , &year) == 5) {
     if (t)
       *t = util_make_date_utc(day , month , year );
     return true;
@@ -3173,8 +3194,10 @@ bool util_sscanf_date_utc(const char * date_token , time_t * t) {
 
 
 bool util_sscanf_percent(const char * percent_token, double * value) {
-  char * percent_ptr;
+  if(!percent_token)
+    return false;
 
+  char * percent_ptr;
   double double_val = strtod( percent_token, &percent_ptr);
 
   if (0 == strcmp(percent_ptr, "%")) {


### PR DESCRIPTION
When passing a NULL buffer to sscanf functions in util, the software crashes.
I've added a check at the beginning of those functions so that, if the input buffer is NULL, they simply return false

**Pre un-WIP checklist**
- [x] Statoil tests pass locally
