### PR TITLE
Make util compilable with C++

### DIFF
--- a/lib/include/ert/util/matrix_stat.h
+++ b/lib/include/ert/util/matrix_stat.h
@@ -22,6 +22,10 @@
 
 #include <ert/util/matrix.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif //__cplusplus
+
 typedef enum {
   LLSQ_SUCCESS = 0,
   LLSQ_INVALID_DIM = 1,
@@ -32,5 +36,8 @@ typedef enum {
 llsq_result_enum matrix_stat_llsq_estimate( matrix_type * beta , const matrix_type * X , const matrix_type * Y , const matrix_type * S);
 llsq_result_enum matrix_stat_polyfit( matrix_type * beta , const matrix_type * X0 , const matrix_type * Y0 , const matrix_type * S);
 
+#ifdef __cplusplus
+}
+#endif //__cplusplus
 
 #endif

--- a/lib/include/ert/util/menu.h
+++ b/lib/include/ert/util/menu.h
@@ -19,6 +19,10 @@
 #ifndef ERT_MENU_H
 #define ERT_MENU_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif //__cplusplus
+
 typedef struct menu_struct menu_type;
 typedef struct menu_item_struct menu_item_type;
 
@@ -39,5 +43,9 @@ void             menu_item_set_label( menu_item_type * , const char *);
 void             menu_item_disable( menu_item_type * item );
 void             menu_item_enable( menu_item_type * item );
 void             menu_add_helptext(menu_type * menu, const char * label );
+
+#ifdef __cplusplus
+}
+#endif //__cplusplus
 
 #endif

--- a/lib/include/ert/util/node_data.h
+++ b/lib/include/ert/util/node_data.h
@@ -18,10 +18,12 @@
 
 #ifndef ERT_NODE_DATA_H
 #define ERT_NODE_DATA_H
+
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-#include <stdbool.h>
 
 typedef void       * (  copyc_ftype ) (const void *);
 typedef void         (  free_ftype )  (void *);

--- a/lib/include/ert/util/parser.h
+++ b/lib/include/ert/util/parser.h
@@ -20,6 +20,10 @@
 #define ERT_PARSER_H
 #include <ert/util/stringlist.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
 typedef struct basic_parser_struct basic_parser_type;
 
 
@@ -156,4 +160,9 @@ stringlist_type * basic_parser_tokenize_file(
 void   basic_parser_strip_buffer(const basic_parser_type * parser , char ** __buffer);
 bool   basic_parser_fseek_string(const basic_parser_type * parser , FILE * stream , const char * string , bool skip_string , bool case_sensitive);
 char * basic_parser_fread_alloc_file_content(const char * filename , const char * quote_set , const char * delete_set , const char * comment_start , const char * comment_end);
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
 #endif
+

--- a/lib/include/ert/util/path_fmt.h
+++ b/lib/include/ert/util/path_fmt.h
@@ -18,13 +18,15 @@
 
 #ifndef ERT_PATH_FMT_H
 #define ERT_PATH_FMT_H
-#ifdef __cplusplus
-extern "C" {
-#endif
+
 #include <stdarg.h>
 #include <stdbool.h>
 
 #include <ert/util/node_ctype.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
   typedef struct path_fmt_struct path_fmt_type;
   

--- a/lib/include/ert/util/perm_vector.h
+++ b/lib/include/ert/util/perm_vector.h
@@ -21,6 +21,10 @@
 
 #include <ert/util/type_macros.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif //__cplusplus
+
 typedef struct perm_vector_struct perm_vector_type;
 
 perm_vector_type * perm_vector_alloc( int * perm_input , int size );
@@ -28,4 +32,9 @@ void               perm_vector_free( perm_vector_type * perm_vector );
 int                perm_vector_get_size( const perm_vector_type * perm);
 int                perm_vector_iget( const perm_vector_type * perm, int index);
 
+#ifdef __cplusplus
+}
+#endif //__cplusplus
+
 #endif
+

--- a/lib/include/ert/util/regression.h
+++ b/lib/include/ert/util/regression.h
@@ -19,13 +19,11 @@
 #ifndef ERT_REGRESSION_H
 #define ERT_REGRESSION_H
 
+#include <ert/util/matrix.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <ert/util/matrix.h>
-
-
 double  regression_scale( matrix_type * X ,  matrix_type * Y , matrix_type * X_mean , matrix_type * X_norm);
 double  regression_unscale(const matrix_type * beta , const matrix_type * X_norm , const matrix_type * X_mean , double Y_mean , matrix_type * beta0);
 void    regression_augmented_OLS(const matrix_type * X , const matrix_type * Y , const matrix_type *E, matrix_type * beta);

--- a/lib/include/ert/util/string_util.h
+++ b/lib/include/ert/util/string_util.h
@@ -18,11 +18,12 @@
 #ifndef ERT_STRING_UTIL_H
 #define ERT_STRING_UTIL_H
 
+#include <ert/util/int_vector.h>
+#include <ert/util/bool_vector.h>
+
 #ifdef __cplusplus 
 extern "C" {
 #endif
-#include <ert/util/int_vector.h>
-#include <ert/util/bool_vector.h>
 
   bool               string_util_init_active_list( const char * range_string , int_vector_type * active_list );
   bool               string_util_update_active_list( const char * range_string , int_vector_type * active_list );

--- a/lib/include/ert/util/stringlist.h
+++ b/lib/include/ert/util/stringlist.h
@@ -18,9 +18,6 @@
 
 #ifndef ERT_STRINGLIST_H
 #define ERT_STRINGLIST_H
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <stdbool.h>
 #include <stdio.h>
@@ -29,6 +26,11 @@ extern "C" {
 #include <ert/util/type_macros.h>
 #include <ert/util/int_vector.h>
 #include <ert/util/buffer.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 
 typedef struct stringlist_struct stringlist_type;
 typedef int  ( string_cmp_ftype)  (const void * , const void *);

--- a/lib/include/ert/util/type_vector_functions.h
+++ b/lib/include/ert/util/type_vector_functions.h
@@ -18,12 +18,13 @@
 #ifndef ERT_TYPE_VECTOR_FUNCTIONS_H
 #define ERT_TYPE_VECTOR_FUNCTIONS_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 #include <ert/util/int_vector.h>
 #include <ert/util/bool_vector.h>
 #include <ert/util/double_vector.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
   int_vector_type  * bool_vector_alloc_active_list( const bool_vector_type * mask );
   bool_vector_type * int_vector_alloc_mask( const int_vector_type * active_list );

--- a/lib/include/ert/util/ui_return.h
+++ b/lib/include/ert/util/ui_return.h
@@ -19,13 +19,13 @@
 #ifndef ERT_UI_RETURN_H
 #define ERT_UI_RETURN_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdbool.h>
 
 #include <ert/util/type_macros.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct ui_return_struct ui_return_type;
 

--- a/lib/include/ert/util/vector.h
+++ b/lib/include/ert/util/vector.h
@@ -19,12 +19,13 @@
 #ifndef ERT_VECTOR_H
 #define ERT_VECTOR_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 #include <ert/util/node_data.h>
 #include <ert/util/type_macros.h>
 #include <ert/util/int_vector.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
   typedef void ( vector_func_type ) (void * , void *);
   typedef int  ( vector_cmp_ftype)  (const void * , const void *);

--- a/lib/util/arg_pack.c
+++ b/lib/util/arg_pack.c
@@ -112,7 +112,7 @@ struct arg_pack_struct {
 /* First comes the arg_node functions. These are all fully static.*/
 
 static arg_node_type * arg_node_alloc_empty() {
-  arg_node_type * node = util_malloc( sizeof * node );
+  arg_node_type * node = (arg_node_type*)util_malloc( sizeof * node );
   node->buffer      = NULL;
   node->destructor  = NULL;
   node->ctype       = CTYPE_INVALID;
@@ -344,7 +344,7 @@ static void __arg_pack_assert_index(const arg_pack_type * arg , int iarg) {
 
 
 static void arg_pack_realloc_nodes(arg_pack_type * arg_pack , int new_size) {
-  arg_pack->nodes      = util_realloc(arg_pack->nodes , new_size * sizeof * arg_pack->nodes );
+  arg_pack->nodes      = (arg_node_type**) util_realloc(arg_pack->nodes , new_size * sizeof * arg_pack->nodes );
   {
     int i;
     for (i = arg_pack->alloc_size; i < new_size; i++)
@@ -400,7 +400,7 @@ void arg_pack_lock(arg_pack_type * arg_pack) {
 
 
 arg_pack_type * arg_pack_alloc() {
-  arg_pack_type * arg_pack = util_malloc(sizeof * arg_pack );
+  arg_pack_type * arg_pack = (arg_pack_type*)util_malloc(sizeof * arg_pack );
   UTIL_TYPE_ID_INIT( arg_pack , ARG_PACK_TYPE_ID);
   arg_pack->nodes      = NULL;
   arg_pack->alloc_size = 0;

--- a/lib/util/buffer.c
+++ b/lib/util/buffer.c
@@ -85,12 +85,12 @@ UTIL_SAFE_CAST_FUNCTION( buffer , BUFFER_TYPE_ID )
 
 static void buffer_resize__(buffer_type * buffer , size_t new_size, bool abort_on_error) {
   if (abort_on_error) {
-    buffer->data       = util_realloc(buffer->data , new_size );
+    buffer->data       = (char*)util_realloc(buffer->data , new_size );
     buffer->alloc_size = new_size;
   } else {
     void * tmp   = realloc(buffer->data , new_size);
     if (tmp != NULL) {
-      buffer->data = tmp;
+      buffer->data = (char*)tmp;
       buffer->alloc_size = new_size;
     }
   }
@@ -100,7 +100,7 @@ static void buffer_resize__(buffer_type * buffer , size_t new_size, bool abort_o
 
 
 static buffer_type * buffer_alloc_empty( ) {
-  buffer_type * buffer = util_malloc( sizeof * buffer );
+  buffer_type * buffer = (buffer_type*)util_malloc( sizeof * buffer );
   UTIL_TYPE_ID_INIT( buffer , BUFFER_TYPE_ID );
   buffer->data = NULL;
 
@@ -142,7 +142,7 @@ void buffer_shrink_to_fit( buffer_type * buffer ) {
 buffer_type * buffer_alloc_private_wrapper(void * data , size_t buffer_size ) {
   buffer_type * buffer = buffer_alloc_empty();
 
-  buffer->data         = data;        /* We have stolen the data pointer. */
+  buffer->data         = (char*)data;        /* We have stolen the data pointer. */
   buffer->content_size = buffer_size;
   buffer->pos          = buffer_size;
   buffer->alloc_size   = buffer_size;
@@ -869,7 +869,7 @@ size_t buffer_fread_compressed(buffer_type * buffer , size_t compressed_size , v
 
 
     if (compressed_size > 0) {
-        int uncompress_result = uncompress(target_ptr , &uncompressed_size , (unsigned char *) &buffer->data[buffer->pos] , compressed_size);
+        int uncompress_result = uncompress((Bytef*)target_ptr , &uncompressed_size , (unsigned char *) &buffer->data[buffer->pos] , compressed_size);
         if (uncompress_result != Z_OK) {
             fprintf(stderr,"%s: ** Warning uncompress result:%d != Z_OK.\n" , __func__ , uncompress_result);
             /**

--- a/lib/util/hash.c
+++ b/lib/util/hash.c
@@ -159,14 +159,14 @@ static void * __hash_get_node(const hash_type *hash_in , const char *key, bool a
   hash_node_type * node;
   hash_type * hash = (hash_type *)hash_in;
   __hash_rdlock( hash );
-  node = __hash_get_node_unlocked(hash , key , abort_on_error);
+  node = (hash_node_type*)__hash_get_node_unlocked(hash , key , abort_on_error);
   __hash_unlock( hash );
   return node;
 }
 
 
 static node_data_type * hash_get_node_data(const hash_type *hash , const char *key) {
-  hash_node_type * node = __hash_get_node(hash , key , true);
+  hash_node_type * node = (hash_node_type*)__hash_get_node(hash , key , true);
   return hash_node_get_data(node);
 }
 
@@ -229,7 +229,7 @@ static void __hash_insert_node(hash_type *hash , hash_node_type *node) {
         If a node with the same key already exists in the table
         it is removed.
       */
-      hash_node_type *existing_node = __hash_get_node_unlocked(hash , hash_node_get_key(node) , false);
+      hash_node_type *existing_node = (hash_node_type*)__hash_get_node_unlocked(hash , hash_node_get_key(node) , false);
       if (existing_node != NULL) {
         hash_sll_del_node(hash->table[table_index] , existing_node);
         hash->elements--;
@@ -312,7 +312,7 @@ static char ** hash_alloc_keylist__(hash_type *hash , bool lock) {
     if (hash->elements > 0) {
       int i = 0;
       hash_node_type *node = NULL;
-      keylist = calloc(hash->elements , sizeof *keylist);
+      keylist = (char**)calloc(hash->elements , sizeof *keylist);
       {
         uint32_t i = 0;
         while (i < hash->size && hash_sll_empty(hash->table[i]))
@@ -457,8 +457,8 @@ void hash_clear(hash_type *hash) {
 
 
 void * hash_get(const hash_type *hash , const char *key) {
-  hash_node_type * hash_node = __hash_get_node(hash , key , true);
-  node_data_type * data_node = hash_node_get_data( hash_node );
+  hash_node_type * hash_node = (hash_node_type*)__hash_get_node(hash , key , true);
+  node_data_type * data_node = (node_data_type*)hash_node_get_data( hash_node );
   return node_data_get_ptr( data_node );
 }
 
@@ -468,7 +468,7 @@ void * hash_get(const hash_type *hash , const char *key) {
    contain 'key'.
 */
 void * hash_safe_get( const hash_type * hash , const char * key ) {
-  hash_node_type * hash_node = __hash_get_node(hash , key , false);
+  hash_node_type * hash_node = (hash_node_type*)__hash_get_node(hash , key , false);
   if (hash_node != NULL) {
     node_data_type * data_node = hash_node_get_data( hash_node );
     return node_data_get_ptr( data_node );
@@ -505,7 +505,7 @@ void * hash_pop( hash_type * hash , const char * key) {
 
 static hash_type * __hash_alloc(int size, double resize_fill , hashf_type *hashf) {
   hash_type* hash;
-  hash = util_malloc(sizeof *hash );
+  hash = (hash_type*)util_malloc(sizeof *hash );
   UTIL_TYPE_ID_INIT(hash , HASH_TYPE_ID);
   hash->size      = size;
   hash->hashf     = hashf;
@@ -656,7 +656,7 @@ int hash_get_size(const hash_type *hash) {
 static hash_sort_type * hash_alloc_sort_list(const hash_type *hash ,
                                              const char **keylist) {
 
-  int i; hash_sort_type * sort_list = calloc(hash_get_size(hash) , sizeof * sort_list);
+  int i; hash_sort_type * sort_list = (hash_sort_type*)calloc(hash_get_size(hash) , sizeof * sort_list);
   for (i=0; i < hash_get_size(hash); i++)
     sort_list[i].key = util_alloc_string_copy(keylist[i]);
 
@@ -694,7 +694,7 @@ static char ** __hash_alloc_ordered_keylist(hash_type *hash , int ( hash_get_cmp
     sort_list[i].cmp_value = hash_get_cmp_value( hash_get(hash , sort_list[i].key) );
 
   qsort(sort_list , hash_get_size(hash) , sizeof *sort_list , &hash_sortlist_cmp);
-  sorted_keylist = calloc(hash_get_size(hash) , sizeof *sorted_keylist);
+  sorted_keylist = (char**)calloc(hash_get_size(hash) , sizeof *sorted_keylist);
   for (i = 0; i < hash_get_size(hash); i++) {
     sorted_keylist[i] = util_alloc_string_copy(sort_list[i].key);
     free(tmp_keylist[i]);
@@ -861,7 +861,7 @@ void hash_iter_restart( hash_iter_type * iter ) {
 
 
 hash_iter_type * hash_iter_alloc(const hash_type * hash) {
-  hash_iter_type * iter = util_malloc(sizeof * iter );
+  hash_iter_type * iter = (hash_iter_type*)util_malloc(sizeof * iter );
 
   iter->hash            = hash;
   iter->num_keys        = hash_get_size(hash);

--- a/lib/util/hash_node.c
+++ b/lib/util/hash_node.c
@@ -92,7 +92,7 @@ node_data_type * hash_node_get_data(const hash_node_type * node) {
 
 hash_node_type * hash_node_alloc_new(const char *key, node_data_type * data, hashf_type *hashf , uint32_t table_size) {
   hash_node_type *node;
-  node              = util_malloc(sizeof *node );
+  node              = (hash_node_type*) util_malloc(sizeof *node );
   node->key         = util_alloc_string_copy( key );
   node->data        = data;
   node->next_node   = NULL;

--- a/lib/util/hash_sll.c
+++ b/lib/util/hash_sll.c
@@ -35,7 +35,7 @@ struct hash_sll_struct {
 
 
 static hash_sll_type * hash_sll_alloc( void ) {
-  hash_sll_type * hash_sll = util_malloc(sizeof * hash_sll );
+  hash_sll_type * hash_sll = (hash_sll_type*) util_malloc(sizeof * hash_sll );
   hash_sll->length = 0;
   hash_sll->head   = NULL;
   return hash_sll;
@@ -43,7 +43,7 @@ static hash_sll_type * hash_sll_alloc( void ) {
 
 
 hash_sll_type ** hash_sll_alloc_table(int size) {
-  hash_sll_type ** table = util_malloc(size * sizeof * table );
+  hash_sll_type ** table = (hash_sll_type**) util_malloc(size * sizeof * table );
   int i;
   for (i=0; i<size; i++)
     table[i] = hash_sll_alloc();

--- a/lib/util/lars.c
+++ b/lib/util/lars.c
@@ -48,7 +48,7 @@ struct lars_struct {
 
 
 static lars_type * lars_alloc__() {
-  lars_type * lars = util_malloc( sizeof * lars );
+  lars_type * lars = (lars_type*)util_malloc( sizeof * lars );
   UTIL_TYPE_ID_INIT( lars , LARS_TYPE_ID );
   lars->X = NULL;
   lars->Y = NULL;

--- a/lib/util/log.c
+++ b/lib/util/log.c
@@ -103,7 +103,7 @@ void log_set_level( log_type * logh , int log_level) {
 log_type * log_open( const char * filename , int log_level) {
   log_type   *logh;
 
-  logh = util_malloc(sizeof *logh );
+  logh = (log_type*)util_malloc(sizeof *logh );
   
   logh->log_level     = log_level;
   logh->filename      = NULL;

--- a/lib/util/lookup_table.c
+++ b/lib/util/lookup_table.c
@@ -111,7 +111,7 @@ bool lookup_table_has_high_limit(const lookup_table_type * lt  ) {
 
 
 lookup_table_type * lookup_table_alloc( double_vector_type * x , double_vector_type * y , bool data_owner) {
-  lookup_table_type * lt = util_malloc( sizeof * lt);
+  lookup_table_type * lt = (lookup_table_type*)util_malloc( sizeof * lt);
   lt->data_owner = false;
   if ((x == NULL) && (y == NULL)) {
     x = double_vector_alloc(0 , 0);

--- a/lib/util/matrix.c
+++ b/lib/util/matrix.c
@@ -134,9 +134,9 @@ static void matrix_realloc_data__( matrix_type * matrix , bool safe_mode ) {
          otherwise we use util_malloc() which will abort if the memory
          is not available.
       */
-      matrix->data = malloc( sizeof * matrix->data * data_size );
+      matrix->data = (double*)malloc( sizeof * matrix->data * data_size );
     } else
-      matrix->data = util_malloc( sizeof * matrix->data * data_size );
+      matrix->data = (double*)util_malloc( sizeof * matrix->data * data_size );
 
 
     /* Initializing matrix content to zero. */
@@ -163,7 +163,7 @@ UTIL_SAFE_CAST_FUNCTION( matrix , MATRIX_TYPE_ID )
    The matrix objecty is NOT ready for use after this function.
 */
 static matrix_type * matrix_alloc_empty( ) {
-  matrix_type * matrix  = util_malloc( sizeof * matrix );
+  matrix_type * matrix  = (matrix_type*)util_malloc( sizeof * matrix );
   UTIL_TYPE_ID_INIT( matrix , MATRIX_TYPE_ID );
   matrix->name = NULL;
   return matrix;
@@ -1072,7 +1072,7 @@ matrix_type * matrix_alloc_transpose( const matrix_type * A) {
 
 void matrix_inplace_matmul(matrix_type * A, const matrix_type * B) {
   if ((A->columns == B->rows) && (B->rows == B->columns)) {
-    double * tmp = util_malloc( sizeof * A->data * A->columns );
+    double * tmp = (double*)util_malloc( sizeof * A->data * A->columns );
     int i,j,k;
 
     for (i=0; i < A->rows; i++) {
@@ -1108,10 +1108,10 @@ void matrix_inplace_matmul(matrix_type * A, const matrix_type * B) {
 static void * matrix_inplace_matmul_mt__(void * arg) {
 
   arg_pack_type * arg_pack = arg_pack_safe_cast( arg );
-  int row_offset         = arg_pack_iget_int( arg_pack , 0 );
-  int rows               = arg_pack_iget_int( arg_pack , 1 );
-  matrix_type * A        = arg_pack_iget_ptr( arg_pack , 2 );
-  const matrix_type * B  = arg_pack_iget_const_ptr( arg_pack , 3 );
+  int row_offset         =                     arg_pack_iget_int( arg_pack , 0 );
+  int rows               =                     arg_pack_iget_int( arg_pack , 1 );
+  matrix_type * A        = (matrix_type*)      arg_pack_iget_ptr( arg_pack , 2 );
+  const matrix_type * B  = (const matrix_type*)arg_pack_iget_const_ptr( arg_pack , 3 );
 
   matrix_type * A_view = matrix_alloc_shared( A , row_offset , 0 , rows , matrix_get_columns( A ));
   matrix_inplace_matmul( A_view , B );
@@ -1136,7 +1136,7 @@ static void * matrix_inplace_matmul_mt__(void * arg) {
 
 void matrix_inplace_matmul_mt2(matrix_type * A, const matrix_type * B , thread_pool_type * thread_pool){
   int num_threads  = thread_pool_get_max_running( thread_pool );
-  arg_pack_type    ** arglist = util_malloc( num_threads * sizeof * arglist );
+  arg_pack_type    ** arglist = (arg_pack_type**)util_malloc( num_threads * sizeof * arglist );
   int it;
   thread_pool_restart( thread_pool );
   {

--- a/lib/util/matrix_lapack.c
+++ b/lib/util/matrix_lapack.c
@@ -87,7 +87,7 @@ void matrix_dgesv(matrix_type * A , matrix_type * B) {
     int lda  = matrix_get_column_stride( A );
     int ldb  = matrix_get_column_stride( B );
     int nrhs = matrix_get_columns( B );
-    long int * ipivot = util_calloc( n , sizeof * ipivot );
+    long int * ipivot = (long int*)util_calloc( n , sizeof * ipivot );
     int info;
 
     dgesv_(&n , &nrhs , matrix_get_data( A ) , &lda , ipivot , matrix_get_data( B ), &ldb , &info);
@@ -183,7 +183,7 @@ void matrix_dgesvd(dgesvd_vector_enum jobu , dgesvd_vector_enum jobvt ,  matrix_
      Query the routine for optimal worksize.
   */
 
-  work     = util_calloc( 1 , sizeof * work );
+  work     = (double*)util_calloc( 1 , sizeof * work );
   worksize = -1;
   dgesvd_(&_jobu               , /* 1  */
           &_jobvt              , /* 2  */
@@ -203,12 +203,12 @@ void matrix_dgesvd(dgesvd_vector_enum jobu , dgesvd_vector_enum jobvt ,  matrix_
 
   /* Try to allocate optimal worksize. */
   worksize = (int) work[0];
-  double * tmp =  realloc( work , sizeof * work * worksize );
+  double * tmp = (double*)realloc( work , sizeof * work * worksize );
   if (tmp == NULL) {
     /* Could not allocate optimal worksize - settle for the minimum. This can not fail. */
     worksize = min_worksize;
     free(work);
-    work = util_calloc( worksize , sizeof * work );
+    work = (double*)util_calloc( worksize , sizeof * work );
   }else{
     work = tmp; /* The request for optimal worksize succeeded */
   }
@@ -273,9 +273,9 @@ int  matrix_dsyevx(bool             compute_eig_vectors ,
 
   {
     int      num_eigenvalues , ldz, info , worksize;
-    int    * ifail = util_calloc( n     , sizeof * ifail );
-    int    * iwork = util_calloc( 5 * n , sizeof * iwork );
-    double * work  = util_calloc( 1     , sizeof * work  );
+    int    * ifail = (int*)   util_calloc( n     , sizeof * ifail );
+    int    * iwork = (int*)   util_calloc( 5 * n , sizeof * iwork );
+    double * work  = (double*)util_calloc( 1     , sizeof * work  );
     double * z_data;
     double   abstol = 0.0; /* SHopuld */
 
@@ -316,14 +316,14 @@ int  matrix_dsyevx(bool             compute_eig_vectors ,
 
     worksize = (int) work[0];
     {
-      double * tmp = realloc(work , sizeof * work * worksize );
+      double * tmp = (double*)realloc(work , sizeof * work * worksize );
       if (tmp == NULL) {
         /*
            OK - we could not get the optimal worksize,
            try again with the minimum.
         */
         worksize = 8 * n;
-        work = util_realloc(work , sizeof * work * worksize );
+        work = (double*)util_realloc(work , sizeof * work * worksize );
       } else
         work = tmp; /* The request for optimal worksize succeeded */
     }
@@ -382,7 +382,7 @@ void matrix_dgeqrf(matrix_type * A , double * tau) {
   int lda       = matrix_get_column_stride( A );
   int m         = matrix_get_rows( A );
   int n         = matrix_get_columns( A );
-  double * work = util_calloc(1 , sizeof * work );
+  double * work = (double*)util_calloc(1 , sizeof * work );
   int worksize;
   int info;
 
@@ -394,14 +394,14 @@ void matrix_dgeqrf(matrix_type * A , double * tau) {
     util_abort("%s: dgerqf routine failed with info:%d \n",__func__ , info);
   worksize = ( int ) work[0];
   {
-    double * tmp = realloc(work , sizeof * work * worksize );
+    double * tmp = (double*)realloc(work , sizeof * work * worksize );
     if (tmp == NULL) {
       /*
          OK - we could not get the optimal worksize,
          try again with the minimum.
       */
       worksize = n;
-      work = util_realloc(work , sizeof * work * worksize );
+      work = (double*)util_realloc(work , sizeof * work * worksize );
     } else
       work = tmp; /* The request for optimal worksize succeeded */
   }
@@ -423,7 +423,7 @@ void matrix_dorgqr(matrix_type * A , double * tau, int num_reflectors) {  /* num
   int lda       = matrix_get_column_stride( A );
   int m         = matrix_get_rows( A );
   int n         = matrix_get_columns( A );
-  double * work = util_malloc(sizeof * work );
+  double * work = (double*)util_malloc(sizeof * work );
   int worksize;
   int info;
 
@@ -435,14 +435,14 @@ void matrix_dorgqr(matrix_type * A , double * tau, int num_reflectors) {  /* num
     util_abort("%s: dorgqf routine failed with info:%d \n",__func__ , info);
   worksize = ( int ) work[0];
   {
-    double * tmp = realloc(work , sizeof * work * worksize );
+    double * tmp = (double*)realloc(work , sizeof * work * worksize );
     if (tmp == NULL) {
       /*
          OK - we could not get the optimal worksize,
          try again with the minimum.
       */
       worksize = n;
-      work = util_realloc(work , sizeof * work * worksize );
+      work = (double*)util_realloc(work , sizeof * work * worksize );
     } else
       work = tmp; /* The request for optimal worksize succeeded */
   }
@@ -483,7 +483,7 @@ double matrix_det( matrix_type *A ) {
     double    det       = 1;
     double    det_scale = 0;
     int       n         = matrix_get_columns( A );
-    int * ipiv          = util_malloc( n * sizeof * ipiv );
+    int * ipiv          = (int*)util_malloc( n * sizeof * ipiv );
     matrix_dgetrf__( A , ipiv , &dgetrf_info );
     {
       int i;
@@ -537,11 +537,11 @@ int matrix_inv( matrix_type * A ) {
     int       dgetrf_info;
     int       info;
     int       n         = matrix_get_columns( A );
-    int * ipiv          = util_malloc( n * sizeof * ipiv );
+    int * ipiv          = (int*)util_malloc( n * sizeof * ipiv );
     matrix_dgetrf__( A , ipiv , &dgetrf_info );
     {
       int lda  = matrix_get_column_stride( A );
-      double * work = util_malloc( sizeof * work );
+      double * work = (double*)util_malloc( sizeof * work );
       int work_size;
 
       /* First call: determine optimal worksize: */
@@ -550,7 +550,7 @@ int matrix_inv( matrix_type * A ) {
 
       if (info == 0) {
         work_size = (int) work[0];
-        work = util_realloc( work , sizeof * work * work_size );
+        work = (double*)util_realloc( work , sizeof * work * work_size );
         dgetri_( &n , matrix_get_data( A ), &lda , ipiv , work , &work_size , &info);
       } else
         util_abort("%s: dgetri_ returned info:%d \n",__func__ , info);

--- a/lib/util/menu.c
+++ b/lib/util/menu.c
@@ -139,7 +139,7 @@ static bool __string_contains(const char * string , const char * char_set) {
 
 
 menu_type * menu_alloc(const char * title , const char * quit_label , const char * quit_keys) {
-  menu_type * menu = util_malloc(sizeof * menu );
+  menu_type * menu = (menu_type*)util_malloc(sizeof * menu );
   
   menu->title     = util_alloc_sprintf_escape( title , 0 );
   menu->quit_keys = util_alloc_string_copy( quit_keys );
@@ -151,7 +151,7 @@ menu_type * menu_alloc(const char * title , const char * quit_label , const char
 }
 
 static menu_item_type * menu_item_alloc_empty() {
-  menu_item_type * item = util_malloc(sizeof * item );
+  menu_item_type * item = (menu_item_type*)util_malloc(sizeof * item );
 
   item->label   = NULL; 
   item->key_set = NULL; 
@@ -335,7 +335,7 @@ static void menu_display(const menu_type * menu) {
   int i;
   int length = strlen(menu->title);
   for (i = 0; i < vector_get_size(menu->items); i++) {
-    const menu_item_type * item = vector_iget_const( menu->items , i);
+    const menu_item_type * item = (const menu_item_type*)vector_iget_const( menu->items , i);
     if(!item->helptext)
       length = util_int_max(length , item->label_length);
     if(item->helptext)
@@ -349,7 +349,7 @@ static void menu_display(const menu_type * menu) {
   util_fprintf_string(menu->title , length + 6 , center_pad , stdout);  printf(" |\n");
   __print_line(length + 10 , 1);
   for (i=0; i < vector_get_size(menu->items); i++) {
-    const menu_item_type * item = vector_iget_const( menu->items , i);
+    const menu_item_type * item = (const menu_item_type*)vector_iget_const( menu->items , i);
     if (item->separator) 
       __print_sep(length + 6);
     else if (item->helptext)
@@ -401,7 +401,7 @@ menu_item_type * menu_get_item(const menu_type * menu, char cmd) {
   int item_index = 0;
   menu_item_type * item = NULL;
   while (item_index < vector_get_size(menu->items)) {
-    menu_item_type * current_item = vector_iget(menu->items , item_index);
+    menu_item_type * current_item = (menu_item_type*)vector_iget(menu->items , item_index);
     if (!current_item->separator || !current_item->helptext) {
       if (strchr(current_item->key_set , cmd) != NULL) {
         item = current_item;
@@ -434,7 +434,7 @@ void menu_run(const menu_type * menu) {
     {
       int item_index = 0;
       while (1) {
-        const menu_item_type * item = vector_iget_const(menu->items , item_index);
+        const menu_item_type * item = (const menu_item_type*)vector_iget_const(menu->items , item_index);
         if (!item->separator) {
           if(!item->helptext) {
             if (strchr(item->key_set , cmd) != NULL) {

--- a/lib/util/msg.c
+++ b/lib/util/msg.c
@@ -132,7 +132,7 @@ void msg_update_int(msg_type * msg , const char * fmt , int value) {
 UTIL_SAFE_CAST_FUNCTION( msg , MSG_TYPE_ID )
 
 msg_type * msg_alloc(const char * prompt, bool debug) {
-  msg_type * msg = util_malloc(sizeof * msg );
+  msg_type * msg = (msg_type*)util_malloc(sizeof * msg );
   UTIL_TYPE_ID_INIT( msg , MSG_TYPE_ID);
   msg->prompt = util_alloc_string_copy(prompt);
   

--- a/lib/util/mzran.c
+++ b/lib/util/mzran.c
@@ -211,7 +211,7 @@ void mzran_get_state(void * __rng , char * state_buffer) {
 
 
 void * mzran_alloc( void ) {
-  mzran_type * rng = util_malloc( sizeof * rng );
+  mzran_type * rng = (mzran_type*) util_malloc( sizeof * rng );
   UTIL_TYPE_ID_INIT( rng , MZRAN_TYPE_ID );
   mzran_set_default_state( rng );
   return rng;

--- a/lib/util/node_data.c
+++ b/lib/util/node_data.c
@@ -53,7 +53,7 @@ struct node_data_struct {
 */
 
 static node_data_type * node_data_alloc__(const void * data , node_ctype ctype , int buffer_size , copyc_ftype * copyc, free_ftype * del) {
-  node_data_type * node = util_malloc(sizeof * node );
+  node_data_type * node = (node_data_type*)util_malloc(sizeof * node );
   node->ctype           = ctype;
   node->copyc           = copyc;
   node->del             = del;
@@ -87,27 +87,27 @@ node_data_type * node_data_alloc_buffer(const void * data, int buffer_size) {  /
 
 
 static node_data_type * node_data_copyc(const node_data_type * src , bool deep_copy) {
-  node_data_type * new;
+  node_data_type * next;
 
   if (src->buffer_size > 0) {
     /* 
        The source node has internal storage - it has been allocated with _alloc_buffer() 
     */
     if (deep_copy) 
-      new  = node_data_alloc__(util_alloc_copy( src->data , src->buffer_size )  /* A new copy is allocated prior to insert. */
+      next  = node_data_alloc__(util_alloc_copy( src->data , src->buffer_size )  /* A next copy is allocated prior to insert. */
                                , src->ctype , src->buffer_size , NULL , free);
     else
-      new  = node_data_alloc__(src->data , src->ctype , src->buffer_size , NULL , NULL);  /* The copy does not have destructor. */
+      next  = node_data_alloc__(src->data , src->ctype , src->buffer_size , NULL , NULL);  /* The copy does not have destructor. */
   } else {
     if (deep_copy) {
       if (src->copyc == NULL) 
         util_abort("%s: Tried allocate deep_copy of mnode with no constructor - aborting. \n",__func__);  
-      new = node_data_alloc__(src->data , src->ctype , 0 , src->copyc , src->del);
+      next = node_data_alloc__(src->data , src->ctype , 0 , src->copyc , src->del);
     } else
-      new = node_data_alloc__(src->data , src->ctype , 0 , NULL , NULL); /*shallow copy - we 'hide' constructor and destructor. */
+      next = node_data_alloc__(src->data , src->ctype , 0 , NULL , NULL); /*shallow copy - we 'hide' constructor and destructor. */
   }
 
-  return new;
+  return next;
 }
 
 node_data_type * node_data_alloc_copy(const node_data_type * node , bool deep_copy) {

--- a/lib/util/parser.c
+++ b/lib/util/parser.c
@@ -88,7 +88,7 @@ basic_parser_type * basic_parser_alloc(
   const char * comment_start,    /** Set to NULL if not interessting.            */
   const char * comment_end)      /** Set to NULL  if not interessting.           */
 {
-  basic_parser_type * parser = util_malloc(sizeof * parser);
+  basic_parser_type * parser = (basic_parser_type*)util_malloc(sizeof * parser);
   parser->splitters     = NULL;
   parser->delete_set    = NULL;
   parser->quoters       = NULL;
@@ -261,11 +261,11 @@ static int length_of_comment(  const char * buffer_position, const basic_parser_
 static char * alloc_quoted_token( const char * buffer, int length,  bool strip_quote_marks) {
   char * token;
   if(!strip_quote_marks) {
-    token = util_calloc( (length + 1) , sizeof * token );
+    token = (char*)util_calloc( (length + 1) , sizeof * token );
     memmove(token, &buffer[0], length * sizeof * token );
     token[length] = '\0';
   } else  {
-    token = util_calloc( (length - 1) , sizeof * token);
+    token = (char*)util_calloc( (length - 1) , sizeof * token);
     memmove(token, &buffer[1], (length -1) * sizeof * token);
     token[length-2] = '\0';
     /**
@@ -432,7 +432,7 @@ stringlist_type * basic_parser_tokenize_buffer(
 
     {
       int length   = length_of_normal_non_splitters( &buffer[position], parser );
-      char * token = util_calloc( (length + 1) , sizeof * token);
+      char * token = (char*)util_calloc( (length + 1) , sizeof * token);
       int token_length;
       if (parser->delete_set == NULL) {
         token_length = length;
@@ -623,7 +623,7 @@ bool basic_parser_fseek_string(const basic_parser_type * parser , FILE * stream 
 
 void basic_parser_strip_buffer(const basic_parser_type * parser , char ** __buffer) {
   char * src     = *__buffer;
-  char * target  = util_calloc( ( strlen( *__buffer ) + 1) , sizeof * target );
+  char * target  = (char*)util_calloc( ( strlen( *__buffer ) + 1) , sizeof * target );
 
   int src_position    = 0;
   int target_position = 0;
@@ -672,7 +672,7 @@ void basic_parser_strip_buffer(const basic_parser_type * parser , char ** __buff
     target_position += 1;
   }
   target[target_position] = '\0';
-  target = util_realloc( target , sizeof * target * (target_position + 1) );
+  target = (char*)util_realloc( target , sizeof * target * (target_position + 1) );
   
   free( src );
   *__buffer = target;

--- a/lib/util/path_fmt.c
+++ b/lib/util/path_fmt.c
@@ -76,7 +76,7 @@ void path_fmt_reset_fmt(path_fmt_type * path , const char * fmt) {
 
 
 static path_fmt_type * path_fmt_alloc__(const char * fmt , bool is_directory) {
-  path_fmt_type * path = util_malloc(sizeof * path );
+  path_fmt_type * path = (path_fmt_type*)util_malloc(sizeof * path );
   UTIL_TYPE_ID_INIT(path , PATH_FMT_ID);
   path->fmt            = NULL;
   path->file_fmt       = NULL;

--- a/lib/util/path_stack.c
+++ b/lib/util/path_stack.c
@@ -51,7 +51,7 @@ struct path_stack_struct {
 */
 
 path_stack_type * path_stack_alloc() {
-  path_stack_type * path_stack = util_malloc( sizeof * path_stack );
+  path_stack_type * path_stack = (path_stack_type*)util_malloc( sizeof * path_stack );
   path_stack->stack = stringlist_alloc_new(); 
   path_stack->storage = stringlist_alloc_new(); 
   return path_stack; 

--- a/lib/util/perm_vector.c
+++ b/lib/util/perm_vector.c
@@ -36,7 +36,7 @@ struct perm_vector_struct {
 */
 
 perm_vector_type * perm_vector_alloc( int * perm_input, int size ) {
-  perm_vector_type * perm = util_malloc( sizeof * perm );
+  perm_vector_type * perm = (perm_vector_type*)util_malloc( sizeof * perm );
   UTIL_TYPE_ID_INIT( perm , PERM_VECTOR_TYPE_ID );
   perm->size = size;
   perm->perm = perm_input;

--- a/lib/util/set.c
+++ b/lib/util/set.c
@@ -38,7 +38,7 @@ static UTIL_SAFE_CAST_FUNCTION( set , SET_TYPE_ID )
 
 
 set_type * set_alloc(int size, const char ** keyList) {
-  set_type * set = malloc(sizeof * set);
+  set_type * set = (set_type*) malloc(sizeof * set);
   UTIL_TYPE_ID_INIT( set , SET_TYPE_ID );
   set->key_hash  = hash_alloc_unlocked();
   {
@@ -242,7 +242,7 @@ struct set_iter_struct
 
 set_iter_type * set_iter_alloc(const set_type * set)
 {
-  set_iter_type * set_iter = util_malloc(sizeof * set_iter);
+  set_iter_type * set_iter = (set_iter_type*) util_malloc(sizeof * set_iter);
   set_iter->hash_iter = hash_iter_alloc(set->key_hash);
   return set_iter;
 }

--- a/lib/util/stepwise.c
+++ b/lib/util/stepwise.c
@@ -153,7 +153,7 @@ static double stepwise_test_var( stepwise_type * stepwise , int test_var , int b
 
 
     /*True Cross-Validation: */
-    int * randperms     = util_calloc( nsample , sizeof * randperms );
+    int * randperms     = (int*)util_calloc( nsample , sizeof * randperms );
     for (int i=0; i < nsample; i++)
       randperms[i] = i;
 
@@ -310,7 +310,7 @@ double stepwise_eval( const stepwise_type * stepwise , const matrix_type * x ) {
 
 
 static stepwise_type * stepwise_alloc__( int nsample , int nvar , rng_type * rng) {
-  stepwise_type * stepwise = util_malloc( sizeof * stepwise );
+  stepwise_type * stepwise = (stepwise_type*)util_malloc( sizeof * stepwise );
 
   stepwise->X_mean      = NULL;
   stepwise->X_norm      = NULL;
@@ -327,7 +327,7 @@ static stepwise_type * stepwise_alloc__( int nsample , int nvar , rng_type * rng
 
 
 stepwise_type * stepwise_alloc0( rng_type * rng) {
-  stepwise_type * stepwise = util_malloc( sizeof * stepwise );
+  stepwise_type * stepwise = (stepwise_type*)util_malloc( sizeof * stepwise );
 
   stepwise->rng         = rng;
   stepwise->X0          = NULL;

--- a/lib/util/stringlist.c
+++ b/lib/util/stringlist.c
@@ -134,7 +134,7 @@ void stringlist_insert_owned_ref(stringlist_type * stringlist , int index , cons
 
 
 static stringlist_type * stringlist_alloc_empty( bool alloc_vector ) {
-  stringlist_type * stringlist = util_malloc(sizeof * stringlist );
+  stringlist_type * stringlist = (stringlist_type*)util_malloc(sizeof * stringlist );
   UTIL_TYPE_ID_INIT( stringlist , STRINGLIST_TYPE_ID);
 
   if (alloc_vector)
@@ -333,20 +333,20 @@ void stringlist_idel(stringlist_type * stringlist , int index) {
 
 
 char * stringlist_pop( stringlist_type * stringlist) {
-  return vector_pop_back( stringlist->strings );
+  return (char*)vector_pop_back( stringlist->strings );
 }
 
 
 const char * stringlist_iget(const stringlist_type * stringlist , int index) {
-  return vector_iget(stringlist->strings ,index);
+  return (const char*)vector_iget(stringlist->strings ,index);
 }
 
 const char * stringlist_front(const stringlist_type * stringlist) {
-  return vector_iget(stringlist->strings , 0);
+  return (const char*)vector_iget(stringlist->strings , 0);
 }
 
 const char * stringlist_back(const stringlist_type * stringlist) {
-  return vector_iget(stringlist->strings , vector_get_size( stringlist->strings ) - 1);
+  return (const char*)vector_iget(stringlist->strings , vector_get_size( stringlist->strings ) - 1);
 }
 
 
@@ -395,7 +395,7 @@ bool stringlist_iget_as_bool( const stringlist_type * stringlist, int index, boo
 }
 
 const char * stringlist_get_last( const stringlist_type * stringlist ) {
-  return vector_get_last( stringlist->strings );
+  return (const char*)vector_get_last( stringlist->strings );
 }
 
 
@@ -438,7 +438,7 @@ static char ** stringlist_alloc_char__(const stringlist_type * stringlist, bool 
   int size = stringlist_get_size( stringlist );
   if (size > 0) {
     int i;
-    strings = util_calloc(size , sizeof * strings );
+    strings = (char**)util_calloc(size , sizeof * strings );
     for (i = 0; i <size; i++) {
       if (deep_copy)
         strings[i] = stringlist_iget_copy( stringlist , i);
@@ -572,7 +572,7 @@ char * stringlist_alloc_joined_substring( const stringlist_type * s , int start_
         total_length += (strlen(stringlist_iget( s , i)) + sep_length);
 
       total_length += (1 - sep_length);
-      string    = util_malloc( total_length * sizeof * string );
+      string    = (char*)util_malloc( total_length * sizeof * string );
       string[0] = '\0';
     }
 
@@ -730,7 +730,7 @@ int stringlist_select_matching(stringlist_type * names , const char * pattern) {
 
   {
     int i;
-    glob_t * pglob = util_malloc( sizeof * pglob );
+    glob_t * pglob = (glob_t*)util_malloc( sizeof * pglob );
     int glob_flags = 0;
     glob( pattern , glob_flags , NULL , pglob);
     match_count = pglob->gl_pathc;

--- a/lib/util/struct_vector.c
+++ b/lib/util/struct_vector.c
@@ -38,7 +38,7 @@ UTIL_IS_INSTANCE_FUNCTION( struct_vector , STRUCT_VECTOR_TYPE_ID)
 
 
 static void struct_vector_resize( struct_vector_type * struct_vector , int new_alloc_size) {
-  struct_vector->data = util_realloc( struct_vector->data , struct_vector->element_size * new_alloc_size );
+  struct_vector->data = (char*)util_realloc( struct_vector->data , struct_vector->element_size * new_alloc_size );
   struct_vector->alloc_size = new_alloc_size;
 }
 
@@ -57,7 +57,7 @@ struct_vector_type * struct_vector_alloc( int element_size ) {
   }
 
   {
-    struct_vector_type * vector = util_malloc( sizeof * vector );
+    struct_vector_type * vector = (struct_vector_type*)util_malloc( sizeof * vector );
     UTIL_TYPE_ID_INIT( vector , STRUCT_VECTOR_TYPE_ID );
     vector->size = 0;
     vector->alloc_size = 0;

--- a/lib/util/subst_func.c
+++ b/lib/util/subst_func.c
@@ -67,7 +67,7 @@ char * subst_func_eval( const subst_func_type * subst_func , const stringlist_ty
 
 
 subst_func_type * subst_func_alloc( const char * func_name , const char * doc_string , subst_func_ftype * func , bool vararg, int argc_min , int argc_max , void * arg) {
-  subst_func_type * subst_func = util_malloc( sizeof * subst_func );
+  subst_func_type * subst_func = (subst_func_type*)util_malloc( sizeof * subst_func );
   UTIL_TYPE_ID_INIT( subst_func , SUBST_FUNC_TYPE_ID );
   subst_func->func       = func;
   subst_func->name       = util_alloc_string_copy( func_name );
@@ -101,7 +101,7 @@ static void subst_func_free__( void * arg ) {
 UTIL_IS_INSTANCE_FUNCTION( subst_func_pool , SUBST_FUNC_POOL_TYPE_ID);
 
 subst_func_pool_type * subst_func_pool_alloc( ) {
-  subst_func_pool_type * pool = util_malloc( sizeof * pool );
+  subst_func_pool_type * pool = (subst_func_pool_type*)util_malloc( sizeof * pool );
   UTIL_TYPE_ID_INIT( pool , SUBST_FUNC_POOL_TYPE_ID );
   pool->func_table = hash_alloc_unlocked();
   return pool;
@@ -122,7 +122,7 @@ void subst_func_pool_add_func( subst_func_pool_type * pool , const char * func_n
 
 
 subst_func_type * subst_func_pool_get_func( const subst_func_pool_type * pool , const char * func_name ) {
-  return hash_get( pool->func_table , func_name );
+  return (subst_func_type*)hash_get( pool->func_table , func_name );
 }
 
 bool subst_func_pool_has_func( const subst_func_pool_type * pool , const char * func_name ) {

--- a/lib/util/test_work_area.c
+++ b/lib/util/test_work_area.c
@@ -131,7 +131,7 @@ static test_work_area_type * test_work_area_alloc__(const char * prefix , const 
     char * test_cwd = util_alloc_sprintf(FULL_PATH_FMT , prefix , test_path );
     util_make_path( test_cwd );
     if (true) {
-      work_area = util_malloc( sizeof * work_area );
+      work_area = (test_work_area_type*)util_malloc( sizeof * work_area );
 
       UTIL_TYPE_ID_INIT( work_area , TEST_WORK_AREA_TYPE_ID );
       work_area->original_cwd = util_alloc_cwd();

--- a/lib/util/thread_pool_posix.c
+++ b/lib/util/thread_pool_posix.c
@@ -153,7 +153,7 @@ static UTIL_SAFE_CAST_FUNCTION( thread_pool , THREAD_POOL_TYPE_ID )
 static void thread_pool_resize_queue( thread_pool_type * pool, int queue_length ) {
   pthread_rwlock_wrlock( &pool->queue_lock );
   {
-    pool->queue            = util_realloc( pool->queue , queue_length * sizeof * pool->queue );
+    pool->queue            = (thread_pool_arg_type*)util_realloc( pool->queue , queue_length * sizeof * pool->queue );
     pool->queue_alloc_size = queue_length;
   }
   pthread_rwlock_unlock( &pool->queue_lock );
@@ -242,7 +242,7 @@ static void * thread_pool_main_loop( void * arg ) {
                take a copy of the node we are interested in.
             */
             pthread_rwlock_rdlock( &tp->queue_lock );
-            tp_arg = util_alloc_copy( &tp->queue[ tp->queue_index ] , sizeof * tp_arg );
+            tp_arg = (thread_pool_arg_type*)util_alloc_copy( &tp->queue[ tp->queue_index ] , sizeof * tp_arg );
             pthread_rwlock_unlock( &tp->queue_lock );
 
             tp_arg->slot_index = slot_index;
@@ -423,9 +423,9 @@ bool thread_pool_try_join(thread_pool_type * pool, int timeout_seconds) {
 */
 
 thread_pool_type * thread_pool_alloc(int max_running , bool start_queue) {
-  thread_pool_type * pool = util_malloc( sizeof *pool );
+  thread_pool_type * pool = (thread_pool_type*)util_malloc( sizeof *pool );
   UTIL_TYPE_ID_INIT( pool , THREAD_POOL_TYPE_ID );
-  pool->job_slots         = util_calloc( max_running , sizeof * pool->job_slots );
+  pool->job_slots         = (thread_pool_job_slot_type*)util_calloc( max_running , sizeof * pool->job_slots );
   pool->max_running       = max_running;
   pool->queue             = NULL;
   pool->accepting_jobs    = false;

--- a/lib/util/time_interval.c
+++ b/lib/util/time_interval.c
@@ -62,7 +62,7 @@ void time_interval_reopen( time_interval_type * time_interval) {
 
 
 time_interval_type * time_interval_alloc( time_t start_time , time_t end_time ) {
-  time_interval_type * ti = util_malloc( sizeof * ti );
+  time_interval_type * ti = (time_interval_type*)util_malloc( sizeof * ti );
   time_interval_update( ti , start_time , end_time );
   return ti;
 }

--- a/lib/util/timer.c
+++ b/lib/util/timer.c
@@ -42,7 +42,7 @@ struct timer_struct {
 
 timer_type * timer_alloc(bool epoch_time) {
   timer_type *timer;
-  timer       = util_malloc(sizeof * timer );
+  timer       = (timer_type*)util_malloc(sizeof * timer );
   
   timer->epoch_time = epoch_time;
   timer_reset(timer);

--- a/lib/util/ui_return.c
+++ b/lib/util/ui_return.c
@@ -43,7 +43,7 @@ UTIL_IS_INSTANCE_FUNCTION(ui_return , UI_RETURN_TYPE_ID)
 
 
 ui_return_type * ui_return_alloc(ui_return_status_enum status) {
-  ui_return_type * ui_return = util_malloc( sizeof * ui_return );
+  ui_return_type * ui_return = (ui_return_type*)util_malloc( sizeof * ui_return );
   UTIL_TYPE_ID_INIT(ui_return , UI_RETURN_TYPE_ID);
   ui_return->status = status;
   ui_return->help_text = NULL;
@@ -105,7 +105,7 @@ const char * ui_return_get_help(const ui_return_type * ui_return) {
 void ui_return_add_help(ui_return_type * ui_return, const char * help_text) {
   if (ui_return->help_text) {
     int new_length = strlen(ui_return->help_text) + strlen(help_text) + 1 + 1;
-    ui_return->help_text = util_realloc(ui_return->help_text , new_length * sizeof * ui_return->help_text);
+    ui_return->help_text = (char*)util_realloc(ui_return->help_text , new_length * sizeof * ui_return->help_text);
 
     strcat(ui_return->help_text , " ");
     strcat(ui_return->help_text , help_text);

--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -304,7 +304,7 @@ void util_fread_dev_urandom(int buffer_size , char * buffer) {
 
 unsigned int util_dev_urandom_seed( ) {
   unsigned int seed;
-  util_fread_dev_urandom( sizeof seed, &seed );
+  util_fread_dev_urandom( sizeof seed, (char*)&seed );
   return seed;
 }
 
@@ -404,7 +404,7 @@ bool util_double_approx_equal( double d1 , double d2) {
 char * util_alloc_substring_copy(const char *src , int offset , int N) {
   char *copy;
   if ((N + offset) < strlen(src)) {
-    copy = util_calloc(N + 1 , sizeof * copy );
+    copy = (char*)util_calloc(N + 1 , sizeof * copy );
     strncpy(copy , &src[offset] , N);
     copy[N] = '\0';
   } else
@@ -416,7 +416,7 @@ char * util_alloc_substring_copy(const char *src , int offset , int N) {
 char * util_alloc_dequoted_copy(const char *s) {
   char first_char = s[0];
   char last_char  = s[strlen(s) - 1];
-  char *new;
+  char *next;
   int offset , len;
 
   if ((first_char == '\'') || (first_char == '\"'))
@@ -429,8 +429,8 @@ char * util_alloc_dequoted_copy(const char *s) {
   else
     len = strlen(s) - offset;
 
-  new = util_alloc_substring_copy(s , offset , len);
-  return new;
+  next = util_alloc_substring_copy(s , offset , len);
+  return next;
 }
 
 
@@ -442,7 +442,7 @@ char * util_alloc_dequoted_copy(const char *s) {
 char * util_realloc_dequoted_string(char *s) {
   char first_char = s[0];
   char last_char  = s[strlen(s) - 1];
-  char *new;
+  char *next;
   int offset , len;
 
   if ((first_char == '\'') || (first_char == '\"'))
@@ -455,9 +455,9 @@ char * util_realloc_dequoted_string(char *s) {
   else
     len = strlen(s) - offset;
 
-  new = util_alloc_substring_copy(s , offset , len);
+  next = util_alloc_substring_copy(s , offset , len);
   free(s);
-  return new;
+  return next;
 }
 
 void util_strupr(char *s) {
@@ -593,7 +593,7 @@ char * util_fscanf_alloc_upto(FILE * stream , const char * stop_string, bool inc
   if (util_fseek_string(stream , stop_string , include_stop_string , true)) {   /* Default case sensitive. */
     long int end_pos = util_ftell(stream);
     int      len     = end_pos - start_pos;
-    char * buffer    = util_calloc( (len + 1) ,  sizeof * buffer );
+    char * buffer    = (char*)util_calloc( (len + 1) ,  sizeof * buffer );
 
     util_fseek(stream , start_pos , SEEK_SET);
     util_fread( buffer , 1 , len , stream , __func__);
@@ -639,7 +639,7 @@ static char * util_fscanf_alloc_line__(FILE *stream , bool *at_eof , char * line
   if (util_fseek(stream , init_pos , SEEK_SET) != 0)
     util_abort("%s: fseek failed: %d/%s \n",__func__ , errno , strerror(errno));
 
-  new_line = util_realloc(line , len + 1 );
+  new_line = (char*)util_realloc(line , len + 1 );
   util_fread(new_line , sizeof * new_line , len , stream , __func__);
   new_line[len] = '\0';
 
@@ -696,7 +696,7 @@ char * util_fscanf_realloc_line(FILE *stream , bool *at_eof , char *line) {
 
 char * util_alloc_stdin_line(void) {
   int input_size = 256;
-  char * input   = util_calloc(input_size , sizeof * input );
+  char * input   = (char*)util_calloc(input_size , sizeof * input );
   int index = 0;
   bool end = false;
   int c;
@@ -707,7 +707,7 @@ char * util_alloc_stdin_line(void) {
       index++;
       if (index == (input_size - 1)) { /* Reserve space for terminating \0 */
         input_size *= 2;
-        input = util_realloc(input , input_size );
+        input = (char*)util_realloc(input , input_size );
       }
     } else end = true;
   } while (!end);
@@ -716,7 +716,7 @@ char * util_alloc_stdin_line(void) {
     input = NULL;
   } else {
     input[index] = '\0';
-    input = util_realloc(input , strlen(input) + 1 );
+    input = (char*)util_realloc(input , strlen(input) + 1 );
   }
 
   return input;
@@ -797,7 +797,7 @@ char * util_alloc_cwd(void) {
   char * cwd;
   int buffer_size = 128;
   do {
-    cwd = util_calloc(buffer_size , sizeof * cwd );
+    cwd = (char*)util_calloc(buffer_size , sizeof * cwd );
     result_ptr = util_getcwd(cwd , buffer_size - 1);
     if (result_ptr == NULL) {
       if (errno == ERANGE) {
@@ -806,7 +806,7 @@ char * util_alloc_cwd(void) {
       }
     }
   } while ( result_ptr == NULL );
-  cwd = util_realloc(cwd , strlen(cwd) + 1 );
+  cwd = (char*)util_realloc(cwd , strlen(cwd) + 1 );
   return cwd;
 }
 
@@ -851,7 +851,7 @@ static char * util_alloc_cwd_abs_path( const char * path ) {
     return util_alloc_string_copy( path );
   else {
     char * cwd       = util_alloc_cwd( );
-    char * abs_path  = util_realloc( cwd , strlen( cwd ) + 1 + strlen( path ) + 1 );
+    char * abs_path  = (char*)util_realloc( cwd , strlen( cwd ) + 1 + strlen( path ) + 1 );
     strcat( abs_path , UTIL_PATH_SEP_STRING );
     strcat( abs_path , path );
     return abs_path;
@@ -872,7 +872,7 @@ static char * util_alloc_cwd_abs_path( const char * path ) {
 
 char * util_alloc_realpath__(const char * input_path) {
   char * abs_path  = util_alloc_cwd_abs_path( input_path );
-  char * real_path = util_malloc( strlen(abs_path) + 2 );
+  char * real_path = (char*)util_malloc( strlen(abs_path) + 2 );
   real_path[0] = '\0';
 
   {
@@ -881,7 +881,7 @@ char * util_alloc_realpath__(const char * input_path) {
     int     path_len;
 
     util_path_split( abs_path , &path_len , &path_list );
-    mask = util_malloc( path_len * sizeof * mask );
+    mask = (bool*)util_malloc( path_len * sizeof * mask );
     {
       int i;
       for (i=0; i < path_len; i++)
@@ -968,14 +968,14 @@ char * util_alloc_realpath__(const char * input_path) {
 
 char * util_alloc_realpath(const char * input_path) {
 #ifdef HAVE_REALPATH
-  char * buffer   = util_calloc(PATH_MAX + 1 , sizeof * buffer );
+  char * buffer   = (char*)util_calloc(PATH_MAX + 1 , sizeof * buffer );
   char * new_path = NULL;
 
   new_path = realpath( input_path , buffer);
   if (new_path == NULL)
     util_abort("%s: input_path:%s - failed: %s(%d) \n",__func__ , input_path , strerror(errno) , errno);
   else
-    new_path = util_realloc(new_path , strlen(new_path) + 1);
+    new_path = (char*)util_realloc(new_path , strlen(new_path) + 1);
 
   return new_path;
 #else
@@ -1138,7 +1138,7 @@ char * util_alloc_rel_path( const char * __root_path , const char * path) {
 char * util_isscanf_alloc_envvar( const char * string , int env_index ) {
   int env_count = 0;
   const char * offset = string;
-  char       * env_ptr;
+  const char * env_ptr;
   do {
     env_ptr = strchr( offset , '$' );
     offset = &env_ptr[1];
@@ -1447,7 +1447,7 @@ char * util_fscanf_alloc_token(FILE * stream) {
     } while (cont);
     if (EOL_CHAR(c)) util_fseek(stream , -1 , SEEK_CUR);
 
-    token = util_calloc(length + 1 , sizeof * token );
+    token = (char*)util_calloc(length + 1 , sizeof * token );
     util_fseek(stream , token_start , SEEK_SET);
     {
       int i;
@@ -2241,7 +2241,7 @@ int util_count_content_file_lines(FILE * stream) {
 
 char * util_fread_alloc_file_content(const char * filename , int * buffer_size) {
   size_t file_size = util_file_size(filename);
-  char * buffer = util_calloc(file_size + 1 , sizeof * buffer );
+  char * buffer = (char*)util_calloc(file_size + 1 , sizeof * buffer );
   {
     FILE * stream = util_fopen(filename , "r");
     util_fread( buffer , 1 , file_size , stream , __func__);
@@ -2385,8 +2385,8 @@ void util_move_file4( const char * src_name , const char * target_name , const c
 bool util_files_equal( const char * file1 , const char * file2 ) {
   bool equal = true;
   const int buffer_size = 4096;
-  char * buffer1 = util_calloc( buffer_size , sizeof * buffer1 );
-  char * buffer2 = util_calloc( buffer_size , sizeof * buffer2 );
+  char * buffer1 = (char*)util_calloc( buffer_size , sizeof * buffer1 );
+  char * buffer2 = (char*)util_calloc( buffer_size , sizeof * buffer2 );
 
   FILE * stream1 = util_fopen( file1 , "r" );
   FILE * stream2 = util_fopen( file2 , "r" );
@@ -2475,7 +2475,7 @@ int util_fmove( FILE * stream , long offset , long shift) {
 
   if (shift != 0) {
     int buffer_size = 1024 * 1024 * 4;  /* 4MB buffer size. */
-    char * buffer = util_calloc( buffer_size , sizeof * buffer );
+    char * buffer = (char*)util_calloc( buffer_size , sizeof * buffer );
 
     /* Shift > 0: We are opening up a hole in the file. */
     if (shift > 0) {
@@ -2933,7 +2933,7 @@ bool util_fmt_bit8_stream(FILE * stream ) {
     double bit8set_fraction;
     int N_bit8set = 0;
     int elm_read,i;
-    char *buffer = util_calloc(buffer_size , sizeof * buffer );
+    char *buffer = (char*)util_calloc(buffer_size , sizeof * buffer );
 
     elm_read = fread(buffer , 1 , buffer_size , stream);
     if (elm_read < min_read)
@@ -3450,11 +3450,11 @@ char * util_alloc_strip_copy(const char *src) {
     while (src[start_index] == ' ')
       start_index++;
     strip_length = end_index - start_index + 1;
-    target = util_calloc(strip_length + 1 , sizeof * target );
+    target = (char*)util_calloc(strip_length + 1 , sizeof * target );
     memcpy(target , &src[start_index] , strip_length);
   } else
     /* A blank string */
-    target = util_calloc(strip_length + 1 , sizeof * target );
+    target = (char*)util_calloc(strip_length + 1 , sizeof * target );
 
   target[strip_length] = '\0';
   return target;
@@ -3476,7 +3476,7 @@ char * util_realloc_strip_copy(char *src) {
 char ** util_alloc_stringlist_copy(const char **src, int len) {
   if (src != NULL) {
     int i;
-    char ** copy = util_calloc(len , sizeof * copy );
+    char ** copy = (char**)util_calloc(len , sizeof * copy );
     for (i=0; i < len; i++)
       copy[i] = util_alloc_string_copy(src[i]);
     return copy;
@@ -3518,7 +3518,7 @@ char ** util_stringlist_append_copy(char ** string_list, int size , const char *
 */
 
 char ** util_stringlist_append_ref(char ** string_list, int size , const char * append_string) {
-  string_list = util_realloc(string_list , (size + 1) * sizeof * string_list );
+  string_list = (char**)util_realloc(string_list , (size + 1) * sizeof * string_list );
   string_list[size] = (char *) append_string;
   return string_list;
 }
@@ -3528,7 +3528,7 @@ char ** util_stringlist_append_ref(char ** string_list, int size , const char * 
 char * util_alloc_string_copy(const char *src ) {
   if (src != NULL) {
     int byte_size = (strlen(src) + 1) * sizeof * src;
-    char * copy   = util_calloc( byte_size , sizeof * copy );
+    char * copy   = (char*)util_calloc( byte_size , sizeof * copy );
     memcpy( copy , src , byte_size );
     return copy;
   } else
@@ -3539,7 +3539,7 @@ char * util_alloc_string_copy(const char *src ) {
 
 char * util_realloc_string_copy(char * old_string , const char *src ) {
   if (src != NULL) {
-    char *copy = util_realloc(old_string , (strlen(src) + 1) * sizeof *copy );
+    char *copy = (char*)util_realloc(old_string , (strlen(src) + 1) * sizeof *copy );
     strcpy(copy , src);
     return copy;
   } else {
@@ -3559,7 +3559,7 @@ char * util_realloc_substring_copy(char * old_string , const char *src , int len
     else
       str_len = len;
 
-    copy = realloc(old_string , (str_len + 1) * sizeof *copy);
+    copy = (char*)realloc(old_string , (str_len + 1) * sizeof *copy);
     strncpy(copy , src , str_len);
     copy[str_len] = '\0';
 
@@ -3618,10 +3618,10 @@ bool util_string_match(const char * string , const char * pattern) {
   if (strcmp(wildcard_st , pattern) == 0)
     return true;
   else {
-    bool    match = true;
-    char ** sub_pattern;
-    int     num_patterns;
-    char *  string_ptr;
+    bool          match = true;
+    char **       sub_pattern;
+    int           num_patterns;
+    const char *  string_ptr;
     util_split_string( pattern , wildcard_st , &num_patterns , &sub_pattern );
 
     if (pattern[0] == '*')
@@ -3634,7 +3634,7 @@ bool util_string_match(const char * string , const char * pattern) {
       int i;
           string_ptr += strlen( sub_pattern[0] );
       for (i=1; i < num_patterns; i++) {
-        char * match_ptr = strstr(string_ptr , sub_pattern[i]);
+        const char * match_ptr = strstr(string_ptr , sub_pattern[i]);
         if (match_ptr != NULL)
           string_ptr = match_ptr + strlen( sub_pattern[i] );
         else {
@@ -3695,7 +3695,9 @@ void util_free_stringlist(char **list , int N) {
 
 
 char * util_strstr_int_format(const char * string ) {
-  char * percent_ptr = strchr(string , '%');
+  // the function itself is essentially removing the const from *string
+  // so do it explicitly here to make C++ happy
+  char * percent_ptr = strchr((char*)string , '%');
 
   if (percent_ptr) {
 
@@ -3770,7 +3772,7 @@ char * util_strcat_realloc(char *s1 , const char * s2) {
   else {
     if (s2 != NULL) {
       int new_length = strlen(s1) + strlen(s2) + 1;
-      s1 = util_realloc( s1 , new_length );
+      s1 = (char*)util_realloc( s1 , new_length );
       strcat(s1 , s2);
     }
   }
@@ -3786,7 +3788,7 @@ char * util_alloc_string_sum(const char ** string_list , int N) {
     if (string_list[i] != NULL)
       len += strlen(string_list[i]);
   }
-  buffer = util_calloc(len + 1 , sizeof * buffer );
+  buffer = (char*)util_calloc(len + 1 , sizeof * buffer );
   buffer[0] = '\0';
   for (i=0; i < N; i++) {
     if (string_list[i] != NULL)
@@ -3823,7 +3825,7 @@ char * util_alloc_joined_string(const char ** item_list , int len , const char *
 
     if (eff_len > 0) {
       total_length += (eff_len - 1) * sep_length + 1;
-      joined_string = util_calloc(total_length , sizeof * joined_string );
+      joined_string = (char*)util_calloc(total_length , sizeof * joined_string );
       joined_string[0] = '\0';
       for (i=0; i < len; i++) {
         if (item_list[i] != NULL) {
@@ -3846,7 +3848,7 @@ char * util_alloc_joined_string(const char ** item_list , int len , const char *
 */
 char * util_alloc_multiline_string(const char ** item_list , int len) {
   char * multiline_string = util_alloc_joined_string(item_list , len , UTIL_NEWLINE_STRING);
-  multiline_string = util_realloc(multiline_string , (strlen(multiline_string) + strlen(UTIL_NEWLINE_STRING) + 1) * sizeof * multiline_string );
+  multiline_string = (char*)util_realloc(multiline_string , (strlen(multiline_string) + strlen(UTIL_NEWLINE_STRING) + 1) * sizeof * multiline_string );
   strcat(multiline_string , UTIL_NEWLINE_STRING);
   return multiline_string;
 }
@@ -3878,7 +3880,7 @@ void util_split_string(const char *line , const char *sep_set, int *_tokens, cha
   } while (line[offset] != '\0');
 
   if (tokens > 0) {
-    token_list = util_calloc(tokens , sizeof * token_list );
+    token_list = (char**)util_calloc(tokens , sizeof * token_list );
     offset = strspn(line , sep_set);
     token  = 0;
     do {
@@ -4126,7 +4128,7 @@ int static util_string_replace_inplace__(char ** _buffer , const char * expr , c
         int    new_size      = size  + len_subs - len_expr;
         if (new_size >= (buffer_size - 1)) {
           buffer_size += buffer_size + 2*len_subs;
-          buffer = util_realloc( buffer , buffer_size );
+          buffer = (char*)util_realloc( buffer , buffer_size );
         }
         {
           char * target    = &buffer[target_offset];
@@ -4162,13 +4164,13 @@ int util_string_replace_inplace(char ** _buffer , const char * expr , const char
 char * util_string_replace_alloc(const char * buff_org, const char * expr, const char * subs)
 {
   int buffer_size   = strlen(buff_org) * 2;
-  char * new_buffer = util_calloc(buffer_size ,  sizeof * new_buffer );
+  char * new_buffer = (char*)util_calloc(buffer_size ,  sizeof * new_buffer );
   memcpy(new_buffer , buff_org , strlen(buff_org) + 1);
   util_string_replace_inplace__( &new_buffer , expr , subs);
 
   {
     int size = strlen(new_buffer);
-    new_buffer = util_realloc(new_buffer, (size + 1) * sizeof * new_buffer);
+    new_buffer = (char*)util_realloc(new_buffer, (size + 1) * sizeof * new_buffer);
   }
 
   return new_buffer;
@@ -4182,7 +4184,7 @@ char * util_string_replace_alloc(const char * buff_org, const char * expr, const
 char * util_string_replacen_alloc(const char * buff_org, int num_expr, const char ** expr, const char ** subs)
 {
   int buffer_size   = strlen(buff_org) * 2;
-  char * new_buffer = util_calloc(buffer_size , sizeof * new_buffer );
+  char * new_buffer = (char*)util_calloc(buffer_size , sizeof * new_buffer );
   memcpy(new_buffer , buff_org , strlen(buff_org) + 1);
   {
           int i;
@@ -4192,7 +4194,7 @@ char * util_string_replacen_alloc(const char * buff_org, int num_expr, const cha
 
   {
           int size = strlen(new_buffer);
-          new_buffer = util_realloc(new_buffer, (size + 1) * sizeof * new_buffer);
+          new_buffer = (char*)util_realloc(new_buffer, (size + 1) * sizeof * new_buffer);
   }
 
   return new_buffer;
@@ -4209,7 +4211,7 @@ char * util_string_strip_chars_alloc(const char * buff_org, const char * chars)
   int pos_org = 0;
   int pos_new = 0;
 
-  char * buff_new = util_calloc( (len_org +1) ,  sizeof * buff_new);
+  char * buff_new = (char*)util_calloc( (len_org +1) ,  sizeof * buff_new);
 
   while(pos_org < len_org)
   {
@@ -4228,7 +4230,7 @@ char * util_string_strip_chars_alloc(const char * buff_org, const char * chars)
     }
   }
   buff_new[pos_new + 1] = '\0';
-  buff_new = util_realloc(buff_new, (pos_new + 1) * sizeof buff_new);
+  buff_new = (char*)util_realloc(buff_new, (pos_new + 1) * sizeof buff_new);
 
   return buff_new;
 }
@@ -4289,10 +4291,10 @@ char * util_fread_alloc_string(FILE *stream) {
   char *s = NULL;
   util_fread(&len , sizeof len , 1 , stream , __func__);
   if (len > 0) {
-    s = util_calloc(len + 1 , sizeof * s );
+    s = (char*)util_calloc(len + 1 , sizeof * s );
     util_fread(s , 1 , len + 1 , stream , __func__);
   } else if (len == -1) /* Magic length for "" */ {
-    s = util_calloc(1 , sizeof * s );
+    s = (char*)util_calloc(1 , sizeof * s );
     util_fread(s , 1 , 1 , stream , __func__);
   }
   return s;
@@ -4304,10 +4306,10 @@ char * util_fread_realloc_string(char * old_s , FILE *stream) {
   char *s = NULL;
   util_fread(&len , sizeof len , 1 , stream , __func__);
   if (len > 0) {
-    s = util_realloc(old_s , len + 1 );
+    s = (char*)util_realloc(old_s , len + 1 );
     util_fread(s , 1 , len + 1 , stream , __func__);
   } else if (len == -1) /* Magic length for "" */ {
-    s = util_realloc(s , 1 );
+    s = (char*)util_realloc(s , 1 );
     util_fread(s , 1 , 1 , stream , __func__);
   }
   return s;
@@ -4501,7 +4503,7 @@ double util_double_vector_stddev(int N, const double * vector) {
   {
           double   stddev         = 0.0;
           double   mean           = util_double_vector_mean(N, vector);
-          double * vector_shifted = util_calloc(N , sizeof *vector_shifted);
+          double * vector_shifted = (double*)util_calloc(N , sizeof *vector_shifted);
 
           {
           int i;
@@ -4685,9 +4687,9 @@ void * util_alloc_copy(const void * src , size_t byte_size ) {
   if (byte_size == 0 && src == NULL)
     return NULL;
   {
-    void * new = util_malloc(byte_size );
-    memcpy(new , src , byte_size);
-    return new;
+    void * next = util_malloc(byte_size );
+    memcpy(next , src , byte_size);
+    return next;
   }
 }
 
@@ -4697,9 +4699,9 @@ void * util_realloc_copy(void * org_ptr , const void * src , size_t byte_size ) 
   if (byte_size == 0 && src == NULL)
     return util_realloc( org_ptr , 0 );
   {
-    void * new = util_realloc(org_ptr , byte_size );
-    memcpy(new , src , byte_size);
-    return new;
+    void * next = util_realloc(org_ptr , byte_size );
+    memcpy(next , src , byte_size);
+    return next;
   }
 }
 
@@ -4848,7 +4850,7 @@ char * util_alloc_sprintf_va(const char * fmt , va_list ap) {
   UTIL_VA_COPY(tmp_va , ap);
 
   length = vsnprintf(NULL , 0 , fmt , tmp_va);
-  s = util_calloc(length + 1 , sizeof * s );
+  s = (char*)util_calloc(length + 1 , sizeof * s );
   vsprintf(s , fmt , ap);
   return s;
 }
@@ -4873,7 +4875,7 @@ char * util_alloc_sprintf_escape(const char * src , int max_escape) {
 
   {
     const int src_len = strlen( src );
-    char * target = util_calloc( max_escape + strlen(src) + 1 , sizeof * target);
+    char * target = (char*)util_calloc( max_escape + strlen(src) + 1 , sizeof * target);
 
     int escape_count = 0;
     int src_offset = 0;
@@ -4894,7 +4896,7 @@ char * util_alloc_sprintf_escape(const char * src , int max_escape) {
         break;
     }
     target[target_offset] = '\0';
-    target = util_realloc( target , (target_offset + 1) * sizeof * target);
+    target = (char*)util_realloc( target , (target_offset + 1) * sizeof * target);
     return target;
   }
 }
@@ -5080,9 +5082,9 @@ const char * util_enum_iget( int index , int size , const util_enum_element_type
 }
 
 
-char * __abort_program_message = NULL;                      /* Can use util_abort_append_version_info() to fill this with
+static char * __abort_program_message = NULL;                  /* Can use util_abort_append_version_info() to fill this with
                                                                version info+++ wich will be printed when util_abort() is called. */
-char * __current_executable    = NULL;
+static char * __current_executable    = NULL;
 
 
 void util_abort_append_version_info(const char * msg) {
@@ -5244,7 +5246,7 @@ void util_make_path(const char *_path) {
 
   if (!util_is_directory(path)) {
     int i = 0;
-    active_path = util_calloc(strlen(path) + 1 , sizeof * active_path );
+    active_path = (char*)util_calloc(strlen(path) + 1 , sizeof * active_path );
     do {
       int n = strcspn(path , UTIL_PATH_SEP_STRING);
       if (n < strlen(path))
@@ -5311,7 +5313,7 @@ char * util_alloc_tmp_file(const char * path, const char * prefix , bool include
   int    pid            = 0;
 #endif
 
-  char * file           = util_calloc(strlen(path) + 1 + strlen(prefix) + 1 + pid_digits + 1 + random_digits + 1 , sizeof * file );
+  char * file           = (char*)util_calloc(strlen(path) + 1 + strlen(prefix) + 1 + pid_digits + 1 + random_digits + 1 , sizeof * file );
   char * tmp_prefix     = util_alloc_string_copy( prefix );
 
   if (!util_is_directory(path))
@@ -5350,7 +5352,7 @@ char * util_alloc_filename(const char * path , const char * basename , const cha
   if (extension != NULL)
     length += strlen(extension) + 1;
 
-  file = util_calloc(length , sizeof * file );
+  file = (char*)util_calloc(length , sizeof * file );
 
   if (path == NULL) {
     if (extension == NULL)
@@ -5455,7 +5457,7 @@ char * util_alloc_parent_path( const char * path) {
       int current_length = 4;
       int ip;
 
-      parent_path = util_realloc( parent_path , current_length * sizeof * parent_path);
+      parent_path = (char*)util_realloc( parent_path , current_length * sizeof * parent_path);
       parent_path[0] = '\0';
 
       for (ip=0; ip < path_ncomp - 1; ip++) {
@@ -5464,7 +5466,7 @@ char * util_alloc_parent_path( const char * path) {
 
         if (min_length >= current_length) {
           current_length = 2 * min_length;
-          parent_path = util_realloc( parent_path , current_length * sizeof * parent_path);
+          parent_path = (char*)util_realloc( parent_path , current_length * sizeof * parent_path);
         }
 
         if (is_abs || (ip > 0))

--- a/lib/util/util_abort_gnu.c
+++ b/lib/util/util_abort_gnu.c
@@ -34,6 +34,7 @@
 #include <string.h>
 
 #include <ert/util/util.h>
+#include <ert/util/test_util.h>
 
 #include <stdbool.h>
 
@@ -77,7 +78,7 @@ static bool util_addr2line_lookup__(const void * bt_addr , char ** func_name , c
         char *stdout_file = util_alloc_tmp_file("/tmp" , "addr2line" , true);
         /* 1: Run addr2line application */
         {
-          char ** argv = util_calloc(3 , sizeof * argv );
+          char ** argv = (char**)util_calloc(3 , sizeof * argv );
           argv[0] = util_alloc_string_copy("--functions");
           argv[1] = util_alloc_sprintf("--exe=%s" , executable );
           {
@@ -148,7 +149,7 @@ static pthread_mutex_t __abort_mutex  = PTHREAD_MUTEX_INITIALIZER; /* Used purel
 
 static char * realloc_padding(char * pad_ptr , int pad_length) {
   int i;
-  pad_ptr = util_realloc( pad_ptr , (pad_length + 1) * sizeof * pad_ptr );
+  pad_ptr = (char*)util_realloc( pad_ptr , (pad_length + 1) * sizeof * pad_ptr );
   for (i=0; i < pad_length; i++)
     pad_ptr[i] = ' ';
   pad_ptr[pad_length] = '\0';
@@ -243,8 +244,7 @@ void util_abort_test_set_intercept_function(const char * function) {
   intercept_function = util_realloc_string_copy( intercept_function , function );
 }
 
-char* __abort_program_message;
-char* __current_executable;
+static char* __abort_program_message;
 
 void util_abort__(const char * file , const char * function , int line , const char * fmt , ...) {
   util_abort_test_intercept( function );

--- a/lib/util/util_env.c
+++ b/lib/util/util_env.c
@@ -63,10 +63,10 @@ char ** util_alloc_PATH_list() {
     int     path_size;
     
     util_split_string(path_env , PATHVAR_SPLIT , &path_size , &path_list);
-    path_list = util_realloc( path_list , (path_size + 1) * sizeof * path_list);
+    path_list = (char**)util_realloc( path_list , (path_size + 1) * sizeof * path_list);
     path_list[path_size] = NULL;
   } else {
-    path_list = util_malloc( sizeof * path_list);
+    path_list = (char**)util_malloc( sizeof * path_list);
     path_list[0] = NULL;
   }
   return path_list;
@@ -238,7 +238,7 @@ char * util_alloc_envvar( const char * value ) {
     
     while (true) {
       if (buffer_strchr( buffer , '$')) {
-        const char * data = buffer_get_data( buffer );
+        const char * data = (const char*)buffer_get_data( buffer );
         int offset        = buffer_get_offset( buffer ) + 1;    /* Points at the first character following the '$' */
         int var_length = 0;
         
@@ -272,7 +272,7 @@ char * util_alloc_envvar( const char * value ) {
     
     buffer_shrink_to_fit( buffer );
     {
-      char * expanded_value = buffer_get_data( buffer );
+      char * expanded_value = (char*)buffer_get_data( buffer );
       buffer_free_container( buffer );
       return expanded_value;
     }

--- a/lib/util/util_spawn.c
+++ b/lib/util/util_spawn.c
@@ -62,7 +62,7 @@ static pthread_mutex_t spawn_mutex = PTHREAD_MUTEX_INITIALIZER;
 */
 pid_t util_spawn(const char *executable, int argc, const char **argv, const char *stdout_file, const char *stderr_file) {
   pid_t pid;
-  char **__argv = util_malloc((argc + 2) * sizeof *__argv);
+  char **__argv = (char**)util_malloc((argc + 2) * sizeof *__argv);
 
   {
     int iarg;
@@ -123,7 +123,8 @@ int util_spawn_blocking(const char *executable, int argc, const char **argv, con
 #define str(s) xstr(s)
 bool util_ping(const char *hostname) {
   int wait_status;
-  wait_status = util_spawn_blocking(str(PING_CMD), 4, (const char *[4]) {"-c" , "3" , "-q", hostname}, "/dev/null" , "/dev/null");
+  const char* args[ 4 ] = { "-c", "3", "-q", hostname };
+  wait_status = util_spawn_blocking(str(PING_CMD), 4, args, "/dev/null" , "/dev/null");
 
   if (WIFEXITED( wait_status )) {
       int ping_status = WEXITSTATUS( wait_status );

--- a/lib/util/util_symlink.c
+++ b/lib/util/util_symlink.c
@@ -70,7 +70,7 @@ char * util_alloc_link_target(const char * link) {
     int buffer_size = 256;
     char * target   = NULL;
     do {
-      target        = util_realloc(target , buffer_size );
+      target        = (char*)util_realloc(target , buffer_size );
       target_length = readlink(link , target , buffer_size);
       
       if (target_length == -1) 
@@ -83,7 +83,7 @@ char * util_alloc_link_target(const char * link) {
       
     } while (retry);
     target[target_length] = '\0';
-    target = util_realloc( target , strlen( target ) + 1 );   /* Shrink down to accurate size. */
+    target = (char*)util_realloc( target , strlen( target ) + 1 );   /* Shrink down to accurate size. */
     return target;
   } else
     return util_alloc_string_copy( link );
@@ -119,7 +119,7 @@ char * util_alloc_atlink_target(const char * path , const char * link) {
       int target_length;
       int buffer_size = 256;
       do {
-        target        = util_realloc(target , buffer_size );
+        target        = (char*)util_realloc(target , buffer_size );
         target_length = readlinkat( path_fd , link , target , buffer_size);
         
         if (target_length == -1) 
@@ -132,7 +132,7 @@ char * util_alloc_atlink_target(const char * path , const char * link) {
         
       } while (retry);
       target[target_length] = '\0';
-      target = util_realloc( target , strlen( target ) + 1 );   /* Shrink down to accurate size. */
+      target = (char*)util_realloc( target , strlen( target ) + 1 );   /* Shrink down to accurate size. */
     } 
     closedir( dir );
     return target;

--- a/lib/util/util_unlink.c
+++ b/lib/util/util_unlink.c
@@ -18,6 +18,8 @@
 
 #include "ert/util/build_config.h"
 
+#include <ert/util/util.h>
+
 #if defined(HAVE_WINDOWS_UNLINK)
 
 #include <io.h>

--- a/lib/util/util_zlib.c
+++ b/lib/util/util_zlib.c
@@ -18,7 +18,7 @@
 void util_compress_buffer(const void * data , int data_size , void * zbuffer , unsigned long * compressed_size) {
   int compress_result;
   if (data_size > 0) {
-    compress_result = compress(zbuffer , compressed_size , data , data_size);
+    compress_result = compress((Bytef*)zbuffer , compressed_size , (const Bytef*)data , data_size);
     /**
        Have some not reproducible "one-in-a-thousand" problems with
        the return value from compress. It seemingly randomly returns:
@@ -176,7 +176,7 @@ void util_fread_compressed(void *__data , FILE * stream) {
         util_abort("%s: read only %d/%d bytes from compressed file - aborting \n",__func__ , bytes_read , compressed_size);
       
     }
-    uncompress_result = uncompress(&data[offset] , &block_size , zbuffer , compressed_size);
+    uncompress_result = uncompress(&data[offset] , &block_size , (const Bytef*)zbuffer , compressed_size);
     if (uncompress_result != Z_OK) {
       fprintf(stderr,"%s: ** Warning uncompress result:%d != Z_OK.\n" , __func__ , uncompress_result);
       /**
@@ -217,7 +217,7 @@ void * util_fread_alloc_compressed(FILE * stream) {
     return NULL;
   else {
     util_fseek(stream , current_pos , SEEK_SET);
-    data = util_calloc(size , sizeof * data );
+    data = (char*)util_calloc(size , sizeof * data );
     util_fread_compressed(data , stream);
     return data;
   }

--- a/lib/util/vector.c
+++ b/lib/util/vector.c
@@ -59,7 +59,7 @@ static void vector_resize__(vector_type * vector, int new_alloc_size) {
       node_data_free( vector->data[i] );
   }
 
-  vector->data = util_realloc( vector->data , new_alloc_size * sizeof * vector->data );
+  vector->data = (node_data_type**)util_realloc( vector->data , new_alloc_size * sizeof * vector->data );
   for (i = vector->alloc_size; i < new_alloc_size; i++)
     vector->data[i] = NULL; /* Initialising new nodes to NULL */
 
@@ -69,7 +69,7 @@ static void vector_resize__(vector_type * vector, int new_alloc_size) {
 
 
 vector_type * vector_alloc_new() {
-  vector_type * vector = util_malloc( sizeof * vector );
+  vector_type * vector = (vector_type*)util_malloc( sizeof * vector );
   UTIL_TYPE_ID_INIT(vector , VECTOR_TYPE_ID);
   vector->size       = 0;
   vector->alloc_size = 0;
@@ -557,7 +557,7 @@ static int vector_cmp(const void * s1 , const void * s2) {
 
 
 static vector_sort_node_type * vector_alloc_sort_data( const vector_type * vector , vector_cmp_ftype * cmp) {
-  vector_sort_node_type * sort_data = util_calloc( vector->size , sizeof * sort_data );
+  vector_sort_node_type * sort_data = (vector_sort_node_type*)util_calloc( vector->size , sizeof * sort_data );
   int i;
 
   /* Fill up the temporary storage used for sorting */
@@ -598,7 +598,7 @@ int_vector_type * vector_alloc_sort_perm(const vector_type * vector , vector_cmp
 
 
 void vector_permute(vector_type * vector , const int_vector_type * perm_vector) {
-  node_data_type ** new_data = util_calloc( vector->size , sizeof * new_data );
+  node_data_type ** new_data = (node_data_type**)util_calloc( vector->size , sizeof * new_data );
   for (int index = 0; index < vector->size; index++) {
     int perm_index = int_vector_iget( perm_vector , index );
     new_data[index] = vector->data[ perm_index ];
@@ -611,7 +611,7 @@ void vector_permute(vector_type * vector , const int_vector_type * perm_vector) 
 
 void vector_inplace_reverse(vector_type * vector) {
   if (vector->size > 0) {
-    node_data_type ** new_data = util_calloc( vector->size , sizeof * new_data );
+    node_data_type ** new_data = (node_data_type**)util_calloc( vector->size , sizeof * new_data );
     int index;
     for (index = 0; index < vector->size; index++) {
       int rev_index = vector->size - 1 - index;

--- a/lib/util/vector_template.c
+++ b/lib/util/vector_template.c
@@ -141,7 +141,7 @@ static void @TYPE@_vector_realloc_data__(@TYPE@_vector_type * vector , int new_a
     if (vector->data_owner) {
       if (new_alloc_size > 0) {
         int i;
-        vector->data = util_realloc(vector->data , new_alloc_size * sizeof * vector->data );
+        vector->data = (@TYPE@*)util_realloc(vector->data , new_alloc_size * sizeof * vector->data );
         for (i=vector->alloc_size;  i < new_alloc_size; i++)
           vector->data[i] = vector->default_value;
       } else {
@@ -185,7 +185,7 @@ static void @TYPE@_vector_assert_index(const @TYPE@_vector_type * vector , int i
 
 
 static @TYPE@_vector_type * @TYPE@_vector_alloc__(int init_size , @TYPE@ default_value, @TYPE@ * data, int alloc_size , bool data_owner ) {
-  @TYPE@_vector_type * vector = util_malloc( sizeof * vector );
+  @TYPE@_vector_type * vector = (@TYPE@_vector_type*)util_malloc( sizeof * vector );
   UTIL_TYPE_ID_INIT( vector , TYPE_VECTOR_ID);
   vector->default_value       = default_value;
 
@@ -832,7 +832,7 @@ const @TYPE@ * @TYPE@_vector_get_const_ptr(const @TYPE@_vector_type * vector) {
 
 @TYPE@ * @TYPE@_vector_alloc_data_copy( const @TYPE@_vector_type * vector ) {
   int      size = vector->size * sizeof ( @TYPE@ );
-  @TYPE@ * copy = util_calloc(vector->size , sizeof * copy );
+  @TYPE@ * copy = (@TYPE@*)util_calloc(vector->size , sizeof * copy );
   if (copy != NULL)
     memcpy( copy , vector->data , size);
   return copy;
@@ -1216,8 +1216,8 @@ static int @TYPE@_vector_rcmp_node(const void *a, const void *b) {
 
 
 static perm_vector_type * @TYPE@_vector_alloc_sort_perm__(const @TYPE@_vector_type * vector, bool reverse) {
-  int * perm = util_calloc( vector->size , sizeof * perm ); // The perm_vector return value will take ownership of this array.
-  sort_node_type * sort_nodes = util_calloc( vector->size , sizeof * sort_nodes );
+  int * perm = (int*)util_calloc( vector->size , sizeof * perm ); // The perm_vector return value will take ownership of this array.
+  sort_node_type * sort_nodes = (sort_node_type*)util_calloc( vector->size , sizeof * sort_nodes );
   int i;
   for (i=0; i < vector->size; i++) {
     sort_nodes[i].index = i;
@@ -1250,7 +1250,7 @@ void @TYPE@_vector_permute(@TYPE@_vector_type * vector , const perm_vector_type 
   @TYPE@_vector_assert_writable( vector );
   {
     int i;
-    @TYPE@ * tmp = util_alloc_copy( vector->data , sizeof * tmp * vector->size );
+    @TYPE@ * tmp = (@TYPE@*)util_alloc_copy( vector->data , sizeof * tmp * vector->size );
     for (i=0; i < vector->size; i++)
       vector->data[i] = tmp[perm_vector_iget( perm , i )];
     free( tmp );


### PR DESCRIPTION
**Task**

Compile `util` with `g++`


**Approach**

Renamed all `util/*.c` files to `.cpp` and compiled with `g++`. Lots of errors, most of them crying about implicit `void*` casts.

As a consequence, some `extern C`s are added and fixed.

The patch isn't warning free with C++, but does compile and tests do work.


**Pre un-WIP checklist**
- [X] Statoil tests pass locally
