### PR TITLE
WIP: Ecl file cache

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -381,6 +381,7 @@ foreach (name   ecl_alloc_cpgrid
                 ecl_nnc_info_test
                 ecl_nnc_vector
                 ecl_rft_cell
+                ecl_file_view
                 ecl_rst_file
                 ecl_sum_writer
                 ecl_util_make_date_no_shift

--- a/lib/ecl/ecl_file_kw.c
+++ b/lib/ecl/ecl_file_kw.c
@@ -135,7 +135,7 @@ UTIL_IS_INSTANCE_FUNCTION( ecl_file_kw , ECL_FILE_KW_TYPE_ID )
 
 
 
-static ecl_file_kw_type * ecl_file_kw_alloc__( const char * header , ecl_data_type data_type , int size , offset_type offset) {
+ecl_file_kw_type * ecl_file_kw_alloc0( const char * header , ecl_data_type data_type , int size , offset_type offset) {
   ecl_file_kw_type * file_kw = util_malloc( sizeof * file_kw );
   UTIL_TYPE_ID_INIT( file_kw , ECL_FILE_KW_TYPE_ID );
 
@@ -161,7 +161,7 @@ static ecl_file_kw_type * ecl_file_kw_alloc__( const char * header , ecl_data_ty
 */
 
 ecl_file_kw_type * ecl_file_kw_alloc( const ecl_kw_type * ecl_kw , offset_type offset ) {
-  return ecl_file_kw_alloc__( ecl_kw_get_header( ecl_kw ) , ecl_kw_get_data_type( ecl_kw ) , ecl_kw_get_size( ecl_kw ) , offset );
+  return ecl_file_kw_alloc0( ecl_kw_get_header( ecl_kw ) , ecl_kw_get_data_type( ecl_kw ) , ecl_kw_get_size( ecl_kw ) , offset );
 }
 
 
@@ -169,7 +169,7 @@ ecl_file_kw_type * ecl_file_kw_alloc( const ecl_kw_type * ecl_kw , offset_type o
     Does NOT copy the kw pointer which must be reloaded.
 */
 ecl_file_kw_type * ecl_file_kw_alloc_copy( const ecl_file_kw_type * src ) {
-  return ecl_file_kw_alloc__( src->header , ecl_file_kw_get_data_type(src) , src->kw_size , src->file_offset );
+  return ecl_file_kw_alloc0( src->header , ecl_file_kw_get_data_type(src) , src->kw_size , src->file_offset );
 }
 
 
@@ -191,6 +191,19 @@ void ecl_file_kw_free__( void * arg ) {
 }
 
 
+bool ecl_file_kw_equal( const ecl_file_kw_type * kw1 , const ecl_file_kw_type * kw2)
+{
+  if (kw1->file_offset != kw2->file_offset)
+    return false;
+
+  if (kw1->kw_size != kw2->kw_size)
+    return false;
+
+  if (!ecl_type_is_equal( kw1->data_type, kw2->data_type))
+    return false;
+
+  return util_string_equal( kw1->header , kw2->header );
+}
 
 static void ecl_file_kw_assert_kw( const ecl_file_kw_type * file_kw ) {
   if(!ecl_type_is_equal(
@@ -323,4 +336,88 @@ void ecl_file_kw_inplace_fwrite( ecl_file_kw_type * file_kw , fortio_type * fort
 }
 
 
+void ecl_file_kw_fwrite( const ecl_file_kw_type * file_kw , FILE * stream ) {
+  int header_length = strlen( file_kw->header );
+  for (int i=0; i < ECL_STRING8_LENGTH; i++) {
+    if (i < header_length)
+      fputc( file_kw->header[i], stream );
+    else
+      fputc( ' ' , stream );
+  }
 
+  util_fwrite_int( file_kw->kw_size , stream );
+  util_fwrite_offset( file_kw->file_offset , stream );
+  util_fwrite_int( ecl_type_get_type( file_kw->data_type ) , stream );
+  util_fwrite_size_t( ecl_type_get_sizeof_ctype( file_kw->data_type ) , stream );
+}
+
+
+ecl_file_kw_type ** ecl_file_kw_fread_alloc_multiple( FILE * stream , int num) {
+  size_t buffer_size = num * (ECL_STRING8_LENGTH + 2 * sizeof(int) + sizeof(offset_type) + sizeof(size_t));
+  char * buffer = util_malloc( buffer_size * sizeof * buffer );
+  size_t num_read = fread( buffer, 1 , buffer_size , stream);
+
+  if (num_read != buffer_size) {
+    free( buffer );
+    return NULL;
+  }
+
+  {
+    ecl_file_kw_type ** kw_list = util_malloc( num * sizeof * kw_list );
+    for (int ikw = 0; ikw < num; ikw++) {
+      int buffer_offset = 0;
+      char header[ECL_STRING8_LENGTH + 1];
+      int kw_size;
+      offset_type file_offset;
+      ecl_type_enum ecl_type;
+      size_t type_size;
+      {
+        int index = 0;
+        while (true) {
+        if (buffer[index + buffer_offset] != ' ')
+          header[index] = buffer[index + buffer_offset];
+        else
+          break;
+
+        index++;
+        if (index == ECL_STRING8_LENGTH)
+          break;
+        }
+        header[index] = '\0';
+        buffer_offset += ECL_STRING8_LENGTH;
+      }
+
+      kw_size = *((int *) &buffer[ buffer_offset ]);
+      buffer_offset += sizeof kw_size;
+
+      file_offset = *((offset_type *) &buffer[ buffer_offset ]);
+      buffer_offset += sizeof file_offset;
+
+      ecl_type = *(( ecl_type_enum *) &buffer[ buffer_offset ]);
+      buffer_offset += sizeof ecl_type;
+
+      type_size = *((size_t *) &buffer[ buffer_offset ]);
+      buffer_offset += sizeof type_size;
+
+      kw_list[ikw] = ecl_file_kw_alloc0( header , ecl_type_create( ecl_type , type_size ), kw_size, file_offset );
+    }
+
+    free( buffer );
+    return kw_list;
+  }
+}
+
+
+
+
+ecl_file_kw_type * ecl_file_kw_fread_alloc( FILE * stream ) {
+  ecl_file_kw_type * file_kw = NULL;
+  ecl_file_kw_type ** multiple = ecl_file_kw_fread_alloc_multiple( stream , 1 );
+
+  if (multiple) {
+    file_kw = multiple[0];
+    free( multiple );
+  }
+
+  return file_kw;
+}

--- a/lib/ecl/tests/ecl_file_view.c
+++ b/lib/ecl/tests/ecl_file_view.c
@@ -1,0 +1,112 @@
+/*
+   Copyright (C) 2017  Statoil ASA, Norway.
+
+   The file 'ecl_file_view.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+#include <stdlib.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#include <ert/util/test_util.h>
+#include <ert/util/util.h>
+#include <ert/util/test_work_area.h>
+
+#include <ert/ecl/ecl_util.h>
+#include <ert/ecl/ecl_file.h>
+#include <ert/ecl/ecl_file_view.h>
+#include <ert/ecl/ecl_file_kw.h>
+
+void test_file_kw_equal() {
+  ecl_file_kw_type * kw1 = ecl_file_kw_alloc0( "PRESSURE" , ECL_FLOAT, 1000 , 66);
+  ecl_file_kw_type * kw2 = ecl_file_kw_alloc0( "PRESSURE" , ECL_FLOAT, 1000 , 66);
+  ecl_file_kw_type * kw3 = ecl_file_kw_alloc0( "SWAT" , ECL_FLOAT, 1000 , 66);
+  ecl_file_kw_type * kw4 = ecl_file_kw_alloc0( "PRESSURE" , ECL_DOUBLE, 1000 , 66);
+  ecl_file_kw_type * kw5 = ecl_file_kw_alloc0( "PRESSURE" , ECL_FLOAT, 10 , 66);
+  ecl_file_kw_type * kw6 = ecl_file_kw_alloc0( "PRESSURE" , ECL_FLOAT, 1000 , 67);
+
+  test_assert_true( ecl_file_kw_equal( kw1 , kw1 ));
+  test_assert_true( ecl_file_kw_equal( kw1 , kw2 ));
+  test_assert_false( ecl_file_kw_equal( kw1 , kw3 ));
+  test_assert_false( ecl_file_kw_equal( kw1 , kw4 ));
+  test_assert_false( ecl_file_kw_equal( kw1 , kw5 ));
+  test_assert_false( ecl_file_kw_equal( kw1 , kw6 ));
+
+  ecl_file_kw_free( kw6 );
+  ecl_file_kw_free( kw5 );
+  ecl_file_kw_free( kw4 );
+  ecl_file_kw_free( kw3 );
+  ecl_file_kw_free( kw2 );
+  ecl_file_kw_free( kw1 );
+}
+
+void test_create_file_kw() {
+  ecl_file_kw_type * file_kw = ecl_file_kw_alloc0( "PRESSURE" , ECL_FLOAT, 1000 , 66);
+  test_assert_string_equal( ecl_file_kw_get_header( file_kw ) , "PRESSURE" );
+  test_assert_int_equal( ecl_file_kw_get_size( file_kw ) , 1000 );
+  test_assert_true( ecl_type_is_equal( ecl_file_kw_get_data_type( file_kw ) , ECL_FLOAT ));
+  {
+    test_work_area_type * work_area = test_work_area_alloc("file_kw");
+    {
+      FILE * ostream = util_fopen("file_kw" , "w");
+      ecl_file_kw_fwrite( file_kw , ostream );
+      fclose( ostream );
+    }
+    {
+      FILE * istream = util_fopen("file_kw" , "r");
+      ecl_file_kw_type * disk_kw = ecl_file_kw_fread_alloc( istream );
+      test_assert_true( ecl_file_kw_equal( file_kw , disk_kw ));
+
+      /* Beyond the end of stream - return NULL */
+      test_assert_NULL( ecl_file_kw_fread_alloc( istream ));
+      ecl_file_kw_free( disk_kw );
+      fclose( istream );
+    }
+
+    {
+      FILE * ostream = util_fopen("file_kw" , "w");
+      ecl_file_kw_fwrite( file_kw , ostream );
+      ecl_file_kw_fwrite( file_kw , ostream );
+      ecl_file_kw_fwrite( file_kw , ostream );
+      fclose( ostream );
+    }
+
+    {
+      FILE * istream = util_fopen("file_kw" , "r");
+      ecl_file_kw_type ** disk_kw = ecl_file_kw_fread_alloc_multiple( istream , 3);
+      test_assert_true( ecl_file_kw_equal( file_kw , disk_kw[0] ));
+      test_assert_true( ecl_file_kw_equal( file_kw , disk_kw[1] ));
+      test_assert_true( ecl_file_kw_equal( file_kw , disk_kw[2] ));
+
+      for (int i=0; i < 3; i++)
+        ecl_file_kw_free( disk_kw[i] );
+      free( disk_kw );
+      fclose( istream );
+    }
+    {
+      FILE * istream = util_fopen("file_kw" , "r");
+      test_assert_NULL( ecl_file_kw_fread_alloc_multiple( istream , 10));
+      fclose( istream );
+    }
+    test_work_area_free( work_area );
+  }
+  ecl_file_kw_free( file_kw );
+}
+
+
+int main( int argc , char ** argv) {
+  util_install_signals();
+  test_file_kw_equal( );
+  test_create_file_kw( );
+}

--- a/lib/include/ert/ecl/ecl_file_kw.h
+++ b/lib/include/ert/ecl/ecl_file_kw.h
@@ -36,8 +36,9 @@ typedef struct inv_map_struct inv_map_type;
   inv_map_type     * inv_map_alloc(void);
   ecl_file_kw_type * inv_map_get_file_kw( inv_map_type * inv_map , const ecl_kw_type * ecl_kw );
   void               inv_map_free( inv_map_type * map );
-
+  bool               ecl_file_kw_equal( const ecl_file_kw_type * kw1 , const ecl_file_kw_type * kw2);
   ecl_file_kw_type * ecl_file_kw_alloc( const ecl_kw_type * ecl_kw , offset_type offset);
+  ecl_file_kw_type * ecl_file_kw_alloc0( const char * header , ecl_data_type data_type , int size , offset_type offset);
   void               ecl_file_kw_free( ecl_file_kw_type * file_kw );
   void               ecl_file_kw_free__( void * arg );
   ecl_kw_type      * ecl_file_kw_get_kw( ecl_file_kw_type * file_kw , fortio_type * fortio, inv_map_type * inv_map);

--- a/lib/include/ert/util/util.h
+++ b/lib/include/ert/util/util.h
@@ -349,6 +349,8 @@ typedef enum {left_pad   = 0,
   long     util_fread_long(FILE * );
   bool     util_fread_bool(FILE * );
   double   util_fread_double(FILE * stream);
+  void     util_fwrite_offset(offset_type    , FILE * );
+  void     util_fwrite_size_t (size_t    , FILE * );
   void     util_fwrite_int   (int    , FILE * );
   void     util_fwrite_long  (long    , FILE * );
   void     util_fwrite_bool  (bool    , FILE * );

--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -4303,10 +4303,11 @@ void util_fskip_string(FILE *stream) {
 }
 
 
-
+void util_fwrite_offset( offset_type value , FILE * stream ) { UTIL_FWRITE_SCALAR(value , stream); }
 void util_fwrite_bool     (bool value , FILE * stream)   { UTIL_FWRITE_SCALAR(value , stream); }
 void util_fwrite_int      (int value , FILE * stream)    { UTIL_FWRITE_SCALAR(value , stream); }
 void util_fwrite_time_t   (time_t value , FILE * stream)    { UTIL_FWRITE_SCALAR(value , stream); }
+void util_fwrite_size_t   (size_t value , FILE * stream)    { UTIL_FWRITE_SCALAR(value , stream); }
 void util_fwrite_long  (long value , FILE * stream)    { UTIL_FWRITE_SCALAR(value , stream); }
 void util_fwrite_double(double value , FILE * stream) { UTIL_FWRITE_SCALAR(value , stream); }
 

--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -4236,19 +4236,12 @@ void util_double_to_float(float *float_ptr , const double *double_ptr , int size
    The util_fwrite_string / util_fread_string are BROKEN when it comes
    to NULL / versus an empty string "":
 
-    1. Writing a "" string what is actually written to disk is: "0\0",
-       whereas the disk content when writing NULL is "0".
+    1. When writing 'NULL' to disk what is actually found on the disk
+       is the sequence "0".
 
-    2. When reading back we find the '0' - but it is impossible to
-       determine whether we should interpret this as a NULL or as "".
-
-   When the harm was done, with files allover the place, it is "solved"
-   as follows:
-
-    1. Nothing is changed when writing NULL => '0' to disk.
-
-    2. When writing "" => '-1\0' to disk. The -1 is the magic length
-       signifying that the following string is "".
+    2. When writing the empty string - i.e. "" - what hits the disk is
+       the sequence "-1\0"; i.e. the -1 is used as a magic flag to
+       indicate the empty string.
 */
 
 


### PR DESCRIPTION
**Task**
When loading an ECLIPSE binary we start by seeking through the whole file and building an index. In the case of very large ( ~ 500GB ) this takes prohibitively long time, and the task is to create a on-disk cache of the index. This is mainly for Resinsight.


**Approach**
Added functions to dump an index, and to open a file from an on-disk index.


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
