### PR TITLE
WIP: Ecl well reduce mem use with transactions

### DIFF
--- a/lib/ecl/well_info.c
+++ b/lib/ecl/well_info.c
@@ -30,6 +30,7 @@
 #include <ert/ecl/ecl_kw.h>
 #include <ert/ecl/ecl_kw_magic.h>
 #include <ert/ecl/ecl_util.h>
+#include <ert/ecl/ecl_file_transaction.h>
 
 #include <ert/ecl_well/well_const.h>
 #include <ert/ecl_well/well_conn.h>
@@ -304,10 +305,16 @@ void well_info_add_UNRST_wells2( well_info_type * well_info , ecl_file_view_type
   int num_blocks = ecl_file_view_get_num_named_kw( rst_view , SEQNUM_KW );
   int block_nr;
   for (block_nr = 0; block_nr < num_blocks; block_nr++) {
-    ecl_file_view_type * step_view = ecl_file_view_add_restart_view(rst_view, block_nr , -1 , -1 , -1 );
-    const ecl_kw_type * seqnum_kw = ecl_file_view_iget_named_kw( step_view , SEQNUM_KW , 0);
-    int report_nr = ecl_kw_iget_int( seqnum_kw , 0 );
-    well_info_add_wells2( well_info , step_view , report_nr , load_segment_information );
+
+    ecl_file_transaction_type * t1 = ecl_file_view_start_transaction(rst_view);
+      ecl_file_view_type * step_view = ecl_file_view_add_restart_view(rst_view, block_nr , -1 , -1 , -1 );
+      const ecl_kw_type * seqnum_kw = ecl_file_view_iget_named_kw( step_view , SEQNUM_KW , 0);
+      int report_nr = ecl_kw_iget_int( seqnum_kw , 0 );
+    ecl_file_view_end_transaction(rst_view, t1);
+
+    ecl_file_transaction_type * t2 = ecl_file_view_start_transaction(rst_view);
+      well_info_add_wells2( well_info , step_view , report_nr , load_segment_information );
+    ecl_file_view_end_transaction(rst_view, t2);
   }
 }
 

--- a/lib/ecl/well_info.c
+++ b/lib/ecl/well_info.c
@@ -306,15 +306,13 @@ void well_info_add_UNRST_wells2( well_info_type * well_info , ecl_file_view_type
   int block_nr;
   for (block_nr = 0; block_nr < num_blocks; block_nr++) {
 
-    ecl_file_transaction_type * t1 = ecl_file_view_start_transaction(rst_view);
-      ecl_file_view_type * step_view = ecl_file_view_add_restart_view(rst_view, block_nr , -1 , -1 , -1 );
-      const ecl_kw_type * seqnum_kw = ecl_file_view_iget_named_kw( step_view , SEQNUM_KW , 0);
-      int report_nr = ecl_kw_iget_int( seqnum_kw , 0 );
-    ecl_file_view_end_transaction(rst_view, t1);
+    ecl_file_view_type * step_view = ecl_file_view_add_restart_view(rst_view, block_nr , -1 , -1 , -1 );
+    const ecl_kw_type * seqnum_kw = ecl_file_view_iget_named_kw( step_view , SEQNUM_KW , 0);
+    int report_nr = ecl_kw_iget_int( seqnum_kw , 0 );
 
-    ecl_file_transaction_type * t2 = ecl_file_view_start_transaction(rst_view);
+    ecl_file_transaction_type * t = ecl_file_view_start_transaction(rst_view);
       well_info_add_wells2( well_info , step_view , report_nr , load_segment_information );
-    ecl_file_view_end_transaction(rst_view, t2);
+    ecl_file_view_end_transaction(rst_view, t);
   }
 }
 

--- a/lib/ecl/well_info.c
+++ b/lib/ecl/well_info.c
@@ -30,7 +30,6 @@
 #include <ert/ecl/ecl_kw.h>
 #include <ert/ecl/ecl_kw_magic.h>
 #include <ert/ecl/ecl_util.h>
-#include <ert/ecl/ecl_file_transaction.h>
 
 #include <ert/ecl_well/well_const.h>
 #include <ert/ecl_well/well_conn.h>

--- a/python/tests/well/test_ecl_well2.py
+++ b/python/tests/well/test_ecl_well2.py
@@ -37,7 +37,7 @@ class EclWellTest2(ExtendedTestCase):
 
                 
     def testWell(self):
-        self.checkWell("T07-4A-W2014-06.X0695")
-        self.checkWell("T07-4A-W2014-06.X0709")
+        #self.checkWell("T07-4A-W2014-06.X0695")
+        #self.checkWell("T07-4A-W2014-06.X0709")
         self.checkWell("T07-4A-W2014-06.UNRST")
         

--- a/python/tests/well/test_ecl_well2.py
+++ b/python/tests/well/test_ecl_well2.py
@@ -37,7 +37,7 @@ class EclWellTest2(ExtendedTestCase):
 
                 
     def testWell(self):
-        #self.checkWell("T07-4A-W2014-06.X0695")
-        #self.checkWell("T07-4A-W2014-06.X0709")
+        self.checkWell("T07-4A-W2014-06.X0695")
+        self.checkWell("T07-4A-W2014-06.X0709")
         self.checkWell("T07-4A-W2014-06.UNRST")
         


### PR DESCRIPTION
**Task**
ERT-1345: Due to extremely large (~300 GB) UNRST files, memory use is too high and thus causes program to crash. 


**Approach**
A function in well_info is wrapped in a transaction type. 


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
