### PR TITLE
Sum mask

### DIFF
--- a/lib/ecl/ecl_kw.c
+++ b/lib/ecl/ecl_kw.c
@@ -2442,6 +2442,9 @@ static void ecl_kw_inplace_div_indexed_ ## ctype( ecl_kw_type * target_kw , cons
 }
 
 
+
+
+
 ECL_KW_TYPED_INPLACE_DIV_INDEXED( int )
 ECL_KW_TYPED_INPLACE_DIV_INDEXED( double )
 ECL_KW_TYPED_INPLACE_DIV_INDEXED( float )
@@ -2463,6 +2466,7 @@ void ecl_kw_inplace_div_indexed( ecl_kw_type * target_kw , const int_vector_type
     util_abort("%s: inplace div not implemented for type:%s \n",__func__ , ecl_type_alloc_name( ecl_kw_get_data_type(target_kw) ));
   }
 }
+
 
 
 
@@ -2623,6 +2627,49 @@ ECL_KW_MIN( double )
 #undef ECL_KW_MAX_MIN
 
 
+#define KW_SUM_INDEXED(type)                                       \
+{                                                                  \
+  const type * data = ecl_kw_get_data_ref(ecl_kw);                 \
+  type sum = 0;                                                    \
+  int size = int_vector_size( index_list );                        \
+  const int * index_ptr = int_vector_get_const_ptr( index_list );  \
+  for (int i = 0; i < size; i++)                                   \
+     sum += data[index_ptr[i]];                                    \
+  memcpy(_sum , &sum , ecl_kw_get_sizeof_ctype(ecl_kw));           \
+}
+
+
+void ecl_kw_element_sum_indexed(const ecl_kw_type * ecl_kw , const int_vector_type * index_list, void * _sum) {
+  switch (ecl_kw_get_type(ecl_kw)) {
+  case(ECL_FLOAT_TYPE):
+    KW_SUM_INDEXED(float);
+    break;
+  case(ECL_DOUBLE_TYPE):
+    KW_SUM_INDEXED(double);
+    break;
+  case(ECL_INT_TYPE):
+    KW_SUM_INDEXED(int);
+    break;
+  case(ECL_BOOL_TYPE):
+    {
+      const int * data = ecl_kw_get_data_ref(ecl_kw);
+      const int * index_ptr = int_vector_get_const_ptr( index_list );
+      const int size = int_vector_size( index_list );
+      int sum = 0;
+      for (int i = 0; i < size; i++)
+        sum += (data[index_ptr[i]] == ECL_BOOL_TRUE_INT);
+
+      memcpy(_sum , &sum , sizeof sum);
+    }
+    break;
+  default:
+    util_abort("%s: invalid type for element sum \n",__func__);
+  }
+}
+#undef KW_SUM
+
+
+
 
 
 
@@ -2630,10 +2677,9 @@ ECL_KW_MIN( double )
 
 #define KW_SUM(type)                                        \
 {                                                           \
-  type * data = ecl_kw_get_data_ref(ecl_kw);                \
+  const type * data = ecl_kw_get_data_ref(ecl_kw);          \
   type sum = 0;                                             \
-  int i;                                                    \
-  for (i=0; i < ecl_kw_get_size(ecl_kw); i++)               \
+  for (int i=0; i < ecl_kw_get_size(ecl_kw); i++)           \
      sum += data[i];                                        \
   memcpy(_sum , &sum , ecl_kw_get_sizeof_ctype(ecl_kw));    \
 }

--- a/lib/ecl/ecl_region.c
+++ b/lib/ecl/ecl_region.c
@@ -1492,3 +1492,36 @@ bool ecl_region_equal( const ecl_region_type * region1 , const ecl_region_type *
   } else
     return false;
 }
+
+/*****************************************************************/
+
+int ecl_region_sum_kw_int( ecl_region_type * ecl_region, const ecl_kw_type * ecl_kw , bool force_active) {
+  int sum;
+  const int_vector_type * index_set = ecl_region_get_kw_index_list( ecl_region , ecl_kw , force_active);
+  ecl_kw_element_sum_indexed( ecl_kw , index_set , &sum );
+  return sum;
+}
+
+
+float ecl_region_sum_kw_float( ecl_region_type * ecl_region, const ecl_kw_type * ecl_kw , bool force_active) {
+  float sum;
+  const int_vector_type * index_set = ecl_region_get_kw_index_list( ecl_region , ecl_kw , force_active);
+  ecl_kw_element_sum_indexed( ecl_kw , index_set , &sum);
+  return sum;
+}
+
+
+double ecl_region_sum_kw_double( ecl_region_type * ecl_region, const ecl_kw_type * ecl_kw , bool force_active) {
+  double sum;
+  const int_vector_type * index_set = ecl_region_get_kw_index_list( ecl_region , ecl_kw , force_active);
+  ecl_kw_element_sum_indexed( ecl_kw , index_set , &sum);
+  return sum;
+}
+
+
+int ecl_region_sum_kw_bool( ecl_region_type * ecl_region, const ecl_kw_type * ecl_kw , bool force_active) {
+  int sum;
+  const int_vector_type * index_set = ecl_region_get_kw_index_list( ecl_region , ecl_kw , force_active);
+  ecl_kw_element_sum_indexed( ecl_kw , index_set , &sum);
+  return sum;
+}

--- a/lib/include/ert/ecl/ecl_kw.h
+++ b/lib/include/ert/ecl/ecl_kw.h
@@ -148,6 +148,7 @@ extern "C" {
   double     ecl_kw_element_sum_float( const ecl_kw_type * ecl_kw );
   void       ecl_kw_inplace_inv(ecl_kw_type * my_kw);
   void       ecl_kw_element_sum(const ecl_kw_type * , void * );
+  void ecl_kw_element_sum_indexed(const ecl_kw_type * ecl_kw , const int_vector_type * index_list, void * _sum);
   void       ecl_kw_max_min(const ecl_kw_type * , void * , void *);
   void     * ecl_kw_get_void_ptr(const ecl_kw_type * ecl_kw);
 

--- a/lib/include/ert/ecl/ecl_region.h
+++ b/lib/include/ert/ecl/ecl_region.h
@@ -185,6 +185,10 @@ typedef struct ecl_region_struct ecl_region_type;
 
 /*****************************************************************/
 
+  double ecl_region_sum_kw_double( ecl_region_type * ecl_region , const ecl_kw_type * ecl_kw , bool force_active);
+  int    ecl_region_sum_kw_int( ecl_region_type * ecl_region , const ecl_kw_type * ecl_kw , bool force_active);
+  float  ecl_region_sum_kw_float( ecl_region_type * ecl_region , const ecl_kw_type * ecl_kw , bool force_active);
+  int    ecl_region_sum_kw_bool( ecl_region_type * ecl_region , const ecl_kw_type * ecl_kw , bool force_active);
 
 
 

--- a/python/python/ecl/ecl/ecl_kw.py
+++ b/python/python/ecl/ecl/ecl_kw.py
@@ -643,27 +643,30 @@ class EclKW(BaseCClass):
 
     # No __rdiv__()
 
-    def sum(self):
+    def sum(self, mask = None, force_active = False):
         """
         Will calculate the sum of all the elements in the keyword.
 
         String: Raise ValueError exception.
         Bool:   The number of true values
         """
-        if self.data_type.is_int():
-            return self._int_sum()
-        elif self.data_type.is_float():
-            return self._float_sum()
-        elif self.data_type.is_double():
-            return self._float_sum()
-        elif self.data_type.is_bool():
-            sum = 0
-            for elm in self:
-                if elm:
-                    sum += 1
-            return sum
-        else:
-            raise ValueError('The keyword "%s" is of string type - sum is not implemented' % self.getName())
+        if mask is None:
+            if self.data_type.is_int():
+                return self._int_sum()
+            elif self.data_type.is_float():
+                return self._float_sum()
+            elif self.data_type.is_double():
+                return self._float_sum()
+            elif self.data_type.is_bool():
+                sum = 0
+                for elm in self:
+                    if elm:
+                        sum += 1
+                return sum
+            else:
+                raise ValueError('The keyword "%s" is of string type - sum is not implemented' % self.getName())
+
+        return mask.sum_kw(self, force_active)
 
 
 

--- a/python/python/ecl/ecl/ecl_region.py
+++ b/python/python/ecl/ecl/ecl_region.py
@@ -206,7 +206,7 @@ class EclRegion(BaseCClass):
         return self._alloc_copy( )
 
 
-    def __zero__(self):
+    def __nonzero__(self):
         global_list = self.getGlobalList()
         if len(global_list) > 0:
             return True
@@ -972,6 +972,14 @@ class EclRegion(BaseCClass):
         Helper function (attribute) to support run-time typechecking.
         """
         return True
+
+
+    def active_size(self):
+        return len(self._get_active_list())
+
+
+    def global_size(self):
+        return len(self._get_global_list())
 
 
     def get_active_list(self):

--- a/python/python/ecl/ecl/ecl_region.py
+++ b/python/python/ecl/ecl/ecl_region.py
@@ -89,6 +89,10 @@ class EclRegion(BaseCClass):
     _scale_kw_int               = EclPrototype("void ecl_region_scale_kw_int( ecl_region , ecl_kw , int, bool) ")
     _scale_kw_float             = EclPrototype("void ecl_region_scale_kw_float( ecl_region , ecl_kw , float, bool ) ")
     _scale_kw_double            = EclPrototype("void ecl_region_scale_kw_double( ecl_region , ecl_kw , double , bool) ")
+    _sum_kw_int                 = EclPrototype("int ecl_region_sum_kw_int( ecl_region , ecl_kw , bool) ")
+    _sum_kw_float               = EclPrototype("float ecl_region_sum_kw_float( ecl_region , ecl_kw , bool ) ")
+    _sum_kw_double              = EclPrototype("double ecl_region_sum_kw_double( ecl_region , ecl_kw , bool) ")
+    _sum_kw_bool                = EclPrototype("int ecl_region_sum_kw_int( ecl_region , ecl_kw , bool) ")
 
     _free                       = EclPrototype("void ecl_region_free( ecl_region )")
     _reset                      = EclPrototype("void ecl_region_reset( ecl_region )")
@@ -944,6 +948,21 @@ class EclRegion(BaseCClass):
                                                 EclDataType.ECL_DOUBLE : self._set_kw_double} , force_active)
 
 
+    def sum_kw(self, kw, force_active = False):
+        data_type = kw.data_type
+        if data_type == EclDataType.ECL_FLOAT:
+            return self._sum_kw_float( kw, force_active )
+
+        if data_type == EclDataType.ECL_INT:
+            return self._sum_kw_int( kw, force_active )
+
+        if data_type == EclDataType.ECL_DOUBLE:
+            return self._sum_kw_double( kw, force_active )
+
+        if data_type == EclDataType.ECL_BOOL:
+            return self._sum_kw_bool( kw, force_active )
+
+        raise ValueError("sum_kw only supported for; INT/FLOAT/DOUBLE/BOOL")
 
 
     #################################################################

--- a/python/tests/ecl/test_region.py
+++ b/python/tests/ecl/test_region.py
@@ -16,7 +16,7 @@
 from ecl.ecl import EclGrid, EclKW, EclRegion, EclDataType
 from ecl.ecl.faults import Layer
 from ecl.test import ExtendedTestCase
-
+from ecl.util import IntVector
 
 class RegionTest(ExtendedTestCase):
 
@@ -59,3 +59,19 @@ class RegionTest(ExtendedTestCase):
         self.assertEqual( double_value.sum( mask = region ) , 1.0*49*50/2 )
         self.assertEqual( float_value.sum( mask = region ) , 1.0*49*50/2 )
         self.assertEqual( bool_value.sum( mask = region ) , 50 )
+
+
+    def test_truth_and_size(self):
+        actnum = IntVector( initial_size = 100, default_value = 0)
+        actnum[0:50] = 1
+        grid = EclGrid.createRectangular( (10,10,1) , (1,1,1), actnum = actnum)
+        region = EclRegion(grid, False)
+
+        self.assertFalse( region )
+        self.assertEqual( 0, region.active_size( ))
+        self.assertEqual( 0, region.global_size( ))
+        region.select_all( )
+        self.assertTrue( region )
+
+        self.assertEqual( 50, region.active_size( ))
+        self.assertEqual( 100, region.global_size( ))

--- a/python/tests/ecl/test_region.py
+++ b/python/tests/ecl/test_region.py
@@ -1,18 +1,17 @@
-#!/usr/bin/env python
-#  Copyright (C) 2017  Statoil ASA, Norway. 
-#   
+#  Copyright (C) 2017  Statoil ASA, Norway.
+#
 #  The file 'test_region.py' is part of ERT - Ensemble based Reservoir Tool.
-#   
-#  ERT is free software: you can redistribute it and/or modify 
-#  it under the terms of the GNU General Public License as published by 
-#  the Free Software Foundation, either version 3 of the License, or 
-#  (at your option) any later version. 
-#   
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-#  FITNESS FOR A PARTICULAR PURPOSE.   
-#   
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from ecl.ecl import EclGrid, EclKW, EclRegion, EclDataType
 from ecl.ecl.faults import Layer

--- a/python/tests/ecl/test_region.py
+++ b/python/tests/ecl/test_region.py
@@ -34,3 +34,28 @@ class RegionTest(ExtendedTestCase):
 
         with self.assertRaises(ValueError):
             region.select_equal( kw_float , 1 )
+
+    def test_sum(self):
+        grid = EclGrid.createRectangular( (10,10,1) , (1,1,1))
+        kw_mask = EclKW( "INT" , grid.getGlobalSize( ) , EclDataType.ECL_INT )
+        int_value =  EclKW( "INT" , grid.getGlobalSize( ) , EclDataType.ECL_INT )
+        float_value =  EclKW( "FLOAT" , grid.getGlobalSize( ) , EclDataType.ECL_FLOAT)
+        double_value =  EclKW( "DOUBLE" , grid.getGlobalSize( ) , EclDataType.ECL_DOUBLE )
+        bool_value =  EclKW( "BOOL" , grid.getGlobalSize( ) , EclDataType.ECL_BOOL )
+
+        kw_mask[0:50] = 1
+
+        for i in range(len(int_value)):
+            float_value[i] = i
+            double_value[i] = i
+            int_value[i] = i
+            bool_value[i] = True
+
+        region = EclRegion(grid, False)
+        region.select_equal( kw_mask , 1 )
+
+        self.assertEqual( int_value.sum( ) , 99*100/2 )
+        self.assertEqual( int_value.sum( mask = region ) , 49*50/2 )
+        self.assertEqual( double_value.sum( mask = region ) , 1.0*49*50/2 )
+        self.assertEqual( float_value.sum( mask = region ) , 1.0*49*50/2 )
+        self.assertEqual( bool_value.sum( mask = region ) , 50 )


### PR DESCRIPTION
**Task**
The `sum( )` method in `EclKW` has aquired a `mask=` optional argument, so that we can sum only elements matching a criteria.

