### PR TITLE
Index will be written with fortio_size

### DIFF
--- a/lib/ecl/ecl_file_kw.c
+++ b/lib/ecl/ecl_file_kw.c
@@ -348,7 +348,7 @@ void ecl_file_kw_fwrite( const ecl_file_kw_type * file_kw , FILE * stream ) {
   util_fwrite_int( file_kw->kw_size , stream );
   util_fwrite_offset( file_kw->file_offset , stream );
   util_fwrite_int( ecl_type_get_type( file_kw->data_type ) , stream );
-  util_fwrite_size_t( ecl_type_get_sizeof_ctype( file_kw->data_type ) , stream );
+  util_fwrite_size_t( ecl_type_get_sizeof_ctype_fortio( file_kw->data_type ) , stream );
 }
 
 ecl_file_kw_type ** ecl_file_kw_fread_alloc_multiple( FILE * stream , int num) {

--- a/python/tests/ecl/test_ecl_file.py
+++ b/python/tests/ecl/test_ecl_file.py
@@ -83,18 +83,23 @@ class EclFileTest(ExtendedTestCase):
         with TestAreaContext("python/ecl_file/context"):
             kw1 = EclKW( "KW1" , 100 , EclDataType.ECL_INT)
             kw2 = EclKW( "KW2" , 100 , EclDataType.ECL_FLOAT)
+            kw3 = EclKW( "KW3" , 100 , EclDataType.ECL_CHAR)
+            kw4 = EclKW( "KW4" , 100 , EclDataType.ECL_STRING(23))
             with openFortIO("TEST" , mode = FortIO.WRITE_MODE) as f:
                 kw1.fwrite( f )
                 kw2.fwrite( f )
+                kw3.fwrite( f )
+                kw4.fwrite( f )
 
             ecl_file = EclFile("TEST")
             ecl_file.write_index("INDEX_FILE")
             ecl_file.close()
 
             ecl_file_index = EclFile("TEST", 0, "INDEX_FILE")
-            self.assertTrue( ecl_file_index.has_kw("KW1") )
-            self.assertTrue( ecl_file_index.has_kw("KW2") )
-            
+            for kw in ["KW1","KW2","KW3","KW4"]:
+                self.assertIn( kw , ecl_file_index )
+
+
 
     def test_save_kw(self):
         with TestAreaContext("python/ecl_file/save_kw"):

--- a/python/tests/ecl/test_ecl_file_statoil.py
+++ b/python/tests/ecl/test_ecl_file_statoil.py
@@ -154,6 +154,17 @@ class EclFileStatoilTest(ExtendedTestCase):
         v = f.restartView( report_step = 30 )
         v = f.restartView( seqnum_index = 30 )
 
+
+    def test_index(self):
+        with TestAreaContext("python/ecl_file/truncated"):
+            f0 = EclFile( self.test_file )
+            f0.write_index( "index" )
+
+            f1 = EclFile( self.test_file , index_filename = "index")
+            for kw0,kw1 in zip(f0,f1):
+                self.assertEqual(kw0,kw1)
+
+
     def test_ix_case(self):
         f = EclFile( self.createTestPath( "Statoil/ECLIPSE/ix/summary/Create_Region_Around_Well.SMSPEC"))
 


### PR DESCRIPTION
**Task**
In the recent file_cache work the wrong function was used to write index size for character keywords.

**Approach**
Changed name of called function + added tests.

**Pre un-WIP checklist**
- [x] Statoil tests pass locally
