### PR TITLE
Added simple function debug_msg( ).

### DIFF
--- a/python/python/ecl/test/CMakeLists.txt
+++ b/python/python/ecl/test/CMakeLists.txt
@@ -10,6 +10,7 @@ set(PYTHON_SOURCES
     path_context.py
     lint_test_case.py
     import_test_case.py
+    debug_msg.py
 )
 
 add_python_package("python.ecl.test"  ${PYTHON_INSTALL_PREFIX}/ecl/test "${PYTHON_SOURCES}" True)

--- a/python/python/ecl/test/__init__.py
+++ b/python/python/ecl/test/__init__.py
@@ -8,3 +8,4 @@ from .ert_test_runner import ErtTestRunner
 from .path_context import PathContext
 from .lint_test_case import LintTestCase
 from .import_test_case import ImportTestCase
+from .debug_msg import debug_msg

--- a/python/python/ecl/test/debug_msg.py
+++ b/python/python/ecl/test/debug_msg.py
@@ -1,0 +1,7 @@
+import inspect
+
+def debug_msg(msg):
+    record = inspect.stack()[1]
+    frame = record[0]
+    info = inspect.getframeinfo( frame )
+    return "FILE: %s  LINE: %s  Msg: %s" % (info.filename, info.lineno, msg)

--- a/python/tests/ecl/CMakeLists.txt
+++ b/python/tests/ecl/CMakeLists.txt
@@ -10,6 +10,7 @@ set(TEST_SOURCES
     test_ecl_file.py
     test_ecl_init_file.py
     test_ecl_restart_file.py
+    test_debug.py
     test_ecl_sum.py
     test_ecl_sum_vector.py
     test_fault_blocks.py
@@ -69,6 +70,7 @@ addPythonTest(tests.ecl.test_grav.EclGravTest)
 addPythonTest(tests.ecl.test_geertsma.GeertsmaTest)
 addPythonTest(tests.ecl.test_ecl_type.EclDataTypeTest)
 addPythonTest(tests.ecl.test_region.RegionTest)
+addPythonTest(tests.ecl.test_debug.DebugTest)
 
 
 if (STATOIL_TESTDATA_ROOT)

--- a/python/tests/ecl/test_debug.py
+++ b/python/tests/ecl/test_debug.py
@@ -1,0 +1,24 @@
+#  Copyright (C) 2017  Statoil ASA, Norway.
+#
+#  The file 'test_debug.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
+
+from ecl.test import debug_msg, ExtendedTestCase
+
+class DebugTest(ExtendedTestCase):
+
+    def test_create(self):
+        msg = debug_msg( "DEBUG" )
+        self.assertIn( __file__[:-1] , msg )
+        self.assertIn( "DEBUG" , msg )


### PR DESCRIPTION
**Task**
Debugging wpro is quite difficult - this is a minor utility to simplify `print` based debugging.


**Approach**
Added loose function under `ecl.test` package which will inspect the call stack, and determine filename and linenr.

**Pre un-WIP checklist**
- [x] Statoil tests pass locally
