### PR TITLE
Attempt to make ert_util_spawn more robust

### DIFF
--- a/lib/include/ert/util/util.h
+++ b/lib/include/ert/util/util.h
@@ -197,6 +197,7 @@ typedef enum {left_pad   = 0,
 
 #ifdef ERT_HAVE_GETUID
   uid_t        util_get_entry_uid( const char * file );
+  mode_t       util_getmode( const char * filename);
   bool         util_addmode_if_owner( const char * filename , mode_t add_mode );
   bool         util_delmode_if_owner( const char * filename , mode_t del_mode);
   bool         util_chmod_if_owner( const char * filename , mode_t new_mode);

--- a/lib/util/util_getuid.c
+++ b/lib/util/util_getuid.c
@@ -13,6 +13,12 @@ uid_t util_get_entry_uid( const char * file ) {
   return buffer.st_uid;
 }
 
+mode_t util_getmode( const char * file ) {
+  stat_type buffer;
+  util_stat( file , &buffer);
+  return buffer.st_mode;
+}
+
 
 
 bool util_chmod_if_owner( const char * filename , mode_t new_mode) {


### PR DESCRIPTION
**Task**
ert_util_spawn is flaky. When trying to spawn the process for testing, error 127 is reported, which can be "file not found" or "file is not executable"

**Approach**
One of the possible causes could be the creation of the script file the file system. I've rearranged the tests so that the script files are all created in advance. It also checks if the file exists right afterwards. If it doesn't, wait one second and try again (max 10 times). If the file sistem is very slow, it can still fail, but that should be rare

**Pre un-WIP checklist**
- [x] Statoil tests pass locally
