### PR TITLE
Fix ecl nnc data alloc wat flux

### DIFF
--- a/lib/ecl/ecl_nnc_data.c
+++ b/lib/ecl/ecl_nnc_data.c
@@ -167,8 +167,8 @@ static ecl_kw_type * ecl_nnc_data_get_kw( const ecl_grid_type * grid, const ecl_
       return NULL;
 }
 
-static void assert_correct_kw_count(ecl_kw_type * kw, const char * function_name, bool check_kw_count, int correct_kw_count, int kw_count) {
-   if (check_kw_count & (correct_kw_count != kw_count))
+static void assert_correct_kw_count(ecl_kw_type * kw, const char * function_name, int correct_kw_count, int kw_count) {
+   if (correct_kw_count != kw_count)
       util_abort("In function %s, reading kw: %s. %d != %d", function_name, ecl_kw_get_header(kw), correct_kw_count, kw_count);
 }
 
@@ -180,7 +180,6 @@ static bool ecl_nnc_data_set_values(ecl_nnc_data_type * data, const ecl_grid_typ
    ecl_kw_type * current_kw = NULL;
    int correct_kw_count = 0;
    int kw_count = 0;
-   bool check_kw_count = false;
    int nnc_size = ecl_nnc_geometry_size( nnc_geo );   
 
    for (int nnc_index = 0; nnc_index < nnc_size; nnc_index++) {
@@ -191,12 +190,11 @@ static bool ecl_nnc_data_set_values(ecl_nnc_data_type * data, const ecl_grid_typ
       if (grid1 != current_grid1 || grid2 != current_grid2) {
          current_grid1 = grid1;
          current_grid2 = grid2;
-         assert_correct_kw_count(current_kw, __func__, check_kw_count, correct_kw_count, kw_count);
+         assert_correct_kw_count(current_kw, __func__, correct_kw_count, kw_count);
          current_kw = ecl_nnc_data_get_kw( grid, init_file, grid1 , grid2 , kw_type);
          kw_count = 0;
          if (current_kw) {            
             correct_kw_count = ecl_kw_get_size( current_kw );
-            check_kw_count = true;
          }
          else {
             return false;
@@ -208,7 +206,7 @@ static bool ecl_nnc_data_set_values(ecl_nnc_data_type * data, const ecl_grid_typ
       }
       
    }
-   assert_correct_kw_count(current_kw, __func__, check_kw_count, correct_kw_count, kw_count);
+   assert_correct_kw_count(current_kw, __func__, correct_kw_count, kw_count);
    return true;
 }
 

--- a/lib/ecl/ecl_nnc_data.c
+++ b/lib/ecl/ecl_nnc_data.c
@@ -198,7 +198,6 @@ static bool ecl_nnc_data_set_values(ecl_nnc_data_type * data, const ecl_grid_typ
          if (current_kw) {            
             correct_kw_count = ecl_kw_get_size( current_kw );
             check_kw_count = true;
-            data->size = nnc_index + correct_kw_count;
          }
          else {
             all_nnc_kw_present = false;
@@ -216,9 +215,9 @@ static bool ecl_nnc_data_set_values(ecl_nnc_data_type * data, const ecl_grid_typ
 
 static ecl_nnc_data_type * ecl_nnc_data_alloc__(const ecl_grid_type * grid, const ecl_nnc_geometry_type * nnc_geo, const ecl_file_view_type * init_file, int kw_type) {
    ecl_nnc_data_type * data = util_malloc(sizeof * data);
-   data->size = 0;
 
    int nnc_size = ecl_nnc_geometry_size( nnc_geo );
+   data->size = nnc_size;
 
    data->values = util_malloc( nnc_size * sizeof(double));
 

--- a/lib/ecl/ecl_nnc_data.c
+++ b/lib/ecl/ecl_nnc_data.c
@@ -182,7 +182,6 @@ static bool ecl_nnc_data_set_values(ecl_nnc_data_type * data, const ecl_grid_typ
    int kw_count = 0;
    bool check_kw_count = false;
    int nnc_size = ecl_nnc_geometry_size( nnc_geo );   
-   bool all_nnc_kw_present = true;
 
    for (int nnc_index = 0; nnc_index < nnc_size; nnc_index++) {
       const ecl_nnc_pair_type * pair = ecl_nnc_geometry_iget( nnc_geo, nnc_index );
@@ -200,7 +199,7 @@ static bool ecl_nnc_data_set_values(ecl_nnc_data_type * data, const ecl_grid_typ
             check_kw_count = true;
          }
          else {
-            all_nnc_kw_present = false;
+            return false;
          }
       }
       if (current_kw) {
@@ -210,7 +209,7 @@ static bool ecl_nnc_data_set_values(ecl_nnc_data_type * data, const ecl_grid_typ
       
    }
    assert_correct_kw_count(current_kw, __func__, check_kw_count, correct_kw_count, kw_count);
-   return all_nnc_kw_present;
+   return true;
 }
 
 static ecl_nnc_data_type * ecl_nnc_data_alloc__(const ecl_grid_type * grid, const ecl_nnc_geometry_type * nnc_geo, const ecl_file_view_type * init_file, int kw_type) {

--- a/lib/ecl/tests/test_ecl_nnc_data.c
+++ b/lib/ecl/tests/test_ecl_nnc_data.c
@@ -31,6 +31,8 @@
 
 
 
+
+
 void test_alloc_global_only(bool data_in_file) {
    test_work_area_type * work_area = test_work_area_alloc("nnc-INIT");
    {
@@ -66,10 +68,11 @@ void test_alloc_global_only(bool data_in_file) {
          ecl_file_view_type * view_file = ecl_file_get_global_view( init_file );       
          
          ecl_nnc_data_type * nnc_geo_data = ecl_nnc_data_alloc_tran(grid0, nnc_geo, view_file);
-         int nnc_data_size = ecl_nnc_data_get_size( nnc_geo_data );
+         
 
          if (data_in_file) {
-
+    
+            int nnc_data_size = ecl_nnc_data_get_size( nnc_geo_data );
             test_assert_true( ecl_file_view_has_kw( view_file, TRANNNC_KW) );
             test_assert_true(nnc_data_size == 3);
             const double * values = ecl_nnc_data_get_values( nnc_geo_data );
@@ -78,9 +81,10 @@ void test_alloc_global_only(bool data_in_file) {
             test_assert_double_equal(values[2] , 3.0);
          }
          else
-            test_assert_true(nnc_data_size == 0);
+            test_assert_NULL(nnc_geo_data);
          
-         ecl_nnc_data_free( nnc_geo_data );
+         if (data_in_file)
+           ecl_nnc_data_free( nnc_geo_data );
          ecl_nnc_geometry_free( nnc_geo );
          ecl_file_close(init_file);
       }

--- a/lib/ecl/tests/test_ecl_nnc_data_statoil_root.c
+++ b/lib/ecl/tests/test_ecl_nnc_data_statoil_root.c
@@ -30,12 +30,6 @@
 #include <ert/util/test_work_area.h>
 
 
-void assert_data_values_read(ecl_nnc_data_type * nnc_data) {
-   int data_size = ecl_nnc_data_get_size(nnc_data);
-   for (int n = 0; n < data_size; n++) {
-      test_assert_double_not_equal(-1.0, ecl_nnc_data_iget_value(nnc_data, n));
-   }
-}
 
 int find_index(ecl_nnc_geometry_type * nnc_geo, int grid1, int grid2, int indx1, int indx2) {
    int index = -1;
@@ -109,7 +103,7 @@ void test_alloc_file_flux(char * filename, int file_num) {
       ecl_file_view_type * view_file = ecl_file_get_global_view( restart_file );
 
       ecl_nnc_data_type * nnc_flux_data = ecl_nnc_data_alloc_wat_flux(grid, nnc_geo, view_file);
-      assert_data_values_read(nnc_flux_data);
+      test_assert_not_NULL(nnc_flux_data);
       ecl_nnc_data_free( nnc_flux_data );
    }
    ecl_nnc_geometry_free(nnc_geo);


### PR DESCRIPTION
**Task**
ecl_nnc_data_alloc_wat_flux shall return NULL if any wat_flux nnc type kws are missing when loaded from file. 


**Approach**
Changes in ecl_nnc_data.c causing ecl_nnc_data_alloc_XXX (including wat_flux) to return NULL if keywords necessary to build a complete ecl_nnc_data structure are missing. 
Also the data attribute of the ecl_nnc_data structure is set to be the same as for the ecl_nnc_geometry_type input. 

**Pre un-WIP checklist**
- [x] Statoil tests pass locally
