### PR TITLE
Ecl file cache (continued)

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -381,6 +381,7 @@ foreach (name   ecl_alloc_cpgrid
                 ecl_nnc_info_test
                 ecl_nnc_vector
                 ecl_rft_cell
+                ecl_file_view
                 ecl_rst_file
                 ecl_sum_writer
                 ecl_util_make_date_no_shift

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -382,6 +382,7 @@ foreach (name   ecl_alloc_cpgrid
                 ecl_nnc_vector
                 ecl_rft_cell
                 ecl_file_view
+                test_ecl_file_index
                 ecl_rst_file
                 ecl_sum_writer
                 ecl_util_make_date_no_shift

--- a/lib/ecl/ecl_file.c
+++ b/lib/ecl/ecl_file.c
@@ -1048,14 +1048,12 @@ ecl_file_type * ecl_file_fast_open(const char * file_name, const char * index_fi
       ecl_file_kw_type * file_kw;
       for (int i = 0; i < index_size; i++) {
         file_kw = ecl_file_kw_fread_alloc( istream );
-        printf(" ********************************** %s: %s\n", __func__, ecl_file_kw_get_header(file_kw) );
+        fprintf(stderr, " ********************************** %s: %s\n", __func__, ecl_file_kw_get_header(file_kw) );
    
         ecl_file_view_add_kw( ecl_file_index->global_view , file_kw );
       }   
       ecl_file_view_make_index( ecl_file_index->global_view );
       ecl_file_select_global(ecl_file_index);
-
-      ecl_file_view_check_flags( ecl_file_index->flags , ECL_FILE_CLOSE_STREAM);     //debug
 
     {
     

--- a/lib/ecl/ecl_file.c
+++ b/lib/ecl/ecl_file.c
@@ -992,3 +992,12 @@ static ecl_file_type * ecl_file_iopen_rstblock__( const char * filename , int se
 ecl_file_type * ecl_file_iopen_rstblock( const char * filename , int seqnum_index , int flags) {
   return ecl_file_iopen_rstblock__(filename , seqnum_index , flags );
 }
+
+void  ecl_file_write_index( ecl_file_type * ecl_file , const char * filename , const char * index_filename) {
+  
+}
+
+
+ecl_file_type * ecl_file_fast_open(const char * filename, const char * index_filename) {
+  return NULL;
+}

--- a/lib/ecl/ecl_file.c
+++ b/lib/ecl/ecl_file.c
@@ -1003,17 +1003,18 @@ ecl_file_type * ecl_file_iopen_rstblock( const char * filename , int seqnum_inde
 }
 
 bool ecl_file_index_valid(const char * file_name, const char * index_file_name) {
-  if ( !(   util_file_exists( file_name ) && util_file_exists (index_file_name)   )   )
+  if ( !util_file_exists( file_name ))
+    return false;
+  if (!util_file_exists (index_file_name))
     return false;
   if (util_file_difftime( file_name , index_file_name) > 0)
     return false;
   return true;
 }
 
-void  ecl_file_write_index( ecl_file_type * ecl_file , const char * filename , const char * index_filename) {
+void  ecl_file_write_index( const ecl_file_type * ecl_file , const char * index_filename) {
   FILE * ostream = util_fopen(index_filename , "w");
-  util_fwrite_string( filename , ostream );
-  ecl_file_view_write_index( ecl_file->global_view , ostream );
+  ecl_file_view_write_index( ecl_file->global_view , fortio_filename_ref(ecl_file->fortio), ostream );
   fclose( ostream );
 }
 
@@ -1023,6 +1024,7 @@ ecl_file_type * ecl_file_fast_open(const char * file_name, const char * index_fi
     return NULL;
 
   FILE * istream = util_fopen(index_file_name , "r");
+  util_fread_int(istream);
   char * source_file = util_fread_alloc_string(istream);
 
   ecl_file_type * ecl_file = NULL;

--- a/lib/ecl/ecl_file.c
+++ b/lib/ecl/ecl_file.c
@@ -994,10 +994,26 @@ ecl_file_type * ecl_file_iopen_rstblock( const char * filename , int seqnum_inde
 }
 
 void  ecl_file_write_index( ecl_file_type * ecl_file , const char * filename , const char * index_filename) {
+  FILE * ostream = util_fopen(index_filename , "w");
+  util_fwrite_string( filename , ostream );
   
+  
+
+
+  fclose( ostream );
 }
 
 
-ecl_file_type * ecl_file_fast_open(const char * filename, const char * index_filename) {
-  return NULL;
+ecl_file_type * ecl_file_fast_open(const char * file_name, const char * index_file_name) {
+  if ( !(   util_file_exists( file_name ) & util_file_exists (index_file_name)   )   )
+    return NULL;
+
+  FILE * istream = util_fopen(index_file_name , "r");
+  char * file_name_ptr = util_fread_alloc_string(istream);
+  if (strcmp(file_name_ptr, file_name) != 0)   //change to free values in immature returns
+    return NULL;  
+
+
+  ecl_file_type * ecl_file_index = ecl_file_alloc_empty(0);
+  return ecl_file_index;
 }

--- a/lib/ecl/ecl_file.c
+++ b/lib/ecl/ecl_file.c
@@ -1014,7 +1014,8 @@ bool ecl_file_index_valid(const char * file_name, const char * index_file_name) 
 
 void  ecl_file_write_index( const ecl_file_type * ecl_file , const char * index_filename) {
   FILE * ostream = util_fopen(index_filename , "w");
-  ecl_file_view_write_index( ecl_file->global_view , fortio_filename_ref(ecl_file->fortio), ostream );
+  util_fwrite_string( fortio_filename_ref(ecl_file->fortio) , ostream );
+  ecl_file_view_write_index( ecl_file->global_view , ostream );
   fclose( ostream );
 }
 
@@ -1024,7 +1025,6 @@ ecl_file_type * ecl_file_fast_open(const char * file_name, const char * index_fi
     return NULL;
 
   FILE * istream = util_fopen(index_file_name , "r");
-  util_fread_int(istream);
   char * source_file = util_fread_alloc_string(istream);
 
   ecl_file_type * ecl_file = NULL;

--- a/lib/ecl/ecl_file_kw.c
+++ b/lib/ecl/ecl_file_kw.c
@@ -351,10 +351,13 @@ void ecl_file_kw_fwrite( const ecl_file_kw_type * file_kw , FILE * stream ) {
   util_fwrite_size_t( ecl_type_get_sizeof_ctype( file_kw->data_type ) , stream );
 }
 
+size_t ecl_file_kw_get_buffer_size() {
+  return ECL_STRING8_LENGTH + 2 * sizeof(int) + sizeof(offset_type) + sizeof(size_t);
+}
 
 ecl_file_kw_type ** ecl_file_kw_fread_alloc_multiple( FILE * stream , int num) {
   
-  size_t file_kw_size = ECL_STRING8_LENGTH + 2 * sizeof(int) + sizeof(offset_type) + sizeof(size_t);
+  size_t file_kw_size = ecl_file_kw_get_buffer_size();
   size_t buffer_size = num * file_kw_size;
   char * buffer = util_malloc( buffer_size * sizeof * buffer );
   size_t num_read = fread( buffer, 1 , buffer_size , stream);

--- a/lib/ecl/ecl_file_kw.c
+++ b/lib/ecl/ecl_file_kw.c
@@ -351,13 +351,9 @@ void ecl_file_kw_fwrite( const ecl_file_kw_type * file_kw , FILE * stream ) {
   util_fwrite_size_t( ecl_type_get_sizeof_ctype( file_kw->data_type ) , stream );
 }
 
-size_t ecl_file_kw_get_buffer_size() {
-  return ECL_STRING8_LENGTH + 2 * sizeof(int) + sizeof(offset_type) + sizeof(size_t);
-}
-
 ecl_file_kw_type ** ecl_file_kw_fread_alloc_multiple( FILE * stream , int num) {
   
-  size_t file_kw_size = ecl_file_kw_get_buffer_size();
+  size_t file_kw_size = ECL_STRING8_LENGTH + 2 * sizeof(int) + sizeof(offset_type) + sizeof(size_t);
   size_t buffer_size = num * file_kw_size;
   char * buffer = util_malloc( buffer_size * sizeof * buffer );
   size_t num_read = fread( buffer, 1 , buffer_size , stream);

--- a/lib/ecl/ecl_file_kw.c
+++ b/lib/ecl/ecl_file_kw.c
@@ -353,7 +353,9 @@ void ecl_file_kw_fwrite( const ecl_file_kw_type * file_kw , FILE * stream ) {
 
 
 ecl_file_kw_type ** ecl_file_kw_fread_alloc_multiple( FILE * stream , int num) {
-  size_t buffer_size = num * (ECL_STRING8_LENGTH + 2 * sizeof(int) + sizeof(offset_type) + sizeof(size_t));
+  
+  size_t file_kw_size = ECL_STRING8_LENGTH + 2 * sizeof(int) + sizeof(offset_type) + sizeof(size_t);
+  size_t buffer_size = num * file_kw_size;
   char * buffer = util_malloc( buffer_size * sizeof * buffer );
   size_t num_read = fread( buffer, 1 , buffer_size , stream);
 
@@ -365,7 +367,7 @@ ecl_file_kw_type ** ecl_file_kw_fread_alloc_multiple( FILE * stream , int num) {
   {
     ecl_file_kw_type ** kw_list = util_malloc( num * sizeof * kw_list );
     for (int ikw = 0; ikw < num; ikw++) {
-      int buffer_offset = 0;
+      int buffer_offset = ikw * file_kw_size;
       char header[ECL_STRING8_LENGTH + 1];
       int kw_size;
       offset_type file_offset;

--- a/lib/ecl/ecl_file_kw.c
+++ b/lib/ecl/ecl_file_kw.c
@@ -135,7 +135,7 @@ UTIL_IS_INSTANCE_FUNCTION( ecl_file_kw , ECL_FILE_KW_TYPE_ID )
 
 
 
-static ecl_file_kw_type * ecl_file_kw_alloc__( const char * header , ecl_data_type data_type , int size , offset_type offset) {
+ecl_file_kw_type * ecl_file_kw_alloc0( const char * header , ecl_data_type data_type , int size , offset_type offset) {
   ecl_file_kw_type * file_kw = util_malloc( sizeof * file_kw );
   UTIL_TYPE_ID_INIT( file_kw , ECL_FILE_KW_TYPE_ID );
 
@@ -161,7 +161,7 @@ static ecl_file_kw_type * ecl_file_kw_alloc__( const char * header , ecl_data_ty
 */
 
 ecl_file_kw_type * ecl_file_kw_alloc( const ecl_kw_type * ecl_kw , offset_type offset ) {
-  return ecl_file_kw_alloc__( ecl_kw_get_header( ecl_kw ) , ecl_kw_get_data_type( ecl_kw ) , ecl_kw_get_size( ecl_kw ) , offset );
+  return ecl_file_kw_alloc0( ecl_kw_get_header( ecl_kw ) , ecl_kw_get_data_type( ecl_kw ) , ecl_kw_get_size( ecl_kw ) , offset );
 }
 
 
@@ -169,7 +169,7 @@ ecl_file_kw_type * ecl_file_kw_alloc( const ecl_kw_type * ecl_kw , offset_type o
     Does NOT copy the kw pointer which must be reloaded.
 */
 ecl_file_kw_type * ecl_file_kw_alloc_copy( const ecl_file_kw_type * src ) {
-  return ecl_file_kw_alloc__( src->header , ecl_file_kw_get_data_type(src) , src->kw_size , src->file_offset );
+  return ecl_file_kw_alloc0( src->header , ecl_file_kw_get_data_type(src) , src->kw_size , src->file_offset );
 }
 
 
@@ -191,6 +191,19 @@ void ecl_file_kw_free__( void * arg ) {
 }
 
 
+bool ecl_file_kw_equal( const ecl_file_kw_type * kw1 , const ecl_file_kw_type * kw2)
+{
+  if (kw1->file_offset != kw2->file_offset)
+    return false;
+
+  if (kw1->kw_size != kw2->kw_size)
+    return false;
+
+  if (!ecl_type_is_equal( kw1->data_type, kw2->data_type))
+    return false;
+
+  return util_string_equal( kw1->header , kw2->header );
+}
 
 static void ecl_file_kw_assert_kw( const ecl_file_kw_type * file_kw ) {
   if(!ecl_type_is_equal(
@@ -323,4 +336,88 @@ void ecl_file_kw_inplace_fwrite( ecl_file_kw_type * file_kw , fortio_type * fort
 }
 
 
+void ecl_file_kw_fwrite( const ecl_file_kw_type * file_kw , FILE * stream ) {
+  int header_length = strlen( file_kw->header );
+  for (int i=0; i < ECL_STRING8_LENGTH; i++) {
+    if (i < header_length)
+      fputc( file_kw->header[i], stream );
+    else
+      fputc( ' ' , stream );
+  }
 
+  util_fwrite_int( file_kw->kw_size , stream );
+  util_fwrite_offset( file_kw->file_offset , stream );
+  util_fwrite_int( ecl_type_get_type( file_kw->data_type ) , stream );
+  util_fwrite_size_t( ecl_type_get_sizeof_ctype( file_kw->data_type ) , stream );
+}
+
+
+ecl_file_kw_type ** ecl_file_kw_fread_alloc_multiple( FILE * stream , int num) {
+  size_t buffer_size = num * (ECL_STRING8_LENGTH + 2 * sizeof(int) + sizeof(offset_type) + sizeof(size_t));
+  char * buffer = util_malloc( buffer_size * sizeof * buffer );
+  size_t num_read = fread( buffer, 1 , buffer_size , stream);
+
+  if (num_read != buffer_size) {
+    free( buffer );
+    return NULL;
+  }
+
+  {
+    ecl_file_kw_type ** kw_list = util_malloc( num * sizeof * kw_list );
+    for (int ikw = 0; ikw < num; ikw++) {
+      int buffer_offset = 0;
+      char header[ECL_STRING8_LENGTH + 1];
+      int kw_size;
+      offset_type file_offset;
+      ecl_type_enum ecl_type;
+      size_t type_size;
+      {
+        int index = 0;
+        while (true) {
+        if (buffer[index + buffer_offset] != ' ')
+          header[index] = buffer[index + buffer_offset];
+        else
+          break;
+
+        index++;
+        if (index == ECL_STRING8_LENGTH)
+          break;
+        }
+        header[index] = '\0';
+        buffer_offset += ECL_STRING8_LENGTH;
+      }
+
+      kw_size = *((int *) &buffer[ buffer_offset ]);
+      buffer_offset += sizeof kw_size;
+
+      file_offset = *((offset_type *) &buffer[ buffer_offset ]);
+      buffer_offset += sizeof file_offset;
+
+      ecl_type = *(( ecl_type_enum *) &buffer[ buffer_offset ]);
+      buffer_offset += sizeof ecl_type;
+
+      type_size = *((size_t *) &buffer[ buffer_offset ]);
+      buffer_offset += sizeof type_size;
+
+      kw_list[ikw] = ecl_file_kw_alloc0( header , ecl_type_create( ecl_type , type_size ), kw_size, file_offset );
+    }
+
+    free( buffer );
+    return kw_list;
+  }
+}
+
+
+
+
+ecl_file_kw_type * ecl_file_kw_fread_alloc( FILE * stream ) {
+  ecl_file_kw_type * file_kw = NULL;
+  ecl_file_kw_type ** multiple = ecl_file_kw_fread_alloc_multiple( stream , 1 );
+
+  if (multiple) {
+    file_kw = multiple[0];
+    free( multiple );
+  }
+
+  return file_kw;
+}

--- a/lib/ecl/ecl_file_view.c
+++ b/lib/ecl/ecl_file_view.c
@@ -778,8 +778,12 @@ void ecl_file_view_fclose_stream( ecl_file_view_type * file_view ) {
   fortio_fclose_stream( file_view->fortio );
 }
 
-void ecl_file_view_write_index(ecl_file_view_type * file_view, FILE * ostream) {
+void ecl_file_view_write_index(const ecl_file_view_type * file_view, const char * filename, FILE * ostream) {
   int size = ecl_file_view_get_size(file_view);
+
+  int total_file_size = 3 * sizeof(int) + strlen(filename) + size * ecl_file_kw_get_buffer_size();
+  util_fwrite_int( total_file_size , ostream);
+  util_fwrite_string( filename , ostream );
   util_fwrite_int( size , ostream);
   
   ecl_file_kw_type * file_kw;

--- a/lib/ecl/ecl_file_view.c
+++ b/lib/ecl/ecl_file_view.c
@@ -787,7 +787,6 @@ void ecl_file_view_write_index(ecl_file_view_type * file_view, FILE * ostream) {
      file_kw = ecl_file_view_iget_file_kw( file_view, i );
      ecl_file_kw_fwrite( file_kw , ostream );
   }
-
 }
 
 ecl_file_view_type * ecl_file_view_fread_alloc( fortio_type * fortio , int * flags , inv_map_type * inv_map, FILE * istream ) {

--- a/lib/ecl/ecl_file_view.c
+++ b/lib/ecl/ecl_file_view.c
@@ -778,12 +778,8 @@ void ecl_file_view_fclose_stream( ecl_file_view_type * file_view ) {
   fortio_fclose_stream( file_view->fortio );
 }
 
-void ecl_file_view_write_index(const ecl_file_view_type * file_view, const char * filename, FILE * ostream) {
+void ecl_file_view_write_index(const ecl_file_view_type * file_view, FILE * ostream) {
   int size = ecl_file_view_get_size(file_view);
-
-  int total_file_size = 3 * sizeof(int) + strlen(filename) + size * ecl_file_kw_get_buffer_size();
-  util_fwrite_int( total_file_size , ostream);
-  util_fwrite_string( filename , ostream );
   util_fwrite_int( size , ostream);
   
   ecl_file_kw_type * file_kw;

--- a/lib/ecl/ecl_file_view.c
+++ b/lib/ecl/ecl_file_view.c
@@ -802,6 +802,7 @@ ecl_file_view_type * ecl_file_view_fread_alloc( fortio_type * fortio , int * fla
     for (int i=0; i < index_size; i++)
       ecl_file_view_add_kw(file_view , file_kw_list[i]);
 
+    free(file_kw_list);
     ecl_file_view_make_index( file_view );
     return file_view;
   }

--- a/lib/ecl/ecl_file_view.c
+++ b/lib/ecl/ecl_file_view.c
@@ -777,3 +777,35 @@ ecl_file_view_type * ecl_file_view_add_summary_view( ecl_file_view_type * file_v
 void ecl_file_view_fclose_stream( ecl_file_view_type * file_view ) {
   fortio_fclose_stream( file_view->fortio );
 }
+
+void ecl_file_view_write_index(ecl_file_view_type * file_view, FILE * ostream) {
+  int size = ecl_file_view_get_size(file_view);
+  util_fwrite_int( size , ostream);
+  
+  ecl_file_kw_type * file_kw;
+  for (int i = 0; i < size; i++) {
+     file_kw = ecl_file_view_iget_file_kw( file_view, i );
+     ecl_file_kw_fwrite( file_kw , ostream );
+  }
+
+}
+
+ecl_file_view_type * ecl_file_view_fread_alloc( fortio_type * fortio , int * flags , inv_map_type * inv_map, FILE * istream ) {
+
+  int index_size = util_fread_int(istream);
+  ecl_file_kw_type ** file_kw_list = ecl_file_kw_fread_alloc_multiple( istream, index_size);
+  if (file_kw_list) {
+    ecl_file_view_type * file_view = ecl_file_view_alloc( fortio , flags , inv_map , true ); 
+    for (int i=0; i < index_size; i++)
+      ecl_file_view_add_kw(file_view , file_kw_list[i]);
+
+    ecl_file_view_make_index( file_view );
+    return file_view;
+  }
+  else {
+    fprintf(stderr, "%s: error reading ecl_file_type index file.\n", __func__);
+    return NULL;
+  }
+  
+}
+

--- a/lib/ecl/tests/ecl_file_view.c
+++ b/lib/ecl/tests/ecl_file_view.c
@@ -1,0 +1,112 @@
+/*
+   Copyright (C) 2017  Statoil ASA, Norway.
+
+   The file 'ecl_file_view.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+#include <stdlib.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#include <ert/util/test_util.h>
+#include <ert/util/util.h>
+#include <ert/util/test_work_area.h>
+
+#include <ert/ecl/ecl_util.h>
+#include <ert/ecl/ecl_file.h>
+#include <ert/ecl/ecl_file_view.h>
+#include <ert/ecl/ecl_file_kw.h>
+
+void test_file_kw_equal() {
+  ecl_file_kw_type * kw1 = ecl_file_kw_alloc0( "PRESSURE" , ECL_FLOAT, 1000 , 66);
+  ecl_file_kw_type * kw2 = ecl_file_kw_alloc0( "PRESSURE" , ECL_FLOAT, 1000 , 66);
+  ecl_file_kw_type * kw3 = ecl_file_kw_alloc0( "SWAT" , ECL_FLOAT, 1000 , 66);
+  ecl_file_kw_type * kw4 = ecl_file_kw_alloc0( "PRESSURE" , ECL_DOUBLE, 1000 , 66);
+  ecl_file_kw_type * kw5 = ecl_file_kw_alloc0( "PRESSURE" , ECL_FLOAT, 10 , 66);
+  ecl_file_kw_type * kw6 = ecl_file_kw_alloc0( "PRESSURE" , ECL_FLOAT, 1000 , 67);
+
+  test_assert_true( ecl_file_kw_equal( kw1 , kw1 ));
+  test_assert_true( ecl_file_kw_equal( kw1 , kw2 ));
+  test_assert_false( ecl_file_kw_equal( kw1 , kw3 ));
+  test_assert_false( ecl_file_kw_equal( kw1 , kw4 ));
+  test_assert_false( ecl_file_kw_equal( kw1 , kw5 ));
+  test_assert_false( ecl_file_kw_equal( kw1 , kw6 ));
+
+  ecl_file_kw_free( kw6 );
+  ecl_file_kw_free( kw5 );
+  ecl_file_kw_free( kw4 );
+  ecl_file_kw_free( kw3 );
+  ecl_file_kw_free( kw2 );
+  ecl_file_kw_free( kw1 );
+}
+
+void test_create_file_kw() {
+  ecl_file_kw_type * file_kw = ecl_file_kw_alloc0( "PRESSURE" , ECL_FLOAT, 1000 , 66);
+  test_assert_string_equal( ecl_file_kw_get_header( file_kw ) , "PRESSURE" );
+  test_assert_int_equal( ecl_file_kw_get_size( file_kw ) , 1000 );
+  test_assert_true( ecl_type_is_equal( ecl_file_kw_get_data_type( file_kw ) , ECL_FLOAT ));
+  {
+    test_work_area_type * work_area = test_work_area_alloc("file_kw");
+    {
+      FILE * ostream = util_fopen("file_kw" , "w");
+      ecl_file_kw_fwrite( file_kw , ostream );
+      fclose( ostream );
+    }
+    {
+      FILE * istream = util_fopen("file_kw" , "r");
+      ecl_file_kw_type * disk_kw = ecl_file_kw_fread_alloc( istream );
+      test_assert_true( ecl_file_kw_equal( file_kw , disk_kw ));
+
+      /* Beyond the end of stream - return NULL */
+      test_assert_NULL( ecl_file_kw_fread_alloc( istream ));
+      ecl_file_kw_free( disk_kw );
+      fclose( istream );
+    }
+
+    {
+      FILE * ostream = util_fopen("file_kw" , "w");
+      ecl_file_kw_fwrite( file_kw , ostream );
+      ecl_file_kw_fwrite( file_kw , ostream );
+      ecl_file_kw_fwrite( file_kw , ostream );
+      fclose( ostream );
+    }
+
+    {
+      FILE * istream = util_fopen("file_kw" , "r");
+      ecl_file_kw_type ** disk_kw = ecl_file_kw_fread_alloc_multiple( istream , 3);
+      test_assert_true( ecl_file_kw_equal( file_kw , disk_kw[0] ));
+      test_assert_true( ecl_file_kw_equal( file_kw , disk_kw[1] ));
+      test_assert_true( ecl_file_kw_equal( file_kw , disk_kw[2] ));
+
+      for (int i=0; i < 3; i++)
+        ecl_file_kw_free( disk_kw[i] );
+      free( disk_kw );
+      fclose( istream );
+    }
+    {
+      FILE * istream = util_fopen("file_kw" , "r");
+      test_assert_NULL( ecl_file_kw_fread_alloc_multiple( istream , 10));
+      fclose( istream );
+    }
+    test_work_area_free( work_area );
+  }
+  ecl_file_kw_free( file_kw );
+}
+
+
+int main( int argc , char ** argv) {
+  util_install_signals();
+  test_file_kw_equal( );
+  test_create_file_kw( );
+}

--- a/lib/ecl/tests/ecl_file_view.c
+++ b/lib/ecl/tests/ecl_file_view.c
@@ -52,21 +52,23 @@ void test_file_kw_equal() {
 }
 
 void test_create_file_kw() {
-  ecl_file_kw_type * file_kw = ecl_file_kw_alloc0( "PRESSURE" , ECL_FLOAT, 1000 , 66);
-  test_assert_string_equal( ecl_file_kw_get_header( file_kw ) , "PRESSURE" );
-  test_assert_int_equal( ecl_file_kw_get_size( file_kw ) , 1000 );
-  test_assert_true( ecl_type_is_equal( ecl_file_kw_get_data_type( file_kw ) , ECL_FLOAT ));
+  ecl_file_kw_type * file_kw0 = ecl_file_kw_alloc0( "PRESSURE" , ECL_FLOAT, 1000 , 66);
+  ecl_file_kw_type * file_kw1 = ecl_file_kw_alloc0( "TEST1_KW" , ECL_FLOAT, 2000 , 1066);
+  ecl_file_kw_type * file_kw2 = ecl_file_kw_alloc0( "TEST2_KW" , ECL_FLOAT, 3000 , 2066);
+  test_assert_string_equal( ecl_file_kw_get_header( file_kw0 ) , "PRESSURE" );
+  test_assert_int_equal( ecl_file_kw_get_size( file_kw0 ) , 1000 );
+  test_assert_true( ecl_type_is_equal( ecl_file_kw_get_data_type( file_kw0 ) , ECL_FLOAT ));
   {
     test_work_area_type * work_area = test_work_area_alloc("file_kw");
     {
       FILE * ostream = util_fopen("file_kw" , "w");
-      ecl_file_kw_fwrite( file_kw , ostream );
+      ecl_file_kw_fwrite( file_kw0 , ostream );
       fclose( ostream );
     }
     {
       FILE * istream = util_fopen("file_kw" , "r");
       ecl_file_kw_type * disk_kw = ecl_file_kw_fread_alloc( istream );
-      test_assert_true( ecl_file_kw_equal( file_kw , disk_kw ));
+      test_assert_true( ecl_file_kw_equal( file_kw0 , disk_kw ));
 
       /* Beyond the end of stream - return NULL */
       test_assert_NULL( ecl_file_kw_fread_alloc( istream ));
@@ -76,18 +78,18 @@ void test_create_file_kw() {
 
     {
       FILE * ostream = util_fopen("file_kw" , "w");
-      ecl_file_kw_fwrite( file_kw , ostream );
-      ecl_file_kw_fwrite( file_kw , ostream );
-      ecl_file_kw_fwrite( file_kw , ostream );
+      ecl_file_kw_fwrite( file_kw0 , ostream );
+      ecl_file_kw_fwrite( file_kw1 , ostream );
+      ecl_file_kw_fwrite( file_kw2 , ostream );
       fclose( ostream );
     }
 
     {
       FILE * istream = util_fopen("file_kw" , "r");
       ecl_file_kw_type ** disk_kw = ecl_file_kw_fread_alloc_multiple( istream , 3);
-      test_assert_true( ecl_file_kw_equal( file_kw , disk_kw[0] ));
-      test_assert_true( ecl_file_kw_equal( file_kw , disk_kw[1] ));
-      test_assert_true( ecl_file_kw_equal( file_kw , disk_kw[2] ));
+      test_assert_true( ecl_file_kw_equal( file_kw0 , disk_kw[0] ));
+      test_assert_true( ecl_file_kw_equal( file_kw1 , disk_kw[1] ));
+      test_assert_true( ecl_file_kw_equal( file_kw2 , disk_kw[2] ));
 
       for (int i=0; i < 3; i++)
         ecl_file_kw_free( disk_kw[i] );
@@ -101,7 +103,10 @@ void test_create_file_kw() {
     }
     test_work_area_free( work_area );
   }
-  ecl_file_kw_free( file_kw );
+  ecl_file_kw_free( file_kw0 );
+  ecl_file_kw_free( file_kw1 );
+  ecl_file_kw_free( file_kw2 );
+  
 }
 
 

--- a/lib/ecl/tests/test_ecl_file_index.c
+++ b/lib/ecl/tests/test_ecl_file_index.c
@@ -58,11 +58,16 @@ void test_create_and_load_index_file() {
       ecl_kw_type * kw = ecl_kw_alloc("TEST1_KW", data_size, ECL_INT);
       for(int i = 0; i < data_size; ++i)
          ecl_kw_iset_int(kw, i, 537 + i);
-
       fortio_type * fortio = fortio_open_writer(file_name, false, ECL_ENDIAN_FLIP);
       ecl_kw_fwrite(kw, fortio); 
       ecl_kw_free(kw);
-
+      
+      data_size = 5;
+      kw = ecl_kw_alloc("TEST2_KW", data_size, ECL_FLOAT);
+      for(int i = 0; i < data_size; ++i)
+         ecl_kw_iset_float(kw, i, 0.15 * i);
+      ecl_kw_fwrite(kw, fortio);
+      ecl_kw_free(kw);
       fortio_fclose(fortio); 
       //finished creating data file
 
@@ -80,19 +85,18 @@ void test_create_and_load_index_file() {
 
       //Add timestamp check
 
-      test_assert_int_equal(ecl_file_size, ecl_file_get_size(ecl_file_index) );
-      
-       //debug
-       ecl_file_view_type * ecl_file_view = ecl_file_get_global_view( ecl_file_index );
-       fprintf(stderr, " *************************** %s: %d\n", __func__, ecl_file_view_get_size( ecl_file_view ) );
-       kw = ecl_file_view_iget_file_kw( ecl_file_view , 0 );
-       fprintf(stderr, " *************************** %s: ***%s***, size: %d, offset: %d\n", __func__, ecl_file_kw_get_header( kw ) , ecl_file_kw_get_size( kw) , ecl_file_kw_get_offset(kw)  );
-       
-       ecl_file_view_has_kw( ecl_file_index, "TEST1_KW" );
-       //end debug
+      test_assert_int_equal(ecl_file_size, ecl_file_get_size(ecl_file_index) );    
+  
+      test_assert_true( ecl_file_has_kw( ecl_file_index, "TEST1_KW" )  );
+      printf("***************************************************\n");
+      test_assert_true( ecl_file_has_kw( ecl_file_index, "TEST2_KW" )  );
+      kw = ecl_file_iget_kw( ecl_file_index , 0 );  
+      test_assert_double_equal( 537.0, ecl_kw_iget_as_double(kw, 0)  );
+      test_assert_double_equal( 546.0, ecl_kw_iget_as_double(kw, 9)  );
+      kw = ecl_file_iget_kw( ecl_file_index , 1 );
+      test_assert_double_equal( 0.15, ecl_kw_iget_as_double(kw, 1)  );
+      test_assert_double_equal( 0.60, ecl_kw_iget_as_double(kw, 4)  );     
 
-      //test_assert_true( ecl_file_has_kw( ecl_file_index, "TEST1_KW" )  );
-      
       ecl_file_close( ecl_file_index );
       
    }

--- a/lib/ecl/tests/test_ecl_file_index.c
+++ b/lib/ecl/tests/test_ecl_file_index.c
@@ -63,15 +63,16 @@ void test_create_and_load_index_file() {
       ecl_kw_fwrite(kw, fortio); 
       ecl_kw_free(kw);
 
-      //kw = ecl_kw_alloc("TEST2_KW", data_size, ECL_FLOAT);
+      fortio_fclose(fortio); 
+      //finished creating data file
 
-      fortio_fclose(fortio); //finished creating data file
-
+      //creating ecl_file
       ecl_file_type * ecl_file = ecl_file_open( file_name , 0 );
       test_assert_true( ecl_file_has_kw( ecl_file , "TEST1_KW" )  );
       ecl_file_write_index( ecl_file ,  file_name , index_file_name);
       int ecl_file_size = ecl_file_get_size( ecl_file );
-      ecl_file_close( ecl_file ); //finished using ecl_file
+      ecl_file_close( ecl_file ); 
+      //finished using ecl_file
 
       
       ecl_file_type * ecl_file_index = ecl_file_fast_open( file_name, index_file_name , 0);
@@ -83,11 +84,12 @@ void test_create_and_load_index_file() {
       
        //debug
        ecl_file_view_type * ecl_file_view = ecl_file_get_global_view( ecl_file_index );
-       printf(" *************************** %s: %d\n", __func__, ecl_file_view_get_size( ecl_file_view ) );
+       fprintf(stderr, " *************************** %s: %d\n", __func__, ecl_file_view_get_size( ecl_file_view ) );
        kw = ecl_file_view_iget_file_kw( ecl_file_view , 0 );
-       printf(" *************************** %s: ***%s***\n", __func__, ecl_file_kw_get_header( kw ));
-       //test_assert_true( ecl_file_view_has_kw( ecl_file_index, "TEST1_KW" )  );
-       //debug
+       fprintf(stderr, " *************************** %s: ***%s***, size: %d, offset: %d\n", __func__, ecl_file_kw_get_header( kw ) , ecl_file_kw_get_size( kw) , ecl_file_kw_get_offset(kw)  );
+       
+       ecl_file_view_has_kw( ecl_file_index, "TEST1_KW" );
+       //end debug
 
       //test_assert_true( ecl_file_has_kw( ecl_file_index, "TEST1_KW" )  );
       

--- a/lib/ecl/tests/test_ecl_file_index.c
+++ b/lib/ecl/tests/test_ecl_file_index.c
@@ -1,0 +1,23 @@
+/*
+   Copyright (C) 2017  Statoil ASA, Norway.
+
+   The file 'test_ecl_file_index.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+
+
+int main( int argc , char ** argv) {
+
+}

--- a/lib/ecl/tests/test_ecl_file_index.c
+++ b/lib/ecl/tests/test_ecl_file_index.c
@@ -32,22 +32,7 @@ void test_load_nonexisting_file() {
 
 
 void test_create_and_load_index_file() {
-   //X1: Start w/ just one kw
-   //X2: Expand to several kw 
 
-   //***1: create/get an ecl type file
-   //***2: use ecl_file_open to read from the file -> ecl_file_start
-   //3: store some values from the file, V1 ...  Vn
-   //4: use NEW function ecl_file_write_index to create an ecl_index file
-   //5: use NEW function ecl_file_fast_open to create a new ecl_file type -> ecl_file_end
-   //6: Use ecl_file_end to read from file and compare values to V1 ... Vn
-   //7: Remove from work area "initial_data_file", close/free variable ecl_file_start, ecl_file_end
-   //8: Create new initial_data_file
-   //9: Read index_file again w/ ecl_file_fast_open, assert return of NULL
-
-   
-
-   
    test_work_area_type * work_area = test_work_area_alloc("ecl_file_index_testing");
    {
       const char * file_name = "initial_data_file";
@@ -77,24 +62,26 @@ void test_create_and_load_index_file() {
       ecl_file_close( ecl_file ); 
       //finished using ecl_file
 
-      
+      test_assert_true( ecl_file_index_valid(file_name, index_file_name) );
+
       ecl_file_type * ecl_file_index = ecl_file_fast_open( file_name, index_file_name , 0);
       test_assert_true( ecl_file_is_instance(ecl_file_index)  );
-
-      //Add timestamp check
+      test_assert_true( ecl_file_get_global_view(ecl_file_index) );
 
       test_assert_int_equal(ecl_file_size, ecl_file_get_size(ecl_file_index) );    
   
       test_assert_true( ecl_file_has_kw( ecl_file_index, "TEST1_KW" )  );
       test_assert_true( ecl_file_has_kw( ecl_file_index, "TEST2_KW" )  );
+
       ecl_kw_type * kwi1 = ecl_file_iget_kw( ecl_file_index , 0 );  
       test_assert_true (ecl_kw_equal(kw1, kwi1));
-      test_assert_double_equal( 537.0, ecl_kw_iget_as_double(kw1, 0)  );
-      test_assert_double_equal( 546.0, ecl_kw_iget_as_double(kw1, 9)  );
+      test_assert_double_equal( 537.0, ecl_kw_iget_as_double(kwi1, 0)  );
+      test_assert_double_equal( 546.0, ecl_kw_iget_as_double(kwi1, 9)  );
+
       ecl_kw_type * kwi2 = ecl_file_iget_kw( ecl_file_index , 1 );
-      test_assert_true (ecl_kw_equal(kw1, kwi1));
-      test_assert_double_equal( 0.15, ecl_kw_iget_as_double(kw2, 1)  );
-      test_assert_double_equal( 0.60, ecl_kw_iget_as_double(kw2, 4)  );     
+      test_assert_true (ecl_kw_equal(kw2, kwi2));
+      test_assert_double_equal( 0.15, ecl_kw_iget_as_double(kwi2, 1)  );
+      test_assert_double_equal( 0.60, ecl_kw_iget_as_double(kwi2, 4)  );     
 
       ecl_kw_free(kw1);
       ecl_kw_free(kw2);

--- a/lib/ecl/tests/test_ecl_file_index.c
+++ b/lib/ecl/tests/test_ecl_file_index.c
@@ -55,19 +55,17 @@ void test_create_and_load_index_file() {
 
       //creating the data file
       size_t data_size = 10;
-      ecl_kw_type * kw = ecl_kw_alloc("TEST1_KW", data_size, ECL_INT);
+      ecl_kw_type * kw1 = ecl_kw_alloc("TEST1_KW", data_size, ECL_INT);
       for(int i = 0; i < data_size; ++i)
-         ecl_kw_iset_int(kw, i, 537 + i);
+         ecl_kw_iset_int(kw1, i, 537 + i);
       fortio_type * fortio = fortio_open_writer(file_name, false, ECL_ENDIAN_FLIP);
-      ecl_kw_fwrite(kw, fortio); 
-      ecl_kw_free(kw);
+      ecl_kw_fwrite(kw1, fortio); 
       
       data_size = 5;
-      kw = ecl_kw_alloc("TEST2_KW", data_size, ECL_FLOAT);
+      ecl_kw_type * kw2 = ecl_kw_alloc("TEST2_KW", data_size, ECL_FLOAT);
       for(int i = 0; i < data_size; ++i)
-         ecl_kw_iset_float(kw, i, 0.15 * i);
-      ecl_kw_fwrite(kw, fortio);
-      ecl_kw_free(kw);
+         ecl_kw_iset_float(kw2, i, 0.15 * i);
+      ecl_kw_fwrite(kw2, fortio);
       fortio_fclose(fortio); 
       //finished creating data file
 
@@ -88,15 +86,18 @@ void test_create_and_load_index_file() {
       test_assert_int_equal(ecl_file_size, ecl_file_get_size(ecl_file_index) );    
   
       test_assert_true( ecl_file_has_kw( ecl_file_index, "TEST1_KW" )  );
-      printf("***************************************************\n");
       test_assert_true( ecl_file_has_kw( ecl_file_index, "TEST2_KW" )  );
-      kw = ecl_file_iget_kw( ecl_file_index , 0 );  
-      test_assert_double_equal( 537.0, ecl_kw_iget_as_double(kw, 0)  );
-      test_assert_double_equal( 546.0, ecl_kw_iget_as_double(kw, 9)  );
-      kw = ecl_file_iget_kw( ecl_file_index , 1 );
-      test_assert_double_equal( 0.15, ecl_kw_iget_as_double(kw, 1)  );
-      test_assert_double_equal( 0.60, ecl_kw_iget_as_double(kw, 4)  );     
+      ecl_kw_type * kwi1 = ecl_file_iget_kw( ecl_file_index , 0 );  
+      test_assert_true (ecl_kw_equal(kw1, kwi1));
+      test_assert_double_equal( 537.0, ecl_kw_iget_as_double(kw1, 0)  );
+      test_assert_double_equal( 546.0, ecl_kw_iget_as_double(kw1, 9)  );
+      ecl_kw_type * kwi2 = ecl_file_iget_kw( ecl_file_index , 1 );
+      test_assert_true (ecl_kw_equal(kw1, kwi1));
+      test_assert_double_equal( 0.15, ecl_kw_iget_as_double(kw2, 1)  );
+      test_assert_double_equal( 0.60, ecl_kw_iget_as_double(kw2, 4)  );     
 
+      ecl_kw_free(kw1);
+      ecl_kw_free(kw2);
       ecl_file_close( ecl_file_index );
       
    }

--- a/lib/ecl/tests/test_ecl_file_index.c
+++ b/lib/ecl/tests/test_ecl_file_index.c
@@ -57,7 +57,7 @@ void test_create_and_load_index_file() {
       //creating ecl_file
       ecl_file_type * ecl_file = ecl_file_open( file_name , 0 );
       test_assert_true( ecl_file_has_kw( ecl_file , "TEST1_KW" )  );
-      ecl_file_write_index( ecl_file ,  file_name , index_file_name);
+      ecl_file_write_index( ecl_file , index_file_name);
       int ecl_file_size = ecl_file_get_size( ecl_file );
       ecl_file_close( ecl_file ); 
       //finished using ecl_file

--- a/lib/ecl/tests/test_ecl_file_index.c
+++ b/lib/ecl/tests/test_ecl_file_index.c
@@ -17,6 +17,7 @@
 */
 
 #include <stdio.h>
+#include <utime.h>
 
 #include <ert/util/test_util.h>
 #include <ert/util/util.h>
@@ -35,8 +36,8 @@ void test_create_and_load_index_file() {
 
    test_work_area_type * work_area = test_work_area_alloc("ecl_file_index_testing");
    {
-      const char * file_name = "initial_data_file";
-      const char * index_file_name = "index_file";
+      char * file_name = "initial_data_file";
+      char * index_file_name = "index_file";
 
       //creating the data file
       size_t data_size = 10;
@@ -62,6 +63,16 @@ void test_create_and_load_index_file() {
       ecl_file_close( ecl_file ); 
       //finished using ecl_file
 
+      test_assert_false( ecl_file_index_valid(file_name, "nofile"));
+      test_assert_false( ecl_file_index_valid("nofile", index_file_name));
+
+      struct utimbuf tm1 = {1 , 1};
+      struct utimbuf tm2 = {2 , 2};
+      utime(file_name, &tm2);
+      utime(index_file_name, &tm1);
+      test_assert_false( ecl_file_index_valid(file_name, index_file_name) );
+      utime(file_name, &tm1);
+      utime(index_file_name, &tm2);
       test_assert_true( ecl_file_index_valid(file_name, index_file_name) );
 
       ecl_file_type * ecl_file_index = ecl_file_fast_open( file_name, index_file_name , 0);
@@ -86,7 +97,6 @@ void test_create_and_load_index_file() {
       ecl_kw_free(kw1);
       ecl_kw_free(kw2);
       ecl_file_close( ecl_file_index );
-      
    }
    test_work_area_free( work_area );
 }

--- a/lib/ecl/tests/test_ecl_file_index.c
+++ b/lib/ecl/tests/test_ecl_file_index.c
@@ -48,27 +48,34 @@ void test_create_and_load_index_file() {
    //CREATING THE DATA FILE
    test_work_area_type * work_area = test_work_area_alloc("ecl_file_index_testing");
    {
-      const char * data_file_name = "initial_data_file";
+      const char * file_name = "initial_data_file";
+      const char * index_file_name = "index_file";
 
       size_t data_size = 10;
       ecl_kw_type * kw = ecl_kw_alloc("TEST_KW", data_size, ECL_INT);
       for(int i = 0; i < data_size; ++i)
          ecl_kw_iset_int(kw, i, 537 + i);
 
-      fortio_type * fortio = fortio_open_writer(data_file_name, false, ECL_ENDIAN_FLIP);
+      fortio_type * fortio = fortio_open_writer(file_name, false, ECL_ENDIAN_FLIP);
       ecl_kw_fwrite(kw, fortio); 
       ecl_kw_free(kw);
 
       fortio_fclose(fortio);
 
-      ecl_file_type * ecl_file = ecl_file_open( "initial_data_file" , 0 );
+      ecl_file_type * ecl_file = ecl_file_open( file_name , 0 );
       test_assert_true( ecl_file_has_kw( ecl_file , "TEST_KW" )  );
 
 
-      ecl_file_write_index( ecl_file , "initial_data_file" , "index_data_file");
+      ecl_file_write_index( ecl_file ,  file_name , index_file_name);
 
       
+      ecl_file_type * ecl_file_index = ecl_file_fast_open( file_name, index_file_name );
+      test_assert_true( ecl_file_is_instance(ecl_file_index)  );
 
+      //Add timestamp check
+
+      //test_assert_int_equal(ecl_file_get_size(ecl_file), ecl_file_get_size(ecl_file_index) );
+      
 
       ecl_file_close( ecl_file );
    }

--- a/lib/ecl/tests/test_ecl_file_index.c
+++ b/lib/ecl/tests/test_ecl_file_index.c
@@ -26,7 +26,7 @@
 #include <ert/ecl/ecl_file.h>
 
 void test_load_nonexisting_file() {
-   ecl_file_type * ecl_file = ecl_file_fast_open("base_file", "a_file_that_does_not_exist_2384623");
+   ecl_file_type * ecl_file = ecl_file_fast_open("base_file", "a_file_that_does_not_exist_2384623", 0);
    test_assert_NULL( ecl_file );
 }
 
@@ -45,14 +45,17 @@ void test_create_and_load_index_file() {
    //8: Create new initial_data_file
    //9: Read index_file again w/ ecl_file_fast_open, assert return of NULL
 
-   //CREATING THE DATA FILE
+   
+
+   
    test_work_area_type * work_area = test_work_area_alloc("ecl_file_index_testing");
    {
       const char * file_name = "initial_data_file";
       const char * index_file_name = "index_file";
 
+      //creating the data file
       size_t data_size = 10;
-      ecl_kw_type * kw = ecl_kw_alloc("TEST_KW", data_size, ECL_INT);
+      ecl_kw_type * kw = ecl_kw_alloc("TEST1_KW", data_size, ECL_INT);
       for(int i = 0; i < data_size; ++i)
          ecl_kw_iset_int(kw, i, 537 + i);
 
@@ -60,24 +63,36 @@ void test_create_and_load_index_file() {
       ecl_kw_fwrite(kw, fortio); 
       ecl_kw_free(kw);
 
-      fortio_fclose(fortio);
+      //kw = ecl_kw_alloc("TEST2_KW", data_size, ECL_FLOAT);
+
+      fortio_fclose(fortio); //finished creating data file
 
       ecl_file_type * ecl_file = ecl_file_open( file_name , 0 );
-      test_assert_true( ecl_file_has_kw( ecl_file , "TEST_KW" )  );
-
-
+      test_assert_true( ecl_file_has_kw( ecl_file , "TEST1_KW" )  );
       ecl_file_write_index( ecl_file ,  file_name , index_file_name);
+      int ecl_file_size = ecl_file_get_size( ecl_file );
+      ecl_file_close( ecl_file ); //finished using ecl_file
 
       
-      ecl_file_type * ecl_file_index = ecl_file_fast_open( file_name, index_file_name );
+      ecl_file_type * ecl_file_index = ecl_file_fast_open( file_name, index_file_name , 0);
       test_assert_true( ecl_file_is_instance(ecl_file_index)  );
 
       //Add timestamp check
 
-      //test_assert_int_equal(ecl_file_get_size(ecl_file), ecl_file_get_size(ecl_file_index) );
+      test_assert_int_equal(ecl_file_size, ecl_file_get_size(ecl_file_index) );
       
+       //debug
+       ecl_file_view_type * ecl_file_view = ecl_file_get_global_view( ecl_file_index );
+       printf(" *************************** %s: %d\n", __func__, ecl_file_view_get_size( ecl_file_view ) );
+       kw = ecl_file_view_iget_file_kw( ecl_file_view , 0 );
+       printf(" *************************** %s: ***%s***\n", __func__, ecl_file_kw_get_header( kw ));
+       //test_assert_true( ecl_file_view_has_kw( ecl_file_index, "TEST1_KW" )  );
+       //debug
 
-      ecl_file_close( ecl_file );
+      //test_assert_true( ecl_file_has_kw( ecl_file_index, "TEST1_KW" )  );
+      
+      ecl_file_close( ecl_file_index );
+      
    }
    test_work_area_free( work_area );
 }

--- a/lib/include/ert/ecl/ecl_file.h
+++ b/lib/include/ert/ecl/ecl_file.h
@@ -48,7 +48,7 @@ extern "C" {
   bool             ecl_file_load_all( ecl_file_type * ecl_file );
   ecl_file_type  * ecl_file_open( const char * filename , int flags);
   ecl_file_type  * ecl_file_fast_open( const char * filename , const char * index_filename , int flags);
-  void             ecl_file_write_index( ecl_file_type * ecl_file , const char * filename , const char * index_filename);
+  void             ecl_file_write_index( const ecl_file_type * ecl_file , const char * index_filename);
   bool             ecl_file_index_valid(const char * file_name, const char * index_file_name);
   void             ecl_file_close( ecl_file_type * ecl_file );
   void             ecl_file_fortio_detach( ecl_file_type * ecl_file );

--- a/lib/include/ert/ecl/ecl_file.h
+++ b/lib/include/ert/ecl/ecl_file.h
@@ -47,7 +47,7 @@ extern "C" {
   typedef struct ecl_file_struct ecl_file_type;
   bool             ecl_file_load_all( ecl_file_type * ecl_file );
   ecl_file_type  * ecl_file_open( const char * filename , int flags);
-  ecl_file_type  * ecl_file_fast_open( const char * filename , const char * index_filename);
+  ecl_file_type  * ecl_file_fast_open( const char * filename , const char * index_filename , int flags);
   void             ecl_file_write_index( ecl_file_type * ecl_file , const char * filename , const char * index_filename);
   void             ecl_file_close( ecl_file_type * ecl_file );
   void             ecl_file_fortio_detach( ecl_file_type * ecl_file );

--- a/lib/include/ert/ecl/ecl_file.h
+++ b/lib/include/ert/ecl/ecl_file.h
@@ -47,6 +47,8 @@ extern "C" {
   typedef struct ecl_file_struct ecl_file_type;
   bool             ecl_file_load_all( ecl_file_type * ecl_file );
   ecl_file_type  * ecl_file_open( const char * filename , int flags);
+  ecl_file_type  * ecl_file_fast_open( const char * filename , const char * index_filename);
+  void             ecl_file_write_index( ecl_file_type * ecl_file , const char * filename , const char * index_filename);
   void             ecl_file_close( ecl_file_type * ecl_file );
   void             ecl_file_fortio_detach( ecl_file_type * ecl_file );
   void             ecl_file_free__(void * arg);

--- a/lib/include/ert/ecl/ecl_file.h
+++ b/lib/include/ert/ecl/ecl_file.h
@@ -49,6 +49,7 @@ extern "C" {
   ecl_file_type  * ecl_file_open( const char * filename , int flags);
   ecl_file_type  * ecl_file_fast_open( const char * filename , const char * index_filename , int flags);
   void             ecl_file_write_index( ecl_file_type * ecl_file , const char * filename , const char * index_filename);
+  bool             ecl_file_index_valid(const char * file_name, const char * index_file_name);
   void             ecl_file_close( ecl_file_type * ecl_file );
   void             ecl_file_fortio_detach( ecl_file_type * ecl_file );
   void             ecl_file_free__(void * arg);

--- a/lib/include/ert/ecl/ecl_file_kw.h
+++ b/lib/include/ert/ecl/ecl_file_kw.h
@@ -53,6 +53,7 @@ typedef struct inv_map_struct inv_map_type;
   bool               ecl_file_kw_fskip_data( const ecl_file_kw_type * file_kw , fortio_type * fortio);
   void               ecl_file_kw_inplace_fwrite( ecl_file_kw_type * file_kw , fortio_type * fortio);
 
+  size_t              ecl_file_kw_get_buffer_size();
   void                ecl_file_kw_fwrite( const ecl_file_kw_type * file_kw , FILE * stream );
   ecl_file_kw_type ** ecl_file_kw_fread_alloc_multiple( FILE * stream , int num);
   ecl_file_kw_type *  ecl_file_kw_fread_alloc( FILE * stream );

--- a/lib/include/ert/ecl/ecl_file_kw.h
+++ b/lib/include/ert/ecl/ecl_file_kw.h
@@ -52,6 +52,10 @@ typedef struct inv_map_struct inv_map_type;
   void               ecl_file_kw_replace_kw( ecl_file_kw_type * file_kw , fortio_type * target , ecl_kw_type * new_kw );
   bool               ecl_file_kw_fskip_data( const ecl_file_kw_type * file_kw , fortio_type * fortio);
   void               ecl_file_kw_inplace_fwrite( ecl_file_kw_type * file_kw , fortio_type * fortio);
+
+  void                ecl_file_kw_fwrite( const ecl_file_kw_type * file_kw , FILE * stream );
+  ecl_file_kw_type ** ecl_file_kw_fread_alloc_multiple( FILE * stream , int num);
+  ecl_file_kw_type *  ecl_file_kw_fread_alloc( FILE * stream );
  
 #ifdef __cplusplus
 }

--- a/lib/include/ert/ecl/ecl_file_kw.h
+++ b/lib/include/ert/ecl/ecl_file_kw.h
@@ -53,7 +53,6 @@ typedef struct inv_map_struct inv_map_type;
   bool               ecl_file_kw_fskip_data( const ecl_file_kw_type * file_kw , fortio_type * fortio);
   void               ecl_file_kw_inplace_fwrite( ecl_file_kw_type * file_kw , fortio_type * fortio);
 
-  size_t              ecl_file_kw_get_buffer_size();
   void                ecl_file_kw_fwrite( const ecl_file_kw_type * file_kw , FILE * stream );
   ecl_file_kw_type ** ecl_file_kw_fread_alloc_multiple( FILE * stream , int num);
   ecl_file_kw_type *  ecl_file_kw_fread_alloc( FILE * stream );

--- a/lib/include/ert/ecl/ecl_file_kw.h
+++ b/lib/include/ert/ecl/ecl_file_kw.h
@@ -36,8 +36,9 @@ typedef struct inv_map_struct inv_map_type;
   inv_map_type     * inv_map_alloc(void);
   ecl_file_kw_type * inv_map_get_file_kw( inv_map_type * inv_map , const ecl_kw_type * ecl_kw );
   void               inv_map_free( inv_map_type * map );
-
+  bool               ecl_file_kw_equal( const ecl_file_kw_type * kw1 , const ecl_file_kw_type * kw2);
   ecl_file_kw_type * ecl_file_kw_alloc( const ecl_kw_type * ecl_kw , offset_type offset);
+  ecl_file_kw_type * ecl_file_kw_alloc0( const char * header , ecl_data_type data_type , int size , offset_type offset);
   void               ecl_file_kw_free( ecl_file_kw_type * file_kw );
   void               ecl_file_kw_free__( void * arg );
   ecl_kw_type      * ecl_file_kw_get_kw( ecl_file_kw_type * file_kw , fortio_type * fortio, inv_map_type * inv_map);

--- a/lib/include/ert/ecl/ecl_file_view.h
+++ b/lib/include/ert/ecl/ecl_file_view.h
@@ -100,6 +100,8 @@ typedef struct ecl_file_view_struct ecl_file_view_type;
   const char *         ecl_file_view_get_src_file( const ecl_file_view_type * file_view );
   void                 ecl_file_view_fclose_stream( ecl_file_view_type * file_view );
 
+  void                 ecl_file_view_write_index(ecl_file_view_type * file_view, FILE * ostream);
+  ecl_file_view_type * ecl_file_view_fread_alloc( fortio_type * fortio , int * flags , inv_map_type * inv_map, FILE * istream );
 
 #ifdef __cplusplus
 }

--- a/lib/include/ert/ecl/ecl_file_view.h
+++ b/lib/include/ert/ecl/ecl_file_view.h
@@ -100,7 +100,7 @@ typedef struct ecl_file_view_struct ecl_file_view_type;
   const char *         ecl_file_view_get_src_file( const ecl_file_view_type * file_view );
   void                 ecl_file_view_fclose_stream( ecl_file_view_type * file_view );
 
-  void                 ecl_file_view_write_index(ecl_file_view_type * file_view, FILE * ostream);
+  void                 ecl_file_view_write_index(const ecl_file_view_type * file_view, const char * filename, FILE * ostream);
   ecl_file_view_type * ecl_file_view_fread_alloc( fortio_type * fortio , int * flags , inv_map_type * inv_map, FILE * istream );
 
 #ifdef __cplusplus

--- a/lib/include/ert/ecl/ecl_file_view.h
+++ b/lib/include/ert/ecl/ecl_file_view.h
@@ -100,7 +100,7 @@ typedef struct ecl_file_view_struct ecl_file_view_type;
   const char *         ecl_file_view_get_src_file( const ecl_file_view_type * file_view );
   void                 ecl_file_view_fclose_stream( ecl_file_view_type * file_view );
 
-  void                 ecl_file_view_write_index(const ecl_file_view_type * file_view, const char * filename, FILE * ostream);
+  void                 ecl_file_view_write_index(const ecl_file_view_type * file_view, FILE * ostream);
   ecl_file_view_type * ecl_file_view_fread_alloc( fortio_type * fortio , int * flags , inv_map_type * inv_map, FILE * istream );
 
 #ifdef __cplusplus

--- a/lib/include/ert/util/util.h
+++ b/lib/include/ert/util/util.h
@@ -349,6 +349,8 @@ typedef enum {left_pad   = 0,
   long     util_fread_long(FILE * );
   bool     util_fread_bool(FILE * );
   double   util_fread_double(FILE * stream);
+  void     util_fwrite_offset(offset_type    , FILE * );
+  void     util_fwrite_size_t (size_t    , FILE * );
   void     util_fwrite_int   (int    , FILE * );
   void     util_fwrite_long  (long    , FILE * );
   void     util_fwrite_bool  (bool    , FILE * );

--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -4259,19 +4259,12 @@ void util_double_to_float(float *float_ptr , const double *double_ptr , int size
    The util_fwrite_string / util_fread_string are BROKEN when it comes
    to NULL / versus an empty string "":
 
-    1. Writing a "" string what is actually written to disk is: "0\0",
-       whereas the disk content when writing NULL is "0".
+    1. When writing 'NULL' to disk what is actually found on the disk
+       is the sequence "0".
 
-    2. When reading back we find the '0' - but it is impossible to
-       determine whether we should interpret this as a NULL or as "".
-
-   When the harm was done, with files allover the place, it is "solved"
-   as follows:
-
-    1. Nothing is changed when writing NULL => '0' to disk.
-
-    2. When writing "" => '-1\0' to disk. The -1 is the magic length
-       signifying that the following string is "".
+    2. When writing the empty string - i.e. "" - what hits the disk is
+       the sequence "-1\0"; i.e. the -1 is used as a magic flag to
+       indicate the empty string.
 */
 
 

--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -4326,10 +4326,11 @@ void util_fskip_string(FILE *stream) {
 }
 
 
-
+void util_fwrite_offset( offset_type value , FILE * stream ) { UTIL_FWRITE_SCALAR(value , stream); }
 void util_fwrite_bool     (bool value , FILE * stream)   { UTIL_FWRITE_SCALAR(value , stream); }
 void util_fwrite_int      (int value , FILE * stream)    { UTIL_FWRITE_SCALAR(value , stream); }
 void util_fwrite_time_t   (time_t value , FILE * stream)    { UTIL_FWRITE_SCALAR(value , stream); }
+void util_fwrite_size_t   (size_t value , FILE * stream)    { UTIL_FWRITE_SCALAR(value , stream); }
 void util_fwrite_long  (long value , FILE * stream)    { UTIL_FWRITE_SCALAR(value , stream); }
 void util_fwrite_double(double value , FILE * stream) { UTIL_FWRITE_SCALAR(value , stream); }
 

--- a/python/python/ecl/ecl/ecl_file.py
+++ b/python/python/ecl/ecl/ecl_file.py
@@ -62,6 +62,8 @@ class EclFile(BaseCClass):
     _has_report_step             = EclPrototype("bool        ecl_file_has_report_step( ecl_file , int)")
     _has_sim_time                = EclPrototype("bool        ecl_file_has_sim_time( ecl_file , time_t )")
     _get_global_view             = EclPrototype("ecl_file_view_ref ecl_file_get_global_view( ecl_file )")
+    _write_index                 = EclPrototype("void        ecl_file_write_index( ecl_file , char*)")
+    _fast_open                   = EclPrototype("void*       ecl_file_fast_open( char* , char* , int )" , bind=False)
 
 
     @staticmethod
@@ -178,7 +180,7 @@ class EclFile(BaseCClass):
         return self._create_repr('"%s"%s' % (fn,wr))
 
 
-    def __init__( self , filename , flags = 0):
+    def __init__( self , filename , flags = 0 , index_filename = None):
         """
         Loads the complete file @filename.
 
@@ -202,7 +204,10 @@ class EclFile(BaseCClass):
         constituting the file, like e.g. SWAT from a restart file or
         FIPNUM from an INIT file.
         """
-        c_ptr = self._open( filename , flags )
+        if index_filename is None:
+            c_ptr = self._open( filename , flags )
+        else:
+            c_ptr = self._fast_open(filename, index_filename, flags)
         if c_ptr is None:
             raise IOError('Failed to open file "%s"' % filename)
         else:
@@ -677,6 +682,9 @@ class EclFile(BaseCClass):
 
         """
         self._fwrite(  fortio , 0 )
+
+    def write_index(self, index_file_name):
+        self._write_index(index_file_name)
 
 
 class EclFileContextManager(object):

--- a/python/tests/ecl/test_ecl_file.py
+++ b/python/tests/ecl/test_ecl_file.py
@@ -79,6 +79,23 @@ class EclFileTest(ExtendedTestCase):
                 self.assertTrue( ecl_file.has_kw("KW2"))
                 self.assertEqual(ecl_file[1], ecl_file[-1])
 
+    def test_ecl_index(self):
+        with TestAreaContext("python/ecl_file/context"):
+            kw1 = EclKW( "KW1" , 100 , EclDataType.ECL_INT)
+            kw2 = EclKW( "KW2" , 100 , EclDataType.ECL_FLOAT)
+            with openFortIO("TEST" , mode = FortIO.WRITE_MODE) as f:
+                kw1.fwrite( f )
+                kw2.fwrite( f )
+
+            ecl_file = EclFile("TEST")
+            ecl_file.write_index("INDEX_FILE")
+            ecl_file.close()
+
+            ecl_file_index = EclFile("TEST", 0, "INDEX_FILE")
+            self.assertTrue( ecl_file_index.has_kw("KW1") )
+            self.assertTrue( ecl_file_index.has_kw("KW2") )
+            
+
     def test_save_kw(self):
         with TestAreaContext("python/ecl_file/save_kw"):
             data = range(1000)


### PR DESCRIPTION
Task
When loading an ECLIPSE binary we start by seeking through the whole file and building an index. In the case of very large ( ~ 500GB ) this takes prohibitively long time, and the task is to create a on-disk cache of the index. This is mainly for Resinsight.

Approach
Added functions to dump an index, and to open a file from an on-disk index.

Pre un-WIP checklist

 Statoil tests pass locally