### PR TITLE
Windows : Use "rb" and "wb" as mode parameter strings for binary files

### DIFF
--- a/lib/ecl/ecl_file.c
+++ b/lib/ecl/ecl_file.c
@@ -1013,7 +1013,7 @@ bool ecl_file_index_valid(const char * file_name, const char * index_file_name) 
 }
 
 void  ecl_file_write_index( const ecl_file_type * ecl_file , const char * index_filename) {
-  FILE * ostream = util_fopen(index_filename , "w");
+  FILE * ostream = util_fopen(index_filename , "wb");
   util_fwrite_string( fortio_filename_ref(ecl_file->fortio) , ostream );
   ecl_file_view_write_index( ecl_file->global_view , ostream );
   fclose( ostream );
@@ -1024,7 +1024,7 @@ ecl_file_type * ecl_file_fast_open(const char * file_name, const char * index_fi
   if ( !ecl_file_index_valid(file_name, index_file_name)  )
     return NULL;
 
-  FILE * istream = util_fopen(index_file_name , "r");
+  FILE * istream = util_fopen(index_file_name , "rb");
   char * source_file = util_fread_alloc_string(istream);
 
   ecl_file_type * ecl_file = NULL;


### PR DESCRIPTION
**Task**
Write and read index file using binary file mode


**Approach**
Use "rb" and "wb" instead of "r" and "w"

