### PR TITLE
Ecl sum different names

### DIFF
--- a/lib/ecl/ecl_file.c
+++ b/lib/ecl/ecl_file.c
@@ -527,10 +527,8 @@ static bool ecl_file_scan( ecl_file_type * ecl_file ) {
       {
         offset_type current_offset = fortio_ftell( ecl_file->fortio );
         ecl_read_status_enum read_status = ecl_kw_fread_header( work_kw , ecl_file->fortio);
-        if (read_status == ECL_KW_READ_FAIL) {
-          printf("Skipping on read:%s \n", ecl_kw_get_header( work_kw ));
+        if (read_status == ECL_KW_READ_FAIL)
           break;
-        }
 
         if (read_status == ECL_KW_READ_OK) {
           ecl_file_kw_type * file_kw = ecl_file_kw_alloc( work_kw , current_offset);

--- a/lib/ecl/ecl_kw.c
+++ b/lib/ecl/ecl_kw.c
@@ -1321,9 +1321,11 @@ ecl_read_status_enum ecl_kw_fread_header(ecl_kw_type *ecl_kw , fortio_type * for
 
     int read_count = fscanf(stream , "%d" , &size);
     if (read_count != 1)
-      util_abort("%s: reading failed - at end of file?\n",__func__);
+      return ECL_KW_READ_FAIL;
 
-    ecl_kw_fscanf_qstring(ecl_type_str , "%4c" , 4 , stream);
+    if (!ecl_kw_fscanf_qstring(ecl_type_str , "%4c" , 4 , stream))
+      return ECL_KW_READ_FAIL;
+
     fgetc(stream);             /* Reading the trailing newline ... */
   }
   else {

--- a/lib/ecl/ecl_sum.c
+++ b/lib/ecl/ecl_sum.c
@@ -172,13 +172,7 @@ static bool ecl_sum_fread_data( ecl_sum_type * ecl_sum , const stringlist_type *
     ecl_sum_free_data( ecl_sum );
 
   ecl_sum->data = ecl_sum_data_alloc( ecl_sum->smspec );
-  if (ecl_sum_data_fread( ecl_sum->data , data_files )) {
-    if (include_restart) {
-
-    }
-    return true;
-  } else
-    return false;
+  return ecl_sum_data_fread( ecl_sum->data , data_files);
 }
 
 
@@ -250,7 +244,10 @@ static bool ecl_sum_fread_case( ecl_sum_type * ecl_sum , bool include_restart) {
 
 ecl_sum_type * ecl_sum_fread_alloc(const char *header_file , const stringlist_type *data_files , const char * key_join_string, bool include_restart) {
   ecl_sum_type * ecl_sum = ecl_sum_alloc__( header_file , key_join_string );
-  ecl_sum_fread( ecl_sum , header_file , data_files , include_restart);
+  if (!ecl_sum_fread( ecl_sum , header_file , data_files , include_restart)) {
+    ecl_sum_free( ecl_sum );
+    ecl_sum = NULL;
+  }
   return ecl_sum;
 }
 

--- a/lib/ecl/ecl_sum.c
+++ b/lib/ecl/ecl_sum.c
@@ -248,9 +248,9 @@ static bool ecl_sum_fread_case( ecl_sum_type * ecl_sum , bool include_restart) {
 */
 
 
-ecl_sum_type * ecl_sum_fread_alloc(const char *header_file , const stringlist_type *data_files , const char * key_join_string) {
+ecl_sum_type * ecl_sum_fread_alloc(const char *header_file , const stringlist_type *data_files , const char * key_join_string, bool include_restart) {
   ecl_sum_type * ecl_sum = ecl_sum_alloc__( header_file , key_join_string );
-  ecl_sum_fread( ecl_sum , header_file , data_files , false );
+  ecl_sum_fread( ecl_sum , header_file , data_files , include_restart);
   return ecl_sum;
 }
 

--- a/lib/ecl/ecl_sum_data.c
+++ b/lib/ecl/ecl_sum_data.c
@@ -1017,9 +1017,9 @@ static bool ecl_sum_data_fread__( ecl_sum_data_type * data , time_t load_end , c
           }
           ecl_file_close( ecl_file );
         }
-      } else
-        util_abort("%s: invalid file type:%s \n",__func__ , ecl_util_file_type_name(file_type ));
+      }
     }
+
 
     if (ecl_sum_data_get_length( data ) > 0) {
       ecl_sum_data_build_index( data );

--- a/lib/include/ert/ecl/ecl_sum.h
+++ b/lib/include/ert/ecl/ecl_sum.h
@@ -91,7 +91,7 @@ typedef struct ecl_sum_struct       ecl_sum_type;
   void             ecl_sum_free_data(ecl_sum_type * );
   void             ecl_sum_free__(void * );
   void             ecl_sum_free(ecl_sum_type * );
-  ecl_sum_type   * ecl_sum_fread_alloc(const char * , const stringlist_type * data_files, const char * key_join_string);
+  ecl_sum_type   * ecl_sum_fread_alloc(const char * , const stringlist_type * data_files, const char * key_join_string, bool include_restart);
   ecl_sum_type   * ecl_sum_fread_alloc_case(const char *  , const char * key_join_string);
   ecl_sum_type   * ecl_sum_fread_alloc_case__(const char *  , const char * key_join_string , bool include_restart);
   bool             ecl_sum_case_exists( const char * input_file );

--- a/python/python/ecl/test/ecl_mock/CMakeLists.txt
+++ b/python/python/ecl/test/ecl_mock/CMakeLists.txt
@@ -3,5 +3,4 @@ set(PYTHON_SOURCES
     ecl_sum_mock.py
 )
 
-# The ecl_mock package is not installed.
-add_python_package("python.ecl.test.ecl_mock"  ${PYTHON_INSTALL_PREFIX}/ecl/test/ecl_mock "${PYTHON_SOURCES}" False)
+add_python_package("python.ecl.test.ecl_mock"  ${PYTHON_INSTALL_PREFIX}/ecl/test/ecl_mock "${PYTHON_SOURCES}" True)

--- a/python/tests/ecl/test_ecl_file.py
+++ b/python/tests/ecl/test_ecl_file.py
@@ -179,6 +179,15 @@ class EclFileTest(ExtendedTestCase):
                 self.assertEqual( kw1, kw2 )
 
 
+    def test_broken_file(self):
+        with TestAreaContext("test_broken_file"):
+            with open("CASE.FINIT", "w") as f:
+                f.write("This - is not a ECLISPE file\nsdlcblhcdbjlwhc\naschscbasjhcasc\nascasck c s s aiasic asc")
+
+
+            with self.assertRaises(IOError):
+                f = EclFile("CASE.FINIT")
+
 
     def test_block_view(self):
         with TestAreaContext("python/ecl_file/view"):

--- a/python/tests/ecl/test_sum.py
+++ b/python/tests/ecl/test_sum.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python
-#  Copyright (C) 2011  Statoil ASA, Norway. 
-#   
-#  The file 'sum_test.py' is part of ERT - Ensemble based Reservoir Tool. 
-#   
-#  ERT is free software: you can redistribute it and/or modify 
-#  it under the terms of the GNU General Public License as published by 
-#  the Free Software Foundation, either version 3 of the License, or 
-#  (at your option) any later version. 
-#   
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-#  FITNESS FOR A PARTICULAR PURPOSE.   
-#   
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-#  for more details. 
+#  Copyright (C) 2011  Statoil ASA, Norway.
+#
+#  The file 'sum_test.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
 
 import os
 import datetime
@@ -38,7 +38,7 @@ def fgpt(days):
 
 class SumTest(ExtendedTestCase):
 
-    
+
     def test_mock(self):
         case = createEclSum("CSV" , [("FOPT", None , 0) , ("FOPR" , None , 0)])
         self.assertTrue("FOPT" in case)
@@ -86,10 +86,10 @@ class SumTest(ExtendedTestCase):
         self.assertGreater( node2, node3 )
         self.assertEqual( node1, node1 )
         self.assertNotEqual( node1, node2 )
-        
+
         with self.assertRaises(TypeError):
             a = node1 < 1
-        
+
     def test_csv_export(self):
         case = createEclSum("CSV" , [("FOPT", None , 0) , ("FOPR" , None , 0)])
         sep = ";"
@@ -104,8 +104,8 @@ class SumTest(ExtendedTestCase):
                 self.assertIn("FOPR", row)
                 self.assertEqual( len(row) , 4 )
                 break
-                
-            
+
+
 
         with TestAreaContext("ecl/csv"):
             case.exportCSV( "file.csv" , keys = ["FOPT"] , sep = sep)
@@ -117,8 +117,8 @@ class SumTest(ExtendedTestCase):
                 self.assertIn("FOPT", row)
                 self.assertEqual( len(row) , 3 )
                 break
-            
-            
+
+
 
         with TestAreaContext("ecl/csv"):
             date_format = "%y-%m-%d"
@@ -136,8 +136,8 @@ class SumTest(ExtendedTestCase):
                         self.assertEqual( case.iget_date( time_index ) , d )
 
                     time_index += 1
-                
-                
+
+
     def test_solve(self):
         length = 100
         case = createEclSum("CSV" , [("FOPT", None , 0) , ("FOPR" , None , 0), ("FGPT" , None , 0)],
@@ -147,10 +147,10 @@ class SumTest(ExtendedTestCase):
                             func_table = {"FOPT" : fopt,
                                           "FOPR" : fopr ,
                                           "FGPT" : fgpt })
-        
+
         with self.assertRaises( KeyError ):
             case.solveDays( "MISSING:KEY" , 0.56)
-            
+
         sol = case.solveDays( "FOPT" , 150 )
         self.assertEqual( len(sol) , 0 )
 
@@ -172,7 +172,7 @@ class SumTest(ExtendedTestCase):
         sol = case.solveDates("FOPR" , 50.90)
         t = case.getDataStartTime( ) + datetime.timedelta( days = 50 ) + datetime.timedelta( seconds = 1 )
         self.assertEqual( sol[0] , t )
-        
+
         sol = case.solveDays( "FOPR" , 50.90 , rates_clamp_lower = False)
         self.assertEqual( len(sol) , 1 )
         self.assertFloatEqual( sol[0] , 51.00 )


### PR DESCRIPTION
**Task**
In most cases the header file and the data files will have the same basename. With this PR it is possible to load summary cases where the two have different basenames.

**Approach**
Hooked up existing C function from Python.

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally

**Depends on**
- Statoil/libres#102
