### PR TITLE
more packaging updates

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Vcs-Browser: https://github.com/Ensembles/ert
 Package: libecl-dev
 Section: libdevel
 Architecture: any
-Depends: libecl1 (= ${binary:Version})
+Depends: libecl1 (= ${binary:Version}), libblas-dev, liblapack-dev
 Description: libecl Eclipse IO library -- Development files
  libecl is a package for reading and writing the result files from the Eclipse reservoir simulator.
 

--- a/debian/libecl-dev.install
+++ b/debian/libecl-dev.install
@@ -1,2 +1,3 @@
 usr/include/*
 usr/lib/*/*.so
+usr/share/cmake/ecl/*

--- a/debian/rules
+++ b/debian/rules
@@ -13,4 +13,4 @@
 	dh $@
 
 override_dh_auto_configure:
-	DESTDIR=$$(pwd)/debian/tmp dh_auto_configure -- -DBUILD_SHARED_LIBS=1 -DBUILD_ECL_SUMMARY=1 -DBUILD_PYTHON=1 -DCMAKE_BUILD_TYPE=Release -DERT_USE_OPENMP=1
+	DESTDIR=$$(pwd)/debian/tmp dh_auto_configure -- -DBUILD_SHARED_LIBS=1 -DBUILD_ECL_SUMMARY=1 -DBUILD_PYTHON=1 -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
package missing cmake config files
disable OpenMP again, it causes issues in downstreams
add blas/lapack dev to list of development packages

Sorry for the quick update, but some things were discovered while processing downstreams.

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
