### PR TITLE
Some changes to ecl file index

### DIFF
--- a/lib/include/ert/ecl/ecl_file.h
+++ b/lib/include/ert/ecl/ecl_file.h
@@ -48,7 +48,7 @@ extern "C" {
   bool             ecl_file_load_all( ecl_file_type * ecl_file );
   ecl_file_type  * ecl_file_open( const char * filename , int flags);
   ecl_file_type  * ecl_file_fast_open( const char * filename , const char * index_filename , int flags);
-  void             ecl_file_write_index( const ecl_file_type * ecl_file , const char * index_filename);
+  bool             ecl_file_write_index( const ecl_file_type * ecl_file , const char * index_filename);
   bool             ecl_file_index_valid(const char * file_name, const char * index_file_name);
   void             ecl_file_close( ecl_file_type * ecl_file );
   void             ecl_file_fortio_detach( ecl_file_type * ecl_file );

--- a/python/python/ecl/ecl/ecl_file.py
+++ b/python/python/ecl/ecl/ecl_file.py
@@ -62,7 +62,7 @@ class EclFile(BaseCClass):
     _has_report_step             = EclPrototype("bool        ecl_file_has_report_step( ecl_file , int)")
     _has_sim_time                = EclPrototype("bool        ecl_file_has_sim_time( ecl_file , time_t )")
     _get_global_view             = EclPrototype("ecl_file_view_ref ecl_file_get_global_view( ecl_file )")
-    _write_index                 = EclPrototype("void        ecl_file_write_index( ecl_file , char*)")
+    _write_index                 = EclPrototype("bool        ecl_file_write_index( ecl_file , char*)")
     _fast_open                   = EclPrototype("void*       ecl_file_fast_open( char* , char* , int )" , bind=False)
 
 
@@ -208,6 +208,7 @@ class EclFile(BaseCClass):
             c_ptr = self._open( filename , flags )
         else:
             c_ptr = self._fast_open(filename, index_filename, flags)
+
         if c_ptr is None:
             raise IOError('Failed to open file "%s"' % filename)
         else:
@@ -684,7 +685,8 @@ class EclFile(BaseCClass):
         self._fwrite(  fortio , 0 )
 
     def write_index(self, index_file_name):
-        self._write_index(index_file_name)
+        if not self._write_index(index_file_name):
+            raise IOError("Failed to write index file:%s" % index_file_name)
 
 
 class EclFileContextManager(object):

--- a/python/python/ecl/test/path_context.py
+++ b/python/python/ecl/test/path_context.py
@@ -7,7 +7,7 @@ class PathContext(object):
         self.cwd = os.getcwd()
         self.store = store
         self.path_list = [ ]
-        
+
         if not os.path.exists(path):
             work_path = path
 
@@ -27,8 +27,8 @@ class PathContext(object):
                 raise OSError("Entry %s already exists" % path)
         os.chdir( path )
 
-            
-        
+
+
     def __exit__(self , exc_type , exc_val , exc_tb):
         os.chdir( self.cwd )
         if self.store == False:
@@ -38,9 +38,9 @@ class PathContext(object):
                     os.rmdir( path )
                 except OSError:
                     break
-            
+
         return False
 
-    
+
     def __enter__(self):
         return self

--- a/python/python/ecl/util/CMakeLists.txt
+++ b/python/python/ecl/util/CMakeLists.txt
@@ -25,6 +25,7 @@ set(PYTHON_SOURCES
     version.py
     arg_pack.py
     path_format.py
+    cwd_context.py
 )
 
 add_python_package("python.ecl.util"  ${PYTHON_INSTALL_PREFIX}/ecl/util "${PYTHON_SOURCES}" True)

--- a/python/python/ecl/util/__init__.py
+++ b/python/python/ecl/util/__init__.py
@@ -78,7 +78,7 @@ from .install_abort_signals import installAbortSignals, updateAbortSignals
 from .profiler import Profiler
 from .arg_pack import ArgPack
 from .path_format import PathFormat
-
+from .cwd_context import CWDContext
 
 
 

--- a/python/python/ecl/util/cwd_context.py
+++ b/python/python/ecl/util/cwd_context.py
@@ -1,0 +1,16 @@
+import os
+
+class CWDContext(object):
+    def __init__(self , path):
+        self.cwd = os.getcwd()
+        if os.path.isdir( path ):
+            os.chdir( path )
+        else:
+            raise IOError("Path:%s does not exist" % path)
+
+    def __exit__(self , exc_type , exc_val , exc_tb):
+        os.chdir( self.cwd )
+        return False
+
+    def __enter__(self):
+        return self

--- a/python/tests/ecl/test_ecl_file_statoil.py
+++ b/python/tests/ecl/test_ecl_file_statoil.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python
-#  Copyright (C) 2011  Statoil ASA, Norway. 
-#   
-#  The file 'sum_test.py' is part of ERT - Ensemble based Reservoir Tool. 
-#   
-#  ERT is free software: you can redistribute it and/or modify 
-#  it under the terms of the GNU General Public License as published by 
-#  the Free Software Foundation, either version 3 of the License, or 
-#  (at your option) any later version. 
-#   
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-#  FITNESS FOR A PARTICULAR PURPOSE.   
-#   
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+#  Copyright (C) 2011  Statoil ASA, Norway.
+#
+#  The file 'sum_test.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 import datetime
 import os.path
@@ -24,7 +24,7 @@ from ecl.ecl import EclFileFlagEnum, EclFileEnum
 from ecl.test import ExtendedTestCase , TestAreaContext
 
 
-    
+
 
 class EclFileStatoilTest(ExtendedTestCase):
     def setUp(self):
@@ -58,8 +58,8 @@ class EclFileStatoilTest(ExtendedTestCase):
 
         with self.assertRaises(IndexError):
             rst_file.restart_get_kw("SWAT" , dtime = datetime.date( 1985 , 1 , 1))
-            
-            
+
+
 
     def test_iget_named(self):
         f = EclFile(self.test_file)
@@ -145,13 +145,13 @@ class EclFileStatoilTest(ExtendedTestCase):
             size = os.path.getsize("ECLIPSE.UNRST")
             with open("ECLIPSE.UNRST" , "r+") as f:
                 f.truncate( size / 2 )
-            
+
             with self.assertRaises(IOError):
                 rst_file = EclFile("ECLIPSE.UNRST")
 
             with self.assertRaises(IOError):
                 rst_file = EclFile("ECLIPSE.UNRST", flags=EclFileFlagEnum.ECL_FILE_WRITABLE)
-                
+
     def test_restart_view(self):
         f = EclFile( self.test_file )
         with self.assertRaises(ValueError):

--- a/python/tests/ecl/test_ecl_file_statoil.py
+++ b/python/tests/ecl/test_ecl_file_statoil.py
@@ -37,8 +37,16 @@ class EclFileStatoilTest(ExtendedTestCase):
         self.assertEqual( fmt_file , expected[1] )
         self.assertEqual( step , expected[2] )
 
-        
-        
+
+    def test_fast_open(self):
+        with TestAreaContext("index"):
+            f0 = EclFile( self.test_file )
+            f0.write_index("index")
+            f1 = EclFile( self.test_file , 0 , "index")
+            for kw0,kw1 in zip(f0,f1):
+                self.assertEqual( kw0,kw1 )
+
+
     def test_restart_days(self):
         rst_file = EclFile( self.test_file )
         self.assertAlmostEqual(  0.0 , rst_file.iget_restart_sim_days(0) )


### PR DESCRIPTION
**Task**
- All `fopen()` calls are properly checked. 
- The index file only contains the base filename, no path.



**Pre un-WIP checklist**
- [x] Statoil tests pass locally
