### PR TITLE
Fix bug in smspec_cmp for NETWORK_VAR

### DIFF
--- a/lib/ecl/ecl_smspec.c
+++ b/lib/ecl/ecl_smspec.c
@@ -980,24 +980,20 @@ bool ecl_smspec_needs_num( ecl_smspec_var_type var_type ) {
 
 
 
-bool ecl_smspec_equal( const ecl_smspec_type * self , const ecl_smspec_type * other) {
-  bool equal = true;
+bool ecl_smspec_equal(const ecl_smspec_type * self,
+                      const ecl_smspec_type * other) {
+  if (vector_get_size( self->smspec_nodes ) != vector_get_size( other->smspec_nodes))
+    return false;
 
-  if (vector_get_size( self->smspec_nodes ) == vector_get_size( other->smspec_nodes)) {
-    for (int i=0; i < vector_get_size( self->smspec_nodes ); i++) {
-      const smspec_node_type * node1 = vector_iget_const( self->smspec_nodes , i );
-      const smspec_node_type * node2 = vector_iget_const( other->smspec_nodes , i );
+  for (int i=0; i < vector_get_size( self->smspec_nodes ); i++) {
+    const smspec_node_type * node1 = vector_iget_const(self->smspec_nodes, i);
+    const smspec_node_type * node2 = vector_iget_const(other->smspec_nodes, i);
 
-      if (!smspec_node_equal( node1,node2)) {
-        equal = false;
-        break;
-      }
+    if (!smspec_node_equal(node1, node2))
+      return false;
+  }
 
-    }
-  } else
-    equal = false;
-
-  return equal;
+  return true;
 }
 
 

--- a/lib/ecl/smspec_node.c
+++ b/lib/ecl/smspec_node.c
@@ -1122,6 +1122,14 @@ static int smspec_node_cmp_KEYWORD( const smspec_node_type * node1, const smspec
 }
 
 static int smspec_node_cmp_key1( const smspec_node_type * node1, const smspec_node_type * node2) {
+  if (!node1->gen_key1) {
+    if (!node2->gen_key1)
+      return 0;
+    else
+      return -1;
+  } else if (!node2->gen_key1) {
+    return 1;
+  }
   return util_strcmp_int( node1->gen_key1 , node2->gen_key1 );
 }
 

--- a/lib/ecl/tests/ecl_smspec_node.c
+++ b/lib/ecl/tests/ecl_smspec_node.c
@@ -57,6 +57,9 @@ void test_cmp_types() {
   test_assert_true( smspec_node_cmp( misc_node1, misc_node2) < 0 );
   test_assert_true( smspec_node_cmp( misc_node2, misc_node1) > 0 );
 
+  smspec_node_type * net1 = smspec_node_alloc(ECL_SMSPEC_NETWORK_VAR, "Net", "FOPT", "UNIT", ":", dims, 10 , 0, 0);
+  smspec_node_type * net2 = smspec_node_alloc(ECL_SMSPEC_NETWORK_VAR, "Net", "FOPT", "UNIT", ":", dims, 10 , 0, 0);
+  test_assert_true( smspec_node_cmp( net1, net2) == 0 );
 
   smspec_node_free( segment_node );
   smspec_node_free( aquifer_node );
@@ -67,6 +70,8 @@ void test_cmp_types() {
   smspec_node_free( field_node );
   smspec_node_free( misc_node1 );
   smspec_node_free( misc_node2 );
+  smspec_node_free( net1 );
+  smspec_node_free( net2 );
 }
 
 void test_cmp_well() {


### PR DESCRIPTION
**Task**
**ERT-1384**: Bug in ecl summary load_


**Approach**
Fix bug in `smspec_cmp` (two NULLs were attempted compared):
```patch

 
diff --git a/lib/ecl/smspec_node.c b/lib/ecl/smspec_node.c
index 773a1b05a..412b02773 100644
--- a/lib/ecl/smspec_node.c
+++ b/lib/ecl/smspec_node.c
@@ -1122,6 +1122,14 @@ static int smspec_node_cmp_KEYWORD( const smspec_node_type * node1, const smspec
 }
 
 static int smspec_node_cmp_key1( const smspec_node_type * node1, const smspec_node_type * node2) {
+  if (!node1->gen_key1) {
+    if (!node2->gen_key1)
+      return 0;
+    else
+      return -1;
+  } else if (!node2->gen_key1) {
+    return 1;
+  }
   return util_strcmp_int( node1->gen_key1 , node2->gen_key1 );
 }
```


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
