### PR TITLE
util: fixed tests failing when conflicting file is found in /tmp

### DIFF
--- a/python/tests/util/test_path_context.py
+++ b/python/tests/util/test_path_context.py
@@ -3,18 +3,29 @@ from ecl.test import ExtendedTestCase, PathContext,TestAreaContext
 
 
 class PathContextTest(ExtendedTestCase):
+    
     def test_error(self):
-        with self.assertRaises(OSError):
-            with PathContext("/usr/lib/testing"):
-                pass
-
-        with open("/tmp/file" , "w") as f:
-            f.write("xx")
-
-        with self.assertRaises(OSError):
-            with PathContext("/tmp/file"):
-                pass
-        
+        with TestAreaContext("pathcontext"):
+            # Test failure on creating PathContext with an existing path 
+            os.makedirs("path/1")
+            with self.assertRaises(OSError):
+                with PathContext("path/1"):
+                    pass
+                
+            # Test failure on non-writable path 
+            os.chmod("path/1", 0444)
+            with self.assertRaises(OSError):
+                with PathContext("path/1/subfolder"):
+                    pass
+            os.chmod("path/1", 0744)
+            
+            # Test failure on creating PathContext with an existing file
+            with open("path/1/file", "w") as f:
+                f.write("xx")
+            with self.assertRaises(OSError):
+                with PathContext("path/1/file"):
+                    pass
+    
             
     def test_chdir(self):
         with PathContext("/tmp/pc"):
@@ -26,10 +37,6 @@ class PathContextTest(ExtendedTestCase):
     def test_cleanup(self):
         with TestAreaContext("pathcontext"):
             os.makedirs("path/1")
-
-            with self.assertRaises(OSError):
-                with PathContext("path/1"):
-                    pass
                 
             with PathContext("path/1/next/2/level"):
                 with open("../../file" , "w") as f:


### PR DESCRIPTION
**Task**
Fix a test_path_context since it fails when /tmp/file already exists and the user has no access to it


**Approach**
~~If the file exist, create the file required for the test in a subfolder of /tmp with a pseudorandom name~~
Use a dedicated TestAreaContext for performing the test


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
