### PR TITLE
Remove well_state warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ functionality.
 *libecl* uses CMake as build system:
 
 ```bash
-git clone https://github.com/Statoil/*libecl*.git
-cd *libecl*
+git clone https://github.com/Statoil/libecl.git
+cd libecl
 mkdir build
 cd build
 cmake ..

--- a/lib/ecl/tests/well_lgr_load.c
+++ b/lib/ecl/tests/well_lgr_load.c
@@ -51,15 +51,9 @@ int main( int argc , char ** argv) {
     well_info_load_rstfile( well_info , argv[2] , true);
 
     // List all wells:
-    {
-      int iwell;
-      for (iwell = 0; iwell < well_info_get_num_wells( well_info ); iwell++) {
-        well_ts_type * well_ts = well_info_get_ts( well_info , well_info_iget_well_name( well_info , iwell));
-        well_state_type * well_state = well_ts_get_last_state( well_ts );
-        
-        well_state_summarize( well_state , stdout );
-        printf("\n");
-      }
+    for (int iwell = 0; iwell < well_info_get_num_wells( well_info ); iwell++) {
+      well_ts_type * well_ts = well_info_get_ts( well_info , well_info_iget_well_name( well_info , iwell));
+      well_state_type * well_state = well_ts_get_last_state( well_ts );
     }
     well_info_free( well_info );
   }

--- a/lib/ecl/tests/well_lgr_load.c
+++ b/lib/ecl/tests/well_lgr_load.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2013  Statoil ASA, Norway. 
-    
-   The file 'well_lgr_load.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2013  Statoil ASA, Norway.
+
+   The file 'well_lgr_load.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #include <time.h>
@@ -36,16 +36,20 @@
 
 
 int main( int argc , char ** argv) {
-  signal(SIGSEGV , util_abort_signal);    /* Segmentation violation, i.e. overwriting memory ... */
-  signal(SIGTERM , util_abort_signal);    /* If killing the enkf program with SIGTERM (the default kill signal) you will get a backtrace. 
-                                             Killing with SIGKILL (-9) will not give a backtrace.*/
-  signal(SIGABRT , util_abort_signal);    /* Signal abort. */ 
+  signal(SIGSEGV , util_abort_signal);    /* Segmentation violation,
+                                             i.e. overwriting memory ... */
+  signal(SIGTERM , util_abort_signal);    /* If killing the enkf program with
+                                             SIGTERM (the default kill signal)
+                                             you will get a backtrace.  Killing
+                                             with SIGKILL (-9) will not give a
+                                             backtrace.*/
+  signal(SIGABRT , util_abort_signal);    /* Signal abort. */
   {
     ecl_grid_type * grid = ecl_grid_alloc( argv[1] );
     well_info_type * well_info = well_info_alloc( grid );
 
     well_info_load_rstfile( well_info , argv[2] , true);
-    
+
     // List all wells:
     {
       int iwell;
@@ -59,6 +63,6 @@ int main( int argc , char ** argv) {
     }
     well_info_free( well_info );
   }
-  
+
   exit(0);
 }

--- a/lib/ecl/well_state.c
+++ b/lib/ecl/well_state.c
@@ -438,7 +438,9 @@ static void well_state_add_global_connections( well_state_type * well_state ,
   well_state_add_connections__( well_state , rst_view , ECL_GRID_GLOBAL_GRID , 0 , well_nr );
 }
 
-static void well_state_add_LGR_connections( well_state_type * well_state , const ecl_grid_type * grid , ecl_file_view_type * file_view , int global_well_nr ) {
+static void well_state_add_LGR_connections(well_state_type * well_state,
+                                           const ecl_grid_type * grid,
+                                           ecl_file_view_type * file_view) {
   // Go through all the LGRs and add connections; both in the bulk
   // grid and as wellhead.
 
@@ -470,7 +472,7 @@ void well_state_add_connections2( well_state_type * well_state ,
                                  int well_nr) {
 
   well_state_add_global_connections( well_state , rst_view , well_nr );
-  well_state_add_LGR_connections( well_state , grid , rst_view , well_nr );
+  well_state_add_LGR_connections( well_state , grid , rst_view);
 
 }
 
@@ -667,10 +669,6 @@ const char * well_state_get_name( const well_state_type * well_state ) {
 
 
 /*****************************************************************/
-
-void well_state_summarize( const well_state_type * well_state , FILE * stream ) {
-}
-
 
 const well_conn_collection_type * well_state_get_grid_connections( const well_state_type * well_state , const char * grid_name) {
   if (hash_has_key( well_state->connections , grid_name))

--- a/lib/ecl/well_state.c
+++ b/lib/ecl/well_state.c
@@ -443,8 +443,7 @@ static void well_state_add_LGR_connections( well_state_type * well_state , const
   // grid and as wellhead.
 
   int num_lgr = ecl_grid_get_num_lgr( grid );
-  int lgr_index;
-  for (lgr_index = 0; lgr_index < num_lgr; lgr_index++) {
+  for (int lgr_index = 0; lgr_index < num_lgr; lgr_index++) {
     ecl_file_view_type * lgr_view = ecl_file_view_add_blockview(file_view , LGR_KW , lgr_index);
     const char * grid_name = ecl_grid_iget_lgr_name( grid , lgr_index );
     int well_nr = well_state_get_lgr_well_nr( well_state , lgr_view );
@@ -707,4 +706,3 @@ well_segment_collection_type * well_state_get_segments( const well_state_type * 
 well_branch_collection_type * well_state_get_branches( const well_state_type * well_state ) {
   return well_state->branches;
 }
-

--- a/lib/include/ert/ecl_well/well_state.h
+++ b/lib/include/ert/ecl_well/well_state.h
@@ -85,8 +85,7 @@ extern "C" {
   const well_conn_type * well_state_get_global_wellhead( const well_state_type * well_state );
   const well_conn_type * well_state_iget_wellhead( const well_state_type * well_state , int grid_nr);
   const well_conn_type * well_state_get_wellhead( const well_state_type * well_state , const char * grid_name);
-  
-  void                    well_state_summarize( const well_state_type * well_state , FILE * stream );
+
   well_type_enum          well_state_translate_ecl_type_int(int int_type);
 
   const well_conn_collection_type * well_state_get_grid_connections( const well_state_type * well_state , const char * grid_name);

--- a/lib/include/ert/ecl_well/well_state.h
+++ b/lib/include/ert/ecl_well/well_state.h
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2011  Statoil ASA, Norway. 
-    
-   The file 'well_state.h' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'well_state.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 
@@ -26,7 +26,7 @@ extern "C" {
 
 #include <time.h>
 
-#include <ert/ecl/ecl_file.h> 
+#include <ert/ecl/ecl_file.h>
 #include <ert/ecl/ecl_grid.h>
 
 #include <ert/ecl_well/well_conn.h>
@@ -49,13 +49,13 @@ extern "C" {
                                     ecl_file_view_type * rst_view ,
                                     int well_nr);
 
-  void well_state_add_connections( well_state_type * well_state , 
-                                   const ecl_grid_type * grid , 
-                                   ecl_file_type * rst_file ,  
+  void well_state_add_connections( well_state_type * well_state ,
+                                   const ecl_grid_type * grid ,
+                                   ecl_file_type * rst_file ,
                                    int well_nr);
 
-  bool well_state_add_MSW( well_state_type * well_state , 
-                           ecl_file_type * rst_file , 
+  bool well_state_add_MSW( well_state_type * well_state ,
+                           ecl_file_type * rst_file ,
                            int  well_nr,
                            bool load_segment_information);
 
@@ -79,7 +79,7 @@ extern "C" {
   int                    well_state_get_report_nr( const well_state_type * well_state );
   time_t                 well_state_get_sim_time( const well_state_type * well_state );
   well_type_enum         well_state_get_type( const well_state_type * well_state);
-  bool                   well_state_is_open( const well_state_type * well_state );   
+  bool                   well_state_is_open( const well_state_type * well_state );
   int                    well_state_get_well_nr( const well_state_type * well_state );
 
   const well_conn_type * well_state_get_global_wellhead( const well_state_type * well_state );
@@ -99,9 +99,9 @@ extern "C" {
   double well_state_get_water_rate( const well_state_type * well_state);
   double well_state_get_volume_rate( const well_state_type * well_state);
 
-  
+
   UTIL_IS_INSTANCE_HEADER( well_state );
-  
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
**Task**
Function had unused argument `well_nr`:
```
well_state_add_LGR_connections( well_state , grid , rst_view)
```

Function body was empty and therefore had unused arguments, removed function:
```
void well_state_summarize( const well_state_type * well_state , FILE * stream )
```

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
