### PR TITLE
WIP: Ecl big file

### DIFF
--- a/lib/ecl/ecl_file.c
+++ b/lib/ecl/ecl_file.c
@@ -415,6 +415,10 @@ ecl_file_kw_type * ecl_file_iget_named_file_kw( const ecl_file_type * file , con
 
 /* ---- */
 
+ecl_kw_type * ecl_file_alloc_kw( const ecl_file_type * file , int global_index) {
+  return ecl_file_view_alloc_kw( file->active_view , global_index );
+}
+
 ecl_kw_type * ecl_file_iget_kw( const ecl_file_type * file , int global_index) {
   return ecl_file_view_iget_kw( file->active_view , global_index);
 }

--- a/lib/ecl/ecl_file.c
+++ b/lib/ecl/ecl_file.c
@@ -443,6 +443,10 @@ const char * ecl_file_iget_header( const ecl_file_type * file , int global_index
    query functions if you can not take that.
 */
 
+ecl_kw_type * ecl_file_alloc_named_kw( const ecl_file_type * file , const char * kw, int ith) {
+  return ecl_file_view_alloc_named_kw( file->active_view, kw, ith);
+}
+
 ecl_kw_type * ecl_file_iget_named_kw( const ecl_file_type * file , const char * kw, int ith) {
   return ecl_file_view_iget_named_kw( file->active_view , kw , ith);
 }

--- a/lib/ecl/ecl_file_kw.c
+++ b/lib/ecl/ecl_file_kw.c
@@ -244,6 +244,14 @@ static void ecl_file_kw_load_kw( ecl_file_kw_type * file_kw , fortio_type * fort
   }
 }
 
+ecl_kw_type * ecl_file_kw_alloc_kw( ecl_file_kw_type * file_kw, fortio_type * fortio) {
+  if (fortio == NULL)
+    util_abort("%s: trying to load a keyword after the backing file has been detached.\n",__func__);
+
+  fortio_fseek( fortio , file_kw->file_offset , SEEK_SET );
+  return ecl_kw_fread_alloc( fortio );   
+}
+
 ecl_kw_type * ecl_file_kw_get_kw_ptr( ecl_file_kw_type * file_kw , fortio_type * fortio , inv_map_type * inv_map ) {
   return file_kw->kw;
 }

--- a/lib/ecl/ecl_file_kw.c
+++ b/lib/ecl/ecl_file_kw.c
@@ -244,7 +244,7 @@ static void ecl_file_kw_load_kw( ecl_file_kw_type * file_kw , fortio_type * fort
   }
 }
 
-ecl_kw_type * ecl_file_kw_alloc_kw( ecl_file_kw_type * file_kw, fortio_type * fortio) {
+ecl_kw_type * ecl_file_kw_alloc_kw( const ecl_file_kw_type * file_kw, fortio_type * fortio) {
   if (fortio == NULL)
     util_abort("%s: trying to load a keyword after the backing file has been detached.\n",__func__);
 

--- a/lib/ecl/ecl_file_kw.c
+++ b/lib/ecl/ecl_file_kw.c
@@ -245,11 +245,16 @@ static void ecl_file_kw_load_kw( ecl_file_kw_type * file_kw , fortio_type * fort
 }
 
 ecl_kw_type * ecl_file_kw_alloc_kw( const ecl_file_kw_type * file_kw, fortio_type * fortio) {
-  if (fortio == NULL)
-    util_abort("%s: trying to load a keyword after the backing file has been detached.\n",__func__);
+  if (file_kw->kw) {
+    return ecl_kw_alloc_copy(file_kw->kw);
+  }
+  else { 
+    if (fortio == NULL)
+      util_abort("%s: trying to load a keyword after the backing file has been detached.\n",__func__);
 
-  fortio_fseek( fortio , file_kw->file_offset , SEEK_SET );
-  return ecl_kw_fread_alloc( fortio );   
+    fortio_fseek( fortio , file_kw->file_offset , SEEK_SET );
+    return ecl_kw_fread_alloc( fortio );   
+  }
 }
 
 ecl_kw_type * ecl_file_kw_get_kw_ptr( ecl_file_kw_type * file_kw , fortio_type * fortio , inv_map_type * inv_map ) {

--- a/lib/ecl/ecl_file_view.c
+++ b/lib/ecl/ecl_file_view.c
@@ -147,16 +147,19 @@ void ecl_file_view_add_flag( ecl_file_view_type * file_view , int flag)  {
 }
 
 
+ecl_kw_type * ecl_file_view_alloc_kw( const ecl_file_view_type * ecl_file_view , int index) {
+  ecl_file_kw_type * file_kw = ecl_file_view_iget_file_kw( ecl_file_view , index );
+  return ecl_file_kw_alloc_kw( file_kw, ecl_file_view->fortio );
+}
+
 ecl_kw_type * ecl_file_view_iget_kw( const ecl_file_view_type * ecl_file_view , int index) {
   ecl_file_kw_type * file_kw = ecl_file_view_iget_file_kw( ecl_file_view , index );
   ecl_kw_type * ecl_kw = ecl_file_kw_get_kw_ptr( file_kw , ecl_file_view->fortio , ecl_file_view->inv_map);
-  printf(" *******************' %s: ### 1\n", __func__);
   if (!ecl_kw) {
-    printf(" *******************' %s: ### 2\n", __func__);
     if (fortio_assert_stream_open( ecl_file_view->fortio )) {
 
       if (ecl_file_view_flags_set( ecl_file_view , ECL_FILE_RETURN_COPY ) )
-        ecl_kw = ecl_kw_fread_alloc( ecl_file_view->fortio );
+        ecl_kw = ecl_file_kw_alloc_kw( file_kw, ecl_file_view->fortio );
       else
         ecl_kw = ecl_file_kw_get_kw( file_kw , ecl_file_view->fortio , ecl_file_view->inv_map);
 

--- a/lib/ecl/ecl_file_view.c
+++ b/lib/ecl/ecl_file_view.c
@@ -152,8 +152,7 @@ ecl_kw_type * ecl_file_view_alloc_kw( const ecl_file_view_type * ecl_file_view ,
   return ecl_file_kw_alloc_kw( file_kw, ecl_file_view->fortio );
 }
 
-ecl_kw_type * ecl_file_view_iget_kw( const ecl_file_view_type * ecl_file_view , int index) {
-  ecl_file_kw_type * file_kw = ecl_file_view_iget_file_kw( ecl_file_view , index );
+static ecl_kw_type * ecl_file_view_get_kw(ecl_file_view_type * ecl_file_view, ecl_file_kw_type * file_kw) {
   ecl_kw_type * ecl_kw = ecl_file_kw_get_kw_ptr( file_kw , ecl_file_view->fortio , ecl_file_view->inv_map);
   if (!ecl_kw) {
     if (fortio_assert_stream_open( ecl_file_view->fortio )) {
@@ -168,6 +167,11 @@ ecl_kw_type * ecl_file_view_iget_kw( const ecl_file_view_type * ecl_file_view , 
     }
   }
   return ecl_kw;
+}
+
+ecl_kw_type * ecl_file_view_iget_kw( const ecl_file_view_type * ecl_file_view , int index) {
+  ecl_file_kw_type * file_kw = ecl_file_view_iget_file_kw( ecl_file_view , index );
+  return ecl_file_view_get_kw(ecl_file_view, file_kw);
 }
 
 void ecl_file_view_index_fload_kw(const ecl_file_view_type * ecl_file_view, const char* kw, int index, const int_vector_type * index_map, char* buffer) {
@@ -237,20 +241,7 @@ ecl_kw_type * ecl_file_view_alloc_named_kw( const ecl_file_view_type * ecl_file_
 
 ecl_kw_type * ecl_file_view_iget_named_kw( const ecl_file_view_type * ecl_file_view , const char * kw, int ith) {
   ecl_file_kw_type * file_kw = ecl_file_view_iget_named_file_kw( ecl_file_view , kw , ith);
-  ecl_kw_type * ecl_kw = ecl_file_kw_get_kw_ptr( file_kw , ecl_file_view->fortio , ecl_file_view->inv_map );
-  if (!ecl_kw) {
-    if (fortio_assert_stream_open( ecl_file_view->fortio )) {
-
-      if (ecl_file_view_flags_set( ecl_file_view , ECL_FILE_RETURN_COPY ) )
-        ecl_kw = ecl_file_kw_alloc_kw( file_kw, ecl_file_view->fortio );
-      else
-        ecl_kw = ecl_file_kw_get_kw( file_kw , ecl_file_view->fortio , ecl_file_view->inv_map);
-
-      if (ecl_file_view_flags_set( ecl_file_view , ECL_FILE_CLOSE_STREAM))
-        fortio_fclose_stream( ecl_file_view->fortio );
-    }
-  }
-  return ecl_kw;
+  return ecl_file_view_get_kw(ecl_file_view, file_kw);
 }
 
 ecl_data_type ecl_file_view_iget_named_data_type( const ecl_file_view_type * ecl_file_view , const char * kw , int ith) {

--- a/lib/ecl/ecl_file_view.c
+++ b/lib/ecl/ecl_file_view.c
@@ -150,10 +150,15 @@ void ecl_file_view_add_flag( ecl_file_view_type * file_view , int flag)  {
 ecl_kw_type * ecl_file_view_iget_kw( const ecl_file_view_type * ecl_file_view , int index) {
   ecl_file_kw_type * file_kw = ecl_file_view_iget_file_kw( ecl_file_view , index );
   ecl_kw_type * ecl_kw = ecl_file_kw_get_kw_ptr( file_kw , ecl_file_view->fortio , ecl_file_view->inv_map);
+  printf(" *******************' %s: ### 1\n", __func__);
   if (!ecl_kw) {
+    printf(" *******************' %s: ### 2\n", __func__);
     if (fortio_assert_stream_open( ecl_file_view->fortio )) {
 
-      ecl_kw = ecl_file_kw_get_kw( file_kw , ecl_file_view->fortio , ecl_file_view->inv_map);
+      if (ecl_file_view_flags_set( ecl_file_view , ECL_FILE_RETURN_COPY ) )
+        ecl_kw = ecl_kw_fread_alloc( ecl_file_view->fortio );
+      else
+        ecl_kw = ecl_file_kw_get_kw( file_kw , ecl_file_view->fortio , ecl_file_view->inv_map);
 
       if (ecl_file_view_flags_set( ecl_file_view , ECL_FILE_CLOSE_STREAM))
         fortio_fclose_stream( ecl_file_view->fortio );

--- a/lib/ecl/ecl_file_view.c
+++ b/lib/ecl/ecl_file_view.c
@@ -229,13 +229,22 @@ const char * ecl_file_view_iget_header( const ecl_file_view_type * ecl_file_view
 }
 
 
+ecl_kw_type * ecl_file_view_alloc_named_kw( const ecl_file_view_type * ecl_file_view, const char * kw, int ith) {
+  ecl_file_kw_type * file_kw = ecl_file_view_iget_named_file_kw( ecl_file_view , kw , ith);
+  return ecl_file_kw_alloc_kw( file_kw, ecl_file_view->fortio );
+}
+
+
 ecl_kw_type * ecl_file_view_iget_named_kw( const ecl_file_view_type * ecl_file_view , const char * kw, int ith) {
   ecl_file_kw_type * file_kw = ecl_file_view_iget_named_file_kw( ecl_file_view , kw , ith);
   ecl_kw_type * ecl_kw = ecl_file_kw_get_kw_ptr( file_kw , ecl_file_view->fortio , ecl_file_view->inv_map );
   if (!ecl_kw) {
     if (fortio_assert_stream_open( ecl_file_view->fortio )) {
 
-      ecl_kw = ecl_file_kw_get_kw( file_kw , ecl_file_view->fortio , ecl_file_view->inv_map);
+      if (ecl_file_view_flags_set( ecl_file_view , ECL_FILE_RETURN_COPY ) )
+        ecl_kw = ecl_file_kw_alloc_kw( file_kw, ecl_file_view->fortio );
+      else
+        ecl_kw = ecl_file_kw_get_kw( file_kw , ecl_file_view->fortio , ecl_file_view->inv_map);
 
       if (ecl_file_view_flags_set( ecl_file_view , ECL_FILE_CLOSE_STREAM))
         fortio_fclose_stream( ecl_file_view->fortio );

--- a/lib/ecl/tests/ecl_file.c
+++ b/lib/ecl/tests/ecl_file.c
@@ -114,13 +114,14 @@ void test_return_copy() {
     ecl_kw_type * kw1_copy = ecl_file_iget_kw( ecl_file , 0 );
     ecl_kw_type * kw2_copy = ecl_file_iget_kw( ecl_file , 1 );
 
-    test_assert_NULL(kw1_copy);
-    //printf(" ******** %s: kw_size: %d\n", ecl_kw_get_size( kw1_copy ));
-    ecl_file_close( ecl_file ); 
+    ecl_file_close( ecl_file );
 
-    //test_assert_true (ecl_kw_equal(kw1, kw1_copy));
-    //test_assert_true (ecl_kw_equal(kw2, kw2_copy));
-    
+    test_assert_true (ecl_kw_equal(kw1, kw1_copy));
+    test_assert_true (ecl_kw_equal(kw2, kw2_copy));
+    ecl_kw_free(kw1);
+    ecl_kw_free(kw2);
+    ecl_kw_free(kw1_copy);
+    ecl_kw_free(kw2_copy);
   }
   test_work_area_free( work_area );
 
@@ -128,9 +129,9 @@ void test_return_copy() {
 
 int main( int argc , char ** argv) {
   util_install_signals();
-  //test_writable(10);
-  //test_writable(1337);
-  //test_truncated();
+  test_writable(10);
+  test_writable(1337);
+  test_truncated();
   test_return_copy();
   exit(0);
 }

--- a/lib/ecl/tests/ecl_file.c
+++ b/lib/ecl/tests/ecl_file.c
@@ -83,10 +83,54 @@ void test_truncated() {
   test_work_area_free( work_area );
 }
 
+void test_return_copy() {
+  // create some dummy kws
+  // create a dummy file w the kws
+  // open ecl_file in RETURN_COPY mode
+  // extract kws from the file, using ecl_file_get_kw
+  // close ecl_file thus destroying kws within ecl_file
+  // assert correct values in kws
+  test_work_area_type * work_area = test_work_area_alloc("ecl_file_RETURN_COPY_testing");
+  {
+    char * file_name = "data_file";
+
+    //creating the data file
+    size_t data_size = 10;
+    ecl_kw_type * kw1 = ecl_kw_alloc("TEST1_KW", data_size, ECL_INT);
+    for(int i = 0; i < data_size; ++i)
+       ecl_kw_iset_int(kw1, i, 537 + i);
+    fortio_type * fortio = fortio_open_writer(file_name, false, ECL_ENDIAN_FLIP);
+    ecl_kw_fwrite(kw1, fortio); 
+   
+    data_size = 5;
+    ecl_kw_type * kw2 = ecl_kw_alloc("TEST2_KW", data_size, ECL_FLOAT);
+    for(int i = 0; i < data_size; ++i)
+      ecl_kw_iset_float(kw2, i, 0.15 * i);
+    ecl_kw_fwrite(kw2, fortio);
+    fortio_fclose(fortio); 
+    //finished creating data file
+
+    ecl_file_type * ecl_file = ecl_file_open(file_name, ECL_FILE_RETURN_COPY);
+    ecl_kw_type * kw1_copy = ecl_file_iget_kw( ecl_file , 0 );
+    ecl_kw_type * kw2_copy = ecl_file_iget_kw( ecl_file , 1 );
+
+    test_assert_NULL(kw1_copy);
+    //printf(" ******** %s: kw_size: %d\n", ecl_kw_get_size( kw1_copy ));
+    ecl_file_close( ecl_file ); 
+
+    //test_assert_true (ecl_kw_equal(kw1, kw1_copy));
+    //test_assert_true (ecl_kw_equal(kw2, kw2_copy));
+    
+  }
+  test_work_area_free( work_area );
+
+}
 
 int main( int argc , char ** argv) {
-  test_writable(10);
-  test_writable(1337);
-  test_truncated();
+  util_install_signals();
+  //test_writable(10);
+  //test_writable(1337);
+  //test_truncated();
+  test_return_copy();
   exit(0);
 }

--- a/lib/ecl/tests/ecl_file.c
+++ b/lib/ecl/tests/ecl_file.c
@@ -84,12 +84,6 @@ void test_truncated() {
 }
 
 void test_return_copy() {
-  // create some dummy kws
-  // create a dummy file w the kws
-  // open ecl_file in RETURN_COPY mode
-  // extract kws from the file, using ecl_file_get_kw
-  // close ecl_file thus destroying kws within ecl_file
-  // assert correct values in kws
   test_work_area_type * work_area = test_work_area_alloc("ecl_file_RETURN_COPY_testing");
   {
     char * file_name = "data_file";
@@ -113,15 +107,24 @@ void test_return_copy() {
     ecl_file_type * ecl_file = ecl_file_open(file_name, ECL_FILE_RETURN_COPY);
     ecl_kw_type * kw1_copy = ecl_file_iget_kw( ecl_file , 0 );
     ecl_kw_type * kw2_copy = ecl_file_iget_kw( ecl_file , 1 );
-
+    ecl_kw_type * kw_alloc1 = ecl_file_alloc_kw( ecl_file , 0 );
+    ecl_kw_type * kw_named = ecl_file_iget_named_kw( ecl_file, "TEST1_KW", 0);
+    ecl_kw_type * kw_alloc2 = ecl_file_alloc_named_kw( ecl_file, "TEST2_KW", 0);
+    
     ecl_file_close( ecl_file );
 
     test_assert_true (ecl_kw_equal(kw1, kw1_copy));
     test_assert_true (ecl_kw_equal(kw2, kw2_copy));
+    test_assert_true (ecl_kw_equal(kw1, kw_alloc1));
+    test_assert_true (ecl_kw_equal(kw1, kw_named));
+    test_assert_true (ecl_kw_equal(kw2, kw_alloc2));
     ecl_kw_free(kw1);
     ecl_kw_free(kw2);
     ecl_kw_free(kw1_copy);
     ecl_kw_free(kw2_copy);
+    ecl_kw_free(kw_alloc1);
+    ecl_kw_free(kw_named);
+    ecl_kw_free(kw_alloc2);
   }
   test_work_area_free( work_area );
 

--- a/lib/ecl/well_info.c
+++ b/lib/ecl/well_info.c
@@ -305,7 +305,7 @@ void well_info_add_UNRST_wells2( well_info_type * well_info , ecl_file_view_type
   int block_nr;
   for (block_nr = 0; block_nr < num_blocks; block_nr++) {
     ecl_file_view_type * step_view = ecl_file_view_add_restart_view(rst_view, block_nr , -1 , -1 , -1 );
-    ecl_kw_type * seqnum_kw = ecl_file_view_alloc_named_kw( step_view , SEQNUM_KW , 0);
+    ecl_kw_type * seqnum_kw = ecl_file_view_alloc_named_kw( step_view , SEQNUM_KW , 0);    
     int report_nr = ecl_kw_iget_int( seqnum_kw , 0 );
     well_info_add_wells2( well_info , step_view , report_nr , load_segment_information );
     ecl_kw_free( seqnum_kw );

--- a/lib/ecl/well_info.c
+++ b/lib/ecl/well_info.c
@@ -305,9 +305,10 @@ void well_info_add_UNRST_wells2( well_info_type * well_info , ecl_file_view_type
   int block_nr;
   for (block_nr = 0; block_nr < num_blocks; block_nr++) {
     ecl_file_view_type * step_view = ecl_file_view_add_restart_view(rst_view, block_nr , -1 , -1 , -1 );
-    const ecl_kw_type * seqnum_kw = ecl_file_view_iget_named_kw( step_view , SEQNUM_KW , 0);
+    ecl_kw_type * seqnum_kw = ecl_file_view_alloc_named_kw( step_view , SEQNUM_KW , 0);
     int report_nr = ecl_kw_iget_int( seqnum_kw , 0 );
     well_info_add_wells2( well_info , step_view , report_nr , load_segment_information );
+    ecl_kw_free( seqnum_kw );
   }
 }
 

--- a/lib/include/ert/ecl/ecl_file.h
+++ b/lib/include/ert/ecl/ecl_file.h
@@ -81,6 +81,7 @@ extern "C" {
   ecl_file_kw_type * ecl_file_iget_file_kw( const ecl_file_type * file , int global_index);
   ecl_file_kw_type * ecl_file_iget_named_file_kw( const ecl_file_type * file , const char * kw, int ith);
   ecl_kw_type      * ecl_file_iget_kw( const ecl_file_type * file , int global_index);
+  ecl_kw_type      * ecl_file_alloc_kw( const ecl_file_type * file , int global_index);
   ecl_data_type      ecl_file_iget_data_type( const ecl_file_type * file , int global_index);
   int                ecl_file_iget_size( const ecl_file_type * file , int global_index);
   const char       * ecl_file_iget_header( const ecl_file_type * file , int global_index);

--- a/lib/include/ert/ecl/ecl_file.h
+++ b/lib/include/ert/ecl/ecl_file.h
@@ -86,6 +86,7 @@ extern "C" {
   int                ecl_file_iget_size( const ecl_file_type * file , int global_index);
   const char       * ecl_file_iget_header( const ecl_file_type * file , int global_index);
   ecl_kw_type      * ecl_file_iget_named_kw( const ecl_file_type * file , const char * kw, int ith);
+  ecl_kw_type      * ecl_file_alloc_named_kw( const ecl_file_type * file , const char * kw, int ith);
   ecl_data_type      ecl_file_iget_named_data_type( const ecl_file_type * file , const char * kw , int ith);
   int                ecl_file_iget_named_size( const ecl_file_type * file , const char * kw , int ith);
   void               ecl_file_indexed_read(const ecl_file_type * file , const char * kw, int index, const int_vector_type * index_map, char* buffer);

--- a/lib/include/ert/ecl/ecl_file.h
+++ b/lib/include/ert/ecl/ecl_file.h
@@ -38,7 +38,8 @@ extern "C" {
 
 #define ECL_FILE_FLAGS_ENUM_DEFS \
   {.value =   1 , .name="ECL_FILE_CLOSE_STREAM"}, \
-  {.value =   2 , .name="ECL_FILE_WRITABLE"}
+  {.value =   2 , .name="ECL_FILE_WRITABLE"}, \
+  {.value =   4 , .name="ECL_FILE_RETURN_COPY"}.
 #define ECL_FILE_FLAGS_ENUM_SIZE 2
 
 

--- a/lib/include/ert/ecl/ecl_file_kw.h
+++ b/lib/include/ert/ecl/ecl_file_kw.h
@@ -41,6 +41,7 @@ typedef struct inv_map_struct inv_map_type;
   ecl_file_kw_type * ecl_file_kw_alloc0( const char * header , ecl_data_type data_type , int size , offset_type offset);
   void               ecl_file_kw_free( ecl_file_kw_type * file_kw );
   void               ecl_file_kw_free__( void * arg );
+  ecl_kw_type      * ecl_file_kw_alloc_kw( const ecl_file_kw_type * file_kw, fortio_type * fortio);
   ecl_kw_type      * ecl_file_kw_get_kw( ecl_file_kw_type * file_kw , fortio_type * fortio, inv_map_type * inv_map);
   ecl_kw_type      * ecl_file_kw_get_kw_ptr( ecl_file_kw_type * file_kw , fortio_type * fortio , inv_map_type * inv_map );
   ecl_file_kw_type * ecl_file_kw_alloc_copy( const ecl_file_kw_type * src );

--- a/lib/include/ert/ecl/ecl_file_view.h
+++ b/lib/include/ert/ecl/ecl_file_view.h
@@ -60,6 +60,7 @@ typedef struct ecl_file_view_struct ecl_file_view_type;
   bool                      ecl_file_view_has_kw( const ecl_file_view_type * ecl_file_view, const char * kw);
   ecl_file_kw_type        * ecl_file_view_iget_file_kw( const ecl_file_view_type * ecl_file_view , int global_index);
   ecl_file_kw_type        * ecl_file_view_iget_named_file_kw( const ecl_file_view_type * ecl_file_view , const char * kw, int ith);
+  ecl_kw_type             * ecl_file_view_alloc_named_kw( const ecl_file_view_type * ecl_file_view, const char * kw, int ith);
   ecl_kw_type             * ecl_file_view_iget_kw( const ecl_file_view_type * ecl_file_view , int index);
   ecl_kw_type             * ecl_file_view_alloc_kw( const ecl_file_view_type * ecl_file_view , int index);
   void                      ecl_file_view_index_fload_kw(const ecl_file_view_type * ecl_file_view, const char* kw, int index, const int_vector_type * index_map, char* buffer);

--- a/lib/include/ert/ecl/ecl_file_view.h
+++ b/lib/include/ert/ecl/ecl_file_view.h
@@ -61,6 +61,7 @@ typedef struct ecl_file_view_struct ecl_file_view_type;
   ecl_file_kw_type        * ecl_file_view_iget_file_kw( const ecl_file_view_type * ecl_file_view , int global_index);
   ecl_file_kw_type        * ecl_file_view_iget_named_file_kw( const ecl_file_view_type * ecl_file_view , const char * kw, int ith);
   ecl_kw_type             * ecl_file_view_iget_kw( const ecl_file_view_type * ecl_file_view , int index);
+  ecl_kw_type             * ecl_file_view_alloc_kw( const ecl_file_view_type * ecl_file_view , int index);
   void                      ecl_file_view_index_fload_kw(const ecl_file_view_type * ecl_file_view, const char* kw, int index, const int_vector_type * index_map, char* buffer);
   int                       ecl_file_view_find_kw_value( const ecl_file_view_type * ecl_file_view , const char * kw , const void * value);
   const char              * ecl_file_view_iget_distinct_kw( const ecl_file_view_type * ecl_file_view , int index);

--- a/lib/include/ert/ecl/ecl_file_view.h
+++ b/lib/include/ert/ecl/ecl_file_view.h
@@ -38,12 +38,14 @@ typedef enum {
                                     mainly to save filedescriptors in cases where many ecl_file instances are open at
                                     the same time. */
   //
-  ECL_FILE_WRITABLE      =  2    /*
+  ECL_FILE_WRITABLE      =  2 ,  /*
                                     This flag opens the file in a mode where it can be updated and modified, but it
                                     must still exist and be readable. I.e. this should not compared with the normal:
                                     fopen(filename , "w") where an existing file is truncated to zero upon successfull
                                     open.
                                  */
+  ECL_FILE_RETURN_COPY   =  4    /* ecl_file will return ecl_kw objects, but will not retain their reference 
+                                    This is to save memory in case of very large data files.*/
 } ecl_file_flag_type;
 
 


### PR DESCRIPTION
**Task**
When using well_info_add_UNRST_wells() on very large (60 GB+) files memory overload may occur. 


**Approach**
The function  well_info_add_UNRST_wells() uses ecl_file_view_iget_named_kw. When the get_kw functions are used, data from the file is stored in the file_kw objetcs owned by ecl_file and retained in memory. 

The approach is to add the following functionality: It will be possible to obtain ecl_kw from ecl_file or eci_file_view as an independent object. This can be done in two different ways:
- simply using alloc functions
- using a flag ECL_FILE_RETURN_COPY when using ecl_file_open. This will cause ecl_file / ecl_file_view to 
  return independent ecl_kw objects using get functions. 


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
