### PR TITLE
Break long lines into shorter lines

### DIFF
--- a/lib/ecl/ecl_grid.c
+++ b/lib/ecl/ecl_grid.c
@@ -806,7 +806,11 @@ static void ecl_cell_dump( const ecl_cell_type * cell , FILE * stream) {
 static void ecl_cell_assert_center( ecl_cell_type * cell);
 
 static void ecl_cell_dump_ascii( ecl_cell_type * cell , int i , int j , int k , FILE * stream , const double * offset) {
-  fprintf(stream , "Cell: i:%3d  j:%3d    k:%3d   host_cell:%d  CoarseGroup:%4d active_nr:%6d  active:%d \nCorners:\n",i,j,k,cell->host_cell, cell->coarse_group , cell->active_index[MATRIX_INDEX], cell->active);
+  fprintf(stream, "Cell: i:%3d  j:%3d    k:%3d   host_cell:%d  CoarseGroup:%4d active_nr:%6d  active:%d \nCorners:\n",
+          i, j, k,
+          cell->host_cell, cell->coarse_group,
+          cell->active_index[MATRIX_INDEX],
+          cell->active);
 
   ecl_cell_assert_center( cell );
   fprintf(stream , "Center   : ");
@@ -825,7 +829,17 @@ static void ecl_cell_dump_ascii( ecl_cell_type * cell , int i , int j , int k , 
 }
 
 
-static void ecl_cell_fwrite_GRID( const ecl_grid_type * grid , const ecl_cell_type * cell , bool fracture_cell , int coords_size , int i, int j , int k , int global_index , ecl_kw_type * coords_kw , ecl_kw_type * corners_kw, fortio_type * fortio) {
+static void ecl_cell_fwrite_GRID(const ecl_grid_type * grid,
+                                 const ecl_cell_type * cell,
+                                 bool fracture_cell,
+                                 int coords_size,
+                                 int i,
+                                 int j,
+                                 int k,
+                                 int global_index,
+                                 ecl_kw_type * coords_kw,
+                                 ecl_kw_type * corners_kw,
+                                 fortio_type * fortio) {
   ecl_kw_iset_int( coords_kw , 0 , i + 1);
   ecl_kw_iset_int( coords_kw , 1 , j + 1);
   ecl_kw_iset_int( coords_kw , 2 , k + 1);
@@ -1330,12 +1344,17 @@ static double ecl_cell_get_volume( ecl_cell_type * cell ) {
 
 
 
-static double triangle_area(double x1 , double y1 , double x2 , double y2 , double x3 ,double y3) {
+static double triangle_area(double x1, double y1,
+                            double x2, double y2,
+                            double x3, double y3) {
   return fabs(x1*y2 + x2*y3 + x3*y1 - x1*y3 - x3*y2 - x2*y1)*0.5;
 }
 
 
-static bool triangle_contains(const point_type *p0 , const point_type * p1 , const point_type *p2 , double x , double y) {
+static bool triangle_contains(const point_type *p0,
+                              const point_type *p1,
+                              const point_type *p2,
+                              double x, double y) {
   double epsilon = 1e-10;
 
   double vt = triangle_area(p0->x , p0->y,
@@ -1381,7 +1400,10 @@ static double parallelogram_area3d(const point_type * p0, const point_type * p1,
  * p0, p1 and p2. Note that if the triangle is a line, the function will still
  * return true if the point lies on the line segment.
  */
-static bool triangle_contains3d(const point_type *p0 , const point_type * p1 , const point_type *p2 , const point_type *p) {
+static bool triangle_contains3d(const point_type *p0,
+                                const point_type *p1,
+                                const point_type *p2,
+                                const point_type *p) {
   double epsilon = 1e-10;
   double vt = parallelogram_area3d(p0, p1, p2);
 
@@ -1425,7 +1447,10 @@ static bool triangle_contains3d(const point_type *p0 , const point_type * p1 , c
 */
 
 
-static bool ecl_cell_layer_contains_xy( const ecl_cell_type * cell , bool lower_layer , double x , double y) {
+static bool ecl_cell_layer_contains_xy(const ecl_cell_type * cell,
+                                       bool lower_layer,
+                                       double x,
+                                       double y) {
   if (GET_CELL_FLAG(cell,CELL_FLAG_TAINTED))
     return false;
   {
@@ -1459,7 +1484,16 @@ static bool ecl_cell_layer_contains_xy( const ecl_cell_type * cell , bool lower_
          |   |           |   |
          0---1           4---5
 */
-static void ecl_cell_init_regular( ecl_cell_type * cell , const double * offset , int i , int j , int k , int global_index , const double * ivec , const double * jvec , const double * kvec , const int * actnum ) {
+static void ecl_cell_init_regular(ecl_cell_type * cell,
+                                  const double * offset,
+                                  int i,
+                                  int j,
+                                  int k,
+                                  int global_index,
+                                  const double * ivec,
+                                  const double * jvec,
+                                  const double * kvec,
+                                  const int * actnum) {
   point_set(&cell->corner_list[0] , offset[0] , offset[1] , offset[2] ); // Point 0
 
   cell->corner_list[1] = cell->corner_list[0];                       // Point 1
@@ -1498,7 +1532,8 @@ UTIL_IS_INSTANCE_FUNCTION( ecl_grid , ECL_GRID_ID);
 
 
 
-static ecl_cell_type * ecl_grid_get_cell(const ecl_grid_type * grid , int global_index) {
+static ecl_cell_type * ecl_grid_get_cell(const ecl_grid_type * grid,
+                                         int global_index) {
   return &grid->cells[global_index];
 }
 
@@ -1558,7 +1593,13 @@ static bool ecl_grid_alloc_cells( ecl_grid_type * grid , bool init_valid) {
    is performed.
 */
 
-static ecl_grid_type * ecl_grid_alloc_empty(ecl_grid_type * global_grid , int dualp_flag , int nx , int ny , int nz, int lgr_nr, bool init_valid) {
+static ecl_grid_type * ecl_grid_alloc_empty(ecl_grid_type * global_grid,
+                                            int dualp_flag,
+                                            int nx,
+                                            int ny,
+                                            int nz,
+                                            int lgr_nr,
+                                            bool init_valid) {
   ecl_grid_type * grid = util_malloc(sizeof * grid );
   UTIL_TYPE_ID_INIT(grid , ECL_GRID_ID);
   grid->total_active   = 0;
@@ -1635,7 +1676,10 @@ static ecl_grid_type * ecl_grid_alloc_empty(ecl_grid_type * global_grid , int du
 
 
 
-static  int ecl_grid_get_global_index__(const ecl_grid_type * ecl_grid , int i , int j , int k) {
+static int ecl_grid_get_global_index__(const ecl_grid_type * ecl_grid,
+                                       int i,
+                                       int j,
+                                       int k) {
   return i + j * ecl_grid->nx + k * ecl_grid->nx * ecl_grid->ny;
 }
 
@@ -1677,7 +1721,10 @@ static void ecl_grid_set_cell_EGRID(ecl_grid_type * ecl_grid , int i, int j , in
 }
 
 
-static void ecl_grid_set_cell_GRID(ecl_grid_type * ecl_grid , int coords_size , const int * coords , const float * corners) {
+static void ecl_grid_set_cell_GRID(ecl_grid_type * ecl_grid,
+                                   int coords_size,
+                                   const int * coords,
+                                   const float * corners) {
 
   const int i  = coords[0] - 1; /* eclipse 1 offset */
   const int j  = coords[1] - 1;
@@ -1776,10 +1823,12 @@ static void ecl_grid_set_cell_GRID(ecl_grid_type * ecl_grid , int coords_size , 
    ecl_grid->total_active is correct.
 */
 
-static void ecl_grid_init_index_map__( ecl_grid_type * ecl_grid , int * index_map , int * inv_index_map , int active_mask, int type_index) {
-  int global_index;
-
-  for (global_index = 0; global_index < ecl_grid->size; global_index++) {
+static void ecl_grid_init_index_map__(ecl_grid_type * ecl_grid,
+                                      int * index_map,
+                                      int * inv_index_map,
+                                      int active_mask,
+                                      int type_index) {
+  for (int global_index = 0; global_index < ecl_grid->size; global_index++) {
     const ecl_cell_type * cell = ecl_grid_get_cell( ecl_grid , global_index);
     if (cell->active & active_mask) {
       index_map[global_index] = cell->active_index[type_index];
@@ -1796,56 +1845,63 @@ static void ecl_grid_init_index_map__( ecl_grid_type * ecl_grid , int * index_ma
 
 static void ecl_grid_realloc_index_map(ecl_grid_type * ecl_grid) {
   /* Creating the inverse mapping for the matrix cells. */
-  {
-    ecl_grid->index_map     = util_realloc(ecl_grid->index_map     , ecl_grid->size                * sizeof * ecl_grid->index_map     );
-    ecl_grid->inv_index_map = util_realloc(ecl_grid->inv_index_map , ecl_grid->total_active * sizeof * ecl_grid->inv_index_map );
-    ecl_grid_init_index_map__( ecl_grid , ecl_grid->index_map , ecl_grid->inv_index_map , CELL_ACTIVE_MATRIX , MATRIX_INDEX);
-  }
+  ecl_grid->index_map     = util_realloc(ecl_grid->index_map,
+                                         ecl_grid->size * sizeof * ecl_grid->index_map);
+  ecl_grid->inv_index_map = util_realloc(ecl_grid->inv_index_map,
+                                         ecl_grid->total_active * sizeof * ecl_grid->inv_index_map);
+  ecl_grid_init_index_map__(ecl_grid,
+                            ecl_grid->index_map,
+                            ecl_grid->inv_index_map,
+                            CELL_ACTIVE_MATRIX,
+                            MATRIX_INDEX);
+
 
   /* Create the inverse mapping for the fractures. */
   if (ecl_grid->dualp_flag != FILEHEAD_SINGLE_POROSITY) {
-    ecl_grid->fracture_index_map     = util_realloc(ecl_grid->fracture_index_map     , ecl_grid->size                  * sizeof * ecl_grid->fracture_index_map     );
-    ecl_grid->inv_fracture_index_map = util_realloc(ecl_grid->inv_fracture_index_map , ecl_grid->total_active_fracture * sizeof * ecl_grid->inv_fracture_index_map );
-    ecl_grid_init_index_map__( ecl_grid , ecl_grid->fracture_index_map , ecl_grid->inv_fracture_index_map , CELL_ACTIVE_FRACTURE , FRACTURE_INDEX);
+    ecl_grid->fracture_index_map     = util_realloc(ecl_grid->fracture_index_map,
+                                                    ecl_grid->size * sizeof * ecl_grid->fracture_index_map);
+    ecl_grid->inv_fracture_index_map = util_realloc(ecl_grid->inv_fracture_index_map,
+                                                    ecl_grid->total_active_fracture * sizeof * ecl_grid->inv_fracture_index_map);
+    ecl_grid_init_index_map__(ecl_grid,
+                              ecl_grid->fracture_index_map,
+                              ecl_grid->inv_fracture_index_map,
+                              CELL_ACTIVE_FRACTURE,
+                              FRACTURE_INDEX);
   }
 
 
   /* Update the inverse map in the case of coarse cells. Observe that
      in the case of coarse cells with more than one active cell in the
      main grid, the inverse active -> global mapping will map to the
-     first active cell in the coarse cell. */
-  {
-    int coarse_group;
-    for (coarse_group = 0; coarse_group < ecl_grid_get_num_coarse_groups( ecl_grid ); coarse_group++) {
-      ecl_coarse_cell_type * coarse_cell = ecl_grid_iget_coarse_group( ecl_grid , coarse_group );
-      if (ecl_coarse_cell_get_num_active( coarse_cell ) > 0) {
-        int global_index          = ecl_coarse_cell_iget_active_cell_index( coarse_cell , 0 );
-        int active_value          = ecl_coarse_cell_iget_active_value( coarse_cell , 0 );
-        int active_index          = ecl_coarse_cell_get_active_index( coarse_cell );
-        int active_fracture_index = ecl_coarse_cell_get_active_fracture_index( coarse_cell );
+     first active cell in the coarse cell.
+  */
+  int size = ecl_grid_get_num_coarse_groups(ecl_grid);
+  for (int coarse_group = 0; coarse_group < size; coarse_group++) {
+    ecl_coarse_cell_type * coarse_cell = ecl_grid_iget_coarse_group(ecl_grid, coarse_group);
+    if (ecl_coarse_cell_get_num_active(coarse_cell) > 0) {
+      int global_index          = ecl_coarse_cell_iget_active_cell_index(coarse_cell, 0);
+      int active_value          = ecl_coarse_cell_iget_active_value(coarse_cell, 0);
+      int active_index          = ecl_coarse_cell_get_active_index(coarse_cell);
+      int active_fracture_index = ecl_coarse_cell_get_active_fracture_index(coarse_cell);
 
-        if (active_value & CELL_ACTIVE_MATRIX)
-          ecl_grid->inv_index_map[ active_index ] = global_index;    // The active -> global mapping point to one "random" cell in the coarse group
+      if (active_value & CELL_ACTIVE_MATRIX) // active->global mapping point to one "random" cell in the coarse group
+        ecl_grid->inv_index_map[active_index] = global_index;
+
+      if (active_value & CELL_ACTIVE_FRACTURE)
+        ecl_grid->inv_fracture_index_map[active_fracture_index] = global_index;
+
+      int coarse_size = ecl_coarse_cell_get_size(coarse_cell);
+      const int_vector_type * global_index_list = ecl_coarse_cell_get_index_vector(coarse_cell);
+      for (int ic = 0; ic < coarse_size; ic++) {
+        int gi = int_vector_iget(global_index_list, ic);
+
+        if (active_value & CELL_ACTIVE_MATRIX) // All cells in the coarse group point to the same active index.
+          ecl_grid->index_map[gi] = active_index;
 
         if (active_value & CELL_ACTIVE_FRACTURE)
-          ecl_grid->inv_fracture_index_map[ active_fracture_index ] = global_index;
-
-        {
-          int coarse_size = ecl_coarse_cell_get_size( coarse_cell );
-          const int_vector_type * global_index_list = ecl_coarse_cell_get_index_vector( coarse_cell );
-          int ic;
-          for (ic =0; ic < coarse_size; ic++) {
-            int gi = int_vector_iget( global_index_list , ic );
-
-            if (active_value & CELL_ACTIVE_MATRIX)
-              ecl_grid->index_map[ gi ] = active_index;        // All the cells in the coarse group point to the same active index.
-
-            if (active_value & CELL_ACTIVE_FRACTURE)
-              ecl_grid->fracture_index_map[ gi ] = active_fracture_index;
-          }
-        }
-      } // else the coarse cell does not have any active cells.
-    }
+          ecl_grid->fracture_index_map[gi] = active_fracture_index;
+      }
+    } // else the coarse cell does not have any active cells.
   }
 }
 
@@ -1865,14 +1921,12 @@ static void ecl_grid_set_active_index(ecl_grid_type * ecl_grid) {
   if (!ecl_grid_have_coarse_cells( ecl_grid )) {
     /* Keeping a fast path for the 99% most common case of no coarse
        groups and single porosity. */
-    {
-      for (global_index = 0; global_index < ecl_grid->size; global_index++) {
-        ecl_cell_type * cell = ecl_grid_get_cell( ecl_grid , global_index);
+    for (global_index = 0; global_index < ecl_grid->size; global_index++) {
+      ecl_cell_type * cell = ecl_grid_get_cell( ecl_grid , global_index);
 
-        if (cell->active & CELL_ACTIVE_MATRIX) {
-          cell->active_index[MATRIX_INDEX] = active_index;
-          active_index++;
-        }
+      if (cell->active & CELL_ACTIVE_MATRIX) {
+        cell->active_index[MATRIX_INDEX] = active_index;
+        active_index++;
       }
     }
 
@@ -1909,7 +1963,11 @@ static void ecl_grid_set_active_index(ecl_grid_type * ecl_grid) {
 
         } else {
           ecl_coarse_cell_type * coarse_cell = ecl_grid_iget_coarse_group( ecl_grid , cell->coarse_group );
-          ecl_coarse_cell_update_index( coarse_cell , global_index , &active_index , &active_fracture_index , cell->active);
+          ecl_coarse_cell_update_index(coarse_cell,
+                                       global_index,
+                                       &active_index,
+                                       &active_fracture_index,
+                                       cell->active);
         }
       }
     }
@@ -1920,33 +1978,29 @@ static void ecl_grid_set_active_index(ecl_grid_type * ecl_grid) {
          active value of all the cells in the coarse cell to the
          common value for the coarse cell.
     */
-    {
-      int coarse_group;
-      for (coarse_group = 0; coarse_group < ecl_grid_get_num_coarse_groups( ecl_grid ); coarse_group++) {
-        ecl_coarse_cell_type * coarse_cell = ecl_grid_iget_coarse_group( ecl_grid , coarse_group );
-        if (ecl_coarse_cell_get_num_active(coarse_cell) > 0) {
-          int cell_active_index          = ecl_coarse_cell_get_active_index( coarse_cell );
-          int cell_active_value          = ecl_coarse_cell_iget_active_value( coarse_cell , 0);
-          int group_size                 = ecl_coarse_cell_get_size( coarse_cell );
-          const int * coarse_cell_list   = ecl_coarse_cell_get_index_ptr( coarse_cell );
-          int i;
 
-          for (i=0; i < group_size; i++) {
-            global_index = coarse_cell_list[i];
-            {
-              ecl_cell_type * cell = ecl_grid_get_cell( ecl_grid , global_index );
+    int size = ecl_grid_get_num_coarse_groups(ecl_grid);
+    for (int coarse_group = 0; coarse_group < size; coarse_group++) {
+      ecl_coarse_cell_type * coarse_cell = ecl_grid_iget_coarse_group( ecl_grid , coarse_group );
+      if (ecl_coarse_cell_get_num_active(coarse_cell) > 0) {
+        int cell_active_index          = ecl_coarse_cell_get_active_index( coarse_cell );
+        int cell_active_value          = ecl_coarse_cell_iget_active_value( coarse_cell , 0);
+        int group_size                 = ecl_coarse_cell_get_size( coarse_cell );
+        const int * coarse_cell_list   = ecl_coarse_cell_get_index_ptr( coarse_cell );
 
-              if (cell_active_value & CELL_ACTIVE_MATRIX)
-                cell->active_index[MATRIX_INDEX] = cell_active_index;
+        for (int i=0; i < group_size; i++) {
+          global_index = coarse_cell_list[i];
 
-              /* Coarse cell and dual porosity - that is probably close to zero measure. */
-              if (cell_active_value & CELL_ACTIVE_FRACTURE) {
-                int cell_active_fracture_index = ecl_coarse_cell_get_active_fracture_index( coarse_cell );
-                cell->active_index[FRACTURE_INDEX] = cell_active_fracture_index;
-              }
-            }
+          ecl_cell_type * cell = ecl_grid_get_cell( ecl_grid , global_index );
+
+          if (cell_active_value & CELL_ACTIVE_MATRIX)
+            cell->active_index[MATRIX_INDEX] = cell_active_index;
+
+          /* Coarse cell and dual porosity - that is probably close to zero measure. */
+          if (cell_active_value & CELL_ACTIVE_FRACTURE) {
+            int cell_active_fracture_index = ecl_coarse_cell_get_active_fracture_index( coarse_cell );
+            cell->active_index[FRACTURE_INDEX] = cell_active_fracture_index;
           }
-
         }
       }
     }
@@ -2246,7 +2300,12 @@ int ecl_grid_zcorn_index(const ecl_grid_type * grid , int i, int j , int k , int
 }
 
 
-static void ecl_grid_init_GRDECL_data_jslice(ecl_grid_type * ecl_grid ,  const float * zcorn , const float * coord , const int * actnum, const int * corsnum , int j) {
+static void ecl_grid_init_GRDECL_data_jslice(ecl_grid_type * ecl_grid,
+                                             const float * zcorn,
+                                             const float * coord,
+                                             const int * actnum,
+                                             const int * corsnum,
+                                             int j) {
   const int nx = ecl_grid->nx;
   const int ny = ecl_grid->ny;
   const int nz = ecl_grid->nz;
@@ -2316,7 +2375,11 @@ static void ecl_grid_init_GRDECL_data_jslice(ecl_grid_type * ecl_grid ,  const f
 }
 
 
-void ecl_grid_init_GRDECL_data(ecl_grid_type * ecl_grid ,  const float * zcorn , const float * coord , const int * actnum, const int * corsnum) {
+void ecl_grid_init_GRDECL_data(ecl_grid_type * ecl_grid,
+                               const float * zcorn,
+                               const float * coord,
+                               const int * actnum,
+                               const int * corsnum) {
   const int ny = ecl_grid->ny;
   int j;
 #pragma omp parallel for
@@ -2332,9 +2395,17 @@ void ecl_grid_init_GRDECL_data(ecl_grid_type * ecl_grid ,  const float * zcorn ,
   0---1
 */
 
-static ecl_grid_type * ecl_grid_alloc_GRDECL_data__(ecl_grid_type * global_grid ,
-                                                    int dualp_flag , bool apply_mapaxes, int nx , int ny , int nz ,
-                                                    const float * zcorn , const float * coord , const int * actnum, const float * mapaxes, const int * corsnum,
+static ecl_grid_type * ecl_grid_alloc_GRDECL_data__(ecl_grid_type * global_grid,
+                                                    int dualp_flag,
+                                                    bool apply_mapaxes,
+                                                    int nx,
+                                                    int ny,
+                                                    int nz,
+                                                    const float * zcorn,
+                                                    const float * coord,
+                                                    const int * actnum,
+                                                    const float * mapaxes,
+                                                    const int * corsnum,
                                                     int lgr_nr) {
 
   ecl_grid_type * ecl_grid = ecl_grid_alloc_empty(global_grid , dualp_flag , nx,ny,nz,lgr_nr,true);
@@ -2488,8 +2559,26 @@ ecl_grid_type * ecl_grid_alloc_processed_copy( const ecl_grid_type * src_grid , 
   a lgr hierarchy - or cell coarsening.
 */
 
-ecl_grid_type * ecl_grid_alloc_GRDECL_data(int nx , int ny , int nz , const float * zcorn , const float * coord , const int * actnum, bool apply_mapaxes , const float * mapaxes) {
-  return ecl_grid_alloc_GRDECL_data__(NULL , FILEHEAD_SINGLE_POROSITY , apply_mapaxes , nx , ny , nz , zcorn , coord , actnum , mapaxes , NULL , 0);
+ecl_grid_type * ecl_grid_alloc_GRDECL_data(int nx,
+                                           int ny,
+                                           int nz,
+                                           const float * zcorn,
+                                           const float * coord,
+                                           const int * actnum,
+                                           bool apply_mapaxes,
+                                           const float * mapaxes) {
+  return ecl_grid_alloc_GRDECL_data__(NULL,
+                                      FILEHEAD_SINGLE_POROSITY,
+                                      apply_mapaxes,
+                                      nx,
+                                      ny,
+                                      nz,
+                                      zcorn,
+                                      coord,
+                                      actnum,
+                                      mapaxes,
+                                      NULL,
+                                      0);
 }
 
 
@@ -2581,8 +2670,16 @@ ecl_grid_type * ecl_grid_alloc_GRDECL_kw( int nx, int ny , int nz ,
                                           const ecl_kw_type * mapaxes_kw ) {   /* Can be NULL */
 
   bool apply_mapaxes = true;
-  ecl_kw_type * gridhead_kw = ecl_grid_alloc_gridhead_kw( nx , ny , nz , 0);
-  ecl_grid_type * ecl_grid = ecl_grid_alloc_GRDECL_kw__(NULL , FILEHEAD_SINGLE_POROSITY , apply_mapaxes , gridhead_kw , zcorn_kw , coord_kw , actnum_kw , mapaxes_kw , NULL);
+  ecl_kw_type * gridhead_kw = ecl_grid_alloc_gridhead_kw( nx, ny, nz, 0);
+  ecl_grid_type * ecl_grid = ecl_grid_alloc_GRDECL_kw__(NULL,
+                                                        FILEHEAD_SINGLE_POROSITY,
+                                                        apply_mapaxes,
+                                                        gridhead_kw,
+                                                        zcorn_kw,
+                                                        coord_kw,
+                                                        actnum_kw,
+                                                        mapaxes_kw,
+                                                        NULL);
   ecl_kw_free( gridhead_kw );
   return ecl_grid;
 

--- a/lib/include/ert/ecl/ecl_coarse_cell.h
+++ b/lib/include/ert/ecl/ecl_coarse_cell.h
@@ -1,19 +1,19 @@
 /*
-   Copyright (c) 2012  statoil asa, norway. 
-    
-   The file 'ecl_coarse_cell.h' is part of ert - ensemble based reservoir tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the gnu general public license as published by 
-   the free software foundation, either version 3 of the license, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but without any 
-   warranty; without even the implied warranty of merchantability or 
-   fitness for a particular purpose.   
-    
-   See the gnu general public license at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2012  Statoil ASA, Norway.
+
+   This file is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #ifndef ERT_ECL_COARSE_CELL_H
@@ -24,33 +24,47 @@
 extern "C" {
 #endif
 
-  typedef struct ecl_coarse_cell_struct    ecl_coarse_cell_type;
+typedef struct ecl_coarse_cell_struct ecl_coarse_cell_type;
 
-  bool                   ecl_coarse_cell_equal( const ecl_coarse_cell_type * coarse_cell1 , const ecl_coarse_cell_type * coarse_cell2);
-  ecl_coarse_cell_type * ecl_coarse_cell_alloc( void );
-  void                   ecl_coarse_cell_update( ecl_coarse_cell_type * coarse_cell , int i , int j , int k , int global_index );
-  void                   ecl_coarse_cell_free( ecl_coarse_cell_type * coarse_cell );
-  void                   ecl_coarse_cell_free__( void * arg );
+bool        ecl_coarse_cell_equal(const ecl_coarse_cell_type * coarse_cell1,
+                                  const ecl_coarse_cell_type * coarse_cell2);
+ecl_coarse_cell_type * ecl_coarse_cell_alloc(void);
+void        ecl_coarse_cell_update(ecl_coarse_cell_type * coarse_cell,
+                                   int i,
+                                   int j,
+                                   int k,
+                                   int global_index);
+void        ecl_coarse_cell_free(ecl_coarse_cell_type * coarse_cell);
+void        ecl_coarse_cell_free__(void * arg);
 
-  int                    ecl_coarse_cell_get_i1( const ecl_coarse_cell_type * coarse_cell );
-  int                    ecl_coarse_cell_get_j1( const ecl_coarse_cell_type * coarse_cell );  
-  int                    ecl_coarse_cell_get_k1( const ecl_coarse_cell_type * coarse_cell );
-  int                    ecl_coarse_cell_get_i2( const ecl_coarse_cell_type * coarse_cell );
-  int                    ecl_coarse_cell_get_j2( const ecl_coarse_cell_type * coarse_cell );  
-  int                    ecl_coarse_cell_get_k2( const ecl_coarse_cell_type * coarse_cell );
-  const int *            ecl_coarse_cell_get_box_ptr( const ecl_coarse_cell_type * coarse_cell );
+int         ecl_coarse_cell_get_i1(const ecl_coarse_cell_type * coarse_cell);
+int         ecl_coarse_cell_get_j1(const ecl_coarse_cell_type * coarse_cell);
+int         ecl_coarse_cell_get_k1(const ecl_coarse_cell_type * coarse_cell);
+int         ecl_coarse_cell_get_i2(const ecl_coarse_cell_type * coarse_cell);
+int         ecl_coarse_cell_get_j2(const ecl_coarse_cell_type * coarse_cell);
+int         ecl_coarse_cell_get_k2(const ecl_coarse_cell_type * coarse_cell);
+const int * ecl_coarse_cell_get_box_ptr(const ecl_coarse_cell_type * coarse_cell);
 
-  int                     ecl_coarse_cell_get_size( const ecl_coarse_cell_type * coarse_cell );
-  int                     ecl_coarse_cell_iget_cell_index( ecl_coarse_cell_type * coarse_cell , int group_index);
-  const int *             ecl_coarse_cell_get_index_ptr( ecl_coarse_cell_type * coarse_cell );
-  const int_vector_type * ecl_coarse_cell_get_index_vector( ecl_coarse_cell_type * coarse_cell );
+int         ecl_coarse_cell_get_size(const ecl_coarse_cell_type * coarse_cell);
+int         ecl_coarse_cell_iget_cell_index(ecl_coarse_cell_type * coarse_cell,
+                                            int group_index);
+const int * ecl_coarse_cell_get_index_ptr(ecl_coarse_cell_type * coarse_cell);
+const int_vector_type * ecl_coarse_cell_get_index_vector(ecl_coarse_cell_type * coarse_cell);
 
-  void                    ecl_coarse_cell_update_index( ecl_coarse_cell_type * coarse_cell , int global_index , int * active_index , int * active_fracture_index , int active_value);   int                     ecl_coarse_cell_get_active_index( const ecl_coarse_cell_type * coarse_cell );
-  int                     ecl_coarse_cell_get_active_fracture_index( const ecl_coarse_cell_type * coarse_cell );
-  int                     ecl_coarse_cell_iget_active_cell_index( const ecl_coarse_cell_type * coarse_cell , int index);
-  int                     ecl_coarse_cell_iget_active_value( const ecl_coarse_cell_type * coarse_cell , int index);
-  int                     ecl_coarse_cell_get_num_active( const ecl_coarse_cell_type * coarse_cell);
-  void                    ecl_coarse_cell_fprintf( const ecl_coarse_cell_type * coarse_cell , FILE * stream );
+void ecl_coarse_cell_update_index(ecl_coarse_cell_type * coarse_cell,
+                                  int global_index,
+                                  int * active_index,
+                                  int * active_fracture_index,
+                                  int active_value);
+int  ecl_coarse_cell_get_active_index(const ecl_coarse_cell_type * coarse_cell);
+int  ecl_coarse_cell_get_active_fracture_index(const ecl_coarse_cell_type * coarse_cell);
+int  ecl_coarse_cell_iget_active_cell_index(const ecl_coarse_cell_type * coarse_cell,
+                                            int index);
+int  ecl_coarse_cell_iget_active_value(const ecl_coarse_cell_type * coarse_cell,
+                                       int index);
+int  ecl_coarse_cell_get_num_active(const ecl_coarse_cell_type * coarse_cell);
+void ecl_coarse_cell_fprintf(const ecl_coarse_cell_type * coarse_cell,
+                             FILE * stream);
 
 #ifdef __cplusplus
 }

--- a/lib/include/ert/ecl/ecl_grav_common.h
+++ b/lib/include/ert/ecl/ecl_grav_common.h
@@ -28,9 +28,26 @@ extern "C" {
 #include <ert/ecl/ecl_grid_cache.h>
 #include <ert/ecl/ecl_file.h>
 
-  bool   * ecl_grav_common_alloc_aquifer_cell( const ecl_grid_cache_type * grid_cache , const ecl_file_type * init_file);
-  double   ecl_grav_common_eval_biot_savart( const ecl_grid_cache_type * grid_cache , ecl_region_type * region , const bool * aquifer , const double * weight ,  double utm_x , double utm_y , double depth);
-  double ecl_grav_common_eval_geertsma( const ecl_grid_cache_type * grid_cache , ecl_region_type * region , const bool * aquifer , const double * weight , double utm_x , double utm_y , double depth, double poisson_ratio, double seabed);
+bool * ecl_grav_common_alloc_aquifer_cell(const ecl_grid_cache_type * grid_cache,
+                                          const ecl_file_type * init_file);
+
+double ecl_grav_common_eval_biot_savart(const ecl_grid_cache_type * grid_cache,
+                                        ecl_region_type * region,
+                                        const bool * aquifer,
+                                        const double * weight,
+                                        double utm_x,
+                                        double utm_y,
+                                        double depth);
+
+double ecl_grav_common_eval_geertsma(const ecl_grid_cache_type * grid_cache,
+                                     ecl_region_type * region,
+                                     const bool * aquifer,
+                                     const double * weight,
+                                     double utm_x,
+                                     double utm_y,
+                                     double depth,
+                                     double poisson_ratio,
+                                     double seabed);
 
 #ifdef __cplusplus
 }

--- a/lib/include/ert/ecl/ecl_sum.h
+++ b/lib/include/ert/ecl/ecl_sum.h
@@ -156,7 +156,10 @@ typedef struct ecl_sum_struct       ecl_sum_type;
   double ecl_sum_iget_general_var(const ecl_sum_type * ecl_sum , int internal_index , const char * lookup_kw);
 
 
-  void                 ecl_sum_init_data_vector( const ecl_sum_type * ecl_sum , double_vector_type * data_vector , int data_index , bool report_only );
+  void                 ecl_sum_init_data_vector(const ecl_sum_type * ecl_sum ,
+                                                double_vector_type * data_vector ,
+                                                int data_index ,
+                                                bool report_only );
   double_vector_type * ecl_sum_alloc_data_vector( const ecl_sum_type * ecl_sum  , int data_index , bool report_only);
   time_t_vector_type * ecl_sum_alloc_time_vector( const ecl_sum_type * ecl_sum  , bool report_only);
   time_t       ecl_sum_get_data_start( const ecl_sum_type * ecl_sum );
@@ -170,8 +173,14 @@ typedef struct ecl_sum_struct       ecl_sum_type;
   const char * ecl_sum_get_case(const ecl_sum_type * );
   bool         ecl_sum_same_case( const ecl_sum_type * ecl_sum , const char * input_file );
 
-  void ecl_sum_resample_from_sim_days( const ecl_sum_type * ecl_sum , const double_vector_type * sim_days , double_vector_type * value , const char * gen_key);
-  void ecl_sum_resample_from_sim_time( const ecl_sum_type * ecl_sum , const time_t_vector_type * sim_time , double_vector_type * value , const char * gen_key);
+  void ecl_sum_resample_from_sim_days(const ecl_sum_type * ecl_sum ,
+                                      const double_vector_type * sim_days ,
+                                      double_vector_type * value ,
+                                      const char * gen_key);
+  void ecl_sum_resample_from_sim_time(const ecl_sum_type * ecl_sum ,
+                                      const time_t_vector_type * sim_time ,
+                                      double_vector_type * value ,
+                                      const char * gen_key);
   time_t ecl_sum_time_from_days( const ecl_sum_type * ecl_sum , double sim_days );
   double ecl_sum_days_from_time( const ecl_sum_type * ecl_sum , time_t sim_time );
   double                ecl_sum_get_sim_length( const ecl_sum_type * ecl_sum ) ;
@@ -192,14 +201,40 @@ typedef struct ecl_sum_struct       ecl_sum_type;
   int                   ecl_sum_iget_report_end( const ecl_sum_type * ecl_sum , int report_step );
   int                   ecl_sum_iget_report_start( const ecl_sum_type * ecl_sum , int report_step );
 
-  ecl_sum_type * ecl_sum_alloc_restart_writer( const char * ecl_case , const char * restart_case , bool fmt_output , bool unified , const char * key_join_string , time_t sim_start , bool time_in_days , int nx , int ny , int nz);
-  ecl_sum_type        * ecl_sum_alloc_writer( const char * ecl_case , bool fmt_output , bool unified , const char * key_join_string , time_t sim_start , bool time_in_days , int nx , int ny , int nz);
+  ecl_sum_type * ecl_sum_alloc_restart_writer(const char * ecl_case ,
+                                              const char * restart_case ,
+                                              bool fmt_output ,
+                                              bool unified ,
+                                              const char * key_join_string ,
+                                              time_t sim_start ,
+                                              bool time_in_days ,
+                                              int nx ,
+                                              int ny ,
+                                              int nz);
+  ecl_sum_type        * ecl_sum_alloc_writer(const char * ecl_case ,
+                                             bool fmt_output ,
+                                             bool unified ,
+                                             const char * key_join_string ,
+                                             time_t sim_start ,
+                                             bool time_in_days ,
+                                             int nx , int ny , int nz);
   void                  ecl_sum_set_case( ecl_sum_type * ecl_sum , const char * ecl_case);
   void                  ecl_sum_fwrite( const ecl_sum_type * ecl_sum );
   void                  ecl_sum_fwrite_smspec( const ecl_sum_type * ecl_sum );
-  smspec_node_type    * ecl_sum_add_var( ecl_sum_type * ecl_sum , const char * keyword , const char * wgname , int num , const char * unit , float default_value);
-  smspec_node_type    * ecl_sum_add_blank_var( ecl_sum_type * ecl_sum , float default_value);
-  void                  ecl_sum_init_var( ecl_sum_type * ecl_sum , smspec_node_type * smspec_node , const char * keyword , const char * wgname , int num , const char * unit);
+  smspec_node_type    * ecl_sum_add_var(ecl_sum_type * ecl_sum ,
+                                        const char * keyword ,
+                                        const char * wgname ,
+                                        int num ,
+                                        const char * unit ,
+                                        float default_value);
+  smspec_node_type    * ecl_sum_add_blank_var(ecl_sum_type * ecl_sum ,
+                                              float default_value);
+  void                  ecl_sum_init_var(ecl_sum_type * ecl_sum ,
+                                         smspec_node_type * smspec_node ,
+                                         const char * keyword ,
+                                         const char * wgname ,
+                                         int num ,
+                                         const char * unit);
   ecl_sum_tstep_type  * ecl_sum_add_tstep( ecl_sum_type * ecl_sum , int report_step , double sim_seconds);
   void                  ecl_sum_update_wgname( ecl_sum_type * ecl_sum , smspec_node_type * node , const char * wgname );
 
@@ -207,7 +242,11 @@ typedef struct ecl_sum_struct       ecl_sum_type;
   char                * ecl_sum_alloc_well_key( const ecl_sum_type * ecl_sum , const char * keyword , const char * wgname);
   bool                  ecl_sum_report_step_equal( const ecl_sum_type * ecl_sum1 , const ecl_sum_type * ecl_sum2);
   bool                  ecl_sum_report_step_compatible( const ecl_sum_type * ecl_sum1 , const ecl_sum_type * ecl_sum2);
-  void                  ecl_sum_export_csv(const ecl_sum_type * ecl_sum , const char * filename  , const stringlist_type * var_list , const char * date_format , const char * sep);
+  void                  ecl_sum_export_csv(const ecl_sum_type * ecl_sum ,
+                                           const char * filename  ,
+                                           const stringlist_type * var_list ,
+                                           const char * date_format ,
+                                           const char * sep);
 
 
   double_vector_type * ecl_sum_alloc_seconds_solution( const ecl_sum_type * ecl_sum , const char * gen_key , double cmp_value , bool rates_clamp_lower);

--- a/lib/include/ert/ecl_well/well_conn_collection.h
+++ b/lib/include/ert/ecl_well/well_conn_collection.h
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2013  Statoil ASA, Norway. 
-   
-   The file 'well_conn_collection.h' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2013  Statoil ASA, Norway.
+
+   The file 'well_conn_collection.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 
@@ -27,23 +27,33 @@ extern "C" {
 
 #include <ert/util/type_macros.h>
 
-#include <ert/ecl/ecl_kw.h>                           
+#include <ert/ecl/ecl_kw.h>
 
 #include <ert/ecl_well/well_conn.h>
 
-  typedef struct well_conn_collection_struct well_conn_collection_type;
+typedef struct well_conn_collection_struct well_conn_collection_type;
 
-  well_conn_collection_type * well_conn_collection_alloc(void);
-  void                        well_conn_collection_free( well_conn_collection_type * wellcc );
-  void                        well_conn_collection_free__( void * arg );
-  int                         well_conn_collection_get_size( const well_conn_collection_type * wellcc );
-  const well_conn_type *      well_conn_collection_iget_const( const well_conn_collection_type * wellcc , int index);
-  well_conn_type       *      well_conn_collection_iget(const well_conn_collection_type * wellcc , int index);
-  void                        well_conn_collection_add( well_conn_collection_type * wellcc , well_conn_type * conn);
-  void                        well_conn_collection_add_ref( well_conn_collection_type * wellcc , well_conn_type * conn);
-  int                         well_conn_collection_load_from_kw( well_conn_collection_type * wellcc , const ecl_kw_type * iwel_kw , const ecl_kw_type * icon_kw , const ecl_kw_type * scon_kw , const ecl_kw_type * xcon_kw , int iwell , const ecl_rsthead_type * rst_head);
+well_conn_collection_type * well_conn_collection_alloc(void);
+void                   well_conn_collection_free(well_conn_collection_type * wellcc);
+void                   well_conn_collection_free__(void * arg);
+int                    well_conn_collection_get_size(const well_conn_collection_type * wellcc);
+const well_conn_type * well_conn_collection_iget_const(const well_conn_collection_type * wellcc,
+                                                       int index);
+well_conn_type       * well_conn_collection_iget(const well_conn_collection_type * wellcc,
+                                                 int index);
+void                   well_conn_collection_add(well_conn_collection_type * wellcc,
+                                                well_conn_type * conn);
+void                   well_conn_collection_add_ref(well_conn_collection_type * wellcc,
+                                                    well_conn_type * conn);
+int                    well_conn_collection_load_from_kw(well_conn_collection_type * wellcc,
+                                                         const ecl_kw_type * iwel_kw,
+                                                         const ecl_kw_type * icon_kw,
+                                                         const ecl_kw_type * scon_kw,
+                                                         const ecl_kw_type * xcon_kw,
+                                                         int iwell,
+                                                         const ecl_rsthead_type * rst_head);
 
-  UTIL_IS_INSTANCE_HEADER( well_conn_collection );
+UTIL_IS_INSTANCE_HEADER(well_conn_collection);
 
 #ifdef __cplusplus
 }

--- a/lib/util/matrix_lapack.c
+++ b/lib/util/matrix_lapack.c
@@ -30,14 +30,85 @@ extern "C" {
     The external lapack routines
 */
 /*****************************************************************/
-void  dgesv_(int * n, int * nrhs , double * A , int * lda , long int * ipivot , double * B , int * ldb , int * info);
-void  dgesvd_(char * jobu , char * jobvt , int * m , int * n , double * A, int * lda , double * S , double * U , int * ldu , double * VT , int * ldvt, double * work , int * worksize , int * info);
-void  dsyevx_(char * jobz, char * range , char * uplo , int *n , double * A , int * lda , double * vl , double * vu , int * il , int * iu , double * abstol , int * m , double * w , double *z , int * ldz , double * work, int * lwork , int * iwork , int * ifail , int * info);
-void  dgeqrf_(int * m , int * n , double * A , int * lda , double * tau , double * work , int * lwork, int * info);
-void  dorgqr_(int * m, int * n , int * k , double * A , int * lda , double * tau , double * work , int * lwork, int * info);
-void  dgetrf_(int * M , int * n , double * A , int * lda , int * ipiv, int * info);
-void  dgedi_(double * A , int * lda , int * n , int * ipiv , double * det , double * work , int * job);
-void  dgetri_( int * n , double * A , int * lda , int * ipiv , double * work , int * work_size , int * info);
+void  dgesv_(int * n,
+             int * nrhs,
+             double * A,
+             int * lda,
+             long int * ipivot,
+             double * B,
+             int * ldb,
+             int * info);
+void  dgesvd_(char * jobu,
+              char * jobvt,
+              int * m,
+              int * n,
+              double * A,
+              int * lda,
+              double * S,
+              double * U,
+              int * ldu,
+              double * VT,
+              int * ldvt,
+              double * work,
+              int * worksize,
+              int * info);
+void  dsyevx_(char * jobz,
+              char * range,
+              char * uplo,
+              int *n,
+              double * A,
+              int * lda,
+              double * vl,
+              double * vu,
+              int * il,
+              int * iu,
+              double * abstol,
+              int * m,
+              double * w,
+              double *z,
+              int * ldz,
+              double * work,
+              int * lwork,
+              int * iwork,
+              int * ifail,
+              int * info);
+void  dgeqrf_(int * m,
+              int * n,
+              double * A,
+              int * lda,
+              double * tau,
+              double * work,
+              int * lwork,
+              int * info);
+void  dorgqr_(int * m,
+              int * n,
+              int * k,
+              double * A,
+              int * lda,
+              double * tau,
+              double * work,
+              int * lwork,
+              int * info);
+void  dgetrf_(int * M,
+              int * n,
+              double * A,
+              int * lda,
+              int * ipiv,
+              int * info);
+void  dgedi_(double * A,
+             int * lda,
+             int * n,
+             int * ipiv,
+             double * det,
+             double * work,
+             int * job);
+void  dgetri_(int * n,
+              double * A,
+              int * lda,
+              int * ipiv,
+              double * work,
+              int * work_size,
+              int * info);
 /*****************************************************************/
 
 


### PR DESCRIPTION
**Task**

Some lines are > 150 (infact > 250) characters long.

Objectively, that is too long.

We should aim for 80 characters per line, strive to stay within 100, reject lines with length > 130, and anything above 150 is ridiculous.

List of files with longest lines:

```bash
libecl/lib$ find . -type f -exec wc -L {} \; | sort -n | tail
209 ./ecl/ecl_kw.c
212 ./ecl/tests/ecl_grid_cell_contains.c
213 ./include/ert/util/subst_func.h
218 ./ecl/ecl_rft_cell.c
220 ./ecl/tests/well_conn_CF.c
221 ./ecl/tests/ecl_sum_writer.c
223 ./ecl/smspec_node.c
227 ./ecl/ecl_sum.c
235 ./ecl/ecl_grav_common.c
251 ./ecl/ecl_grid.c
```