### PR TITLE
POC: Cell from Grid

### DIFF
--- a/docs/examples/grid_info.py
+++ b/docs/examples/grid_info.py
@@ -3,32 +3,29 @@ import sys
 from ecl.ecl import EclGrid, EclRegion
 
 
-def volum_min_max(grid):
-    vmin = 10000000
-    vmax = 0
-    for a in range(grid.getNumActive()):
-        v = grid.cell_volume( active_index = a )
-        vmin = min(vmin,v)
-        vmax = max(vmax,v)
+def volume_min_max(grid):
+    vols = [c.volume for c in grid if c.active]
+    return min(vols), max(vols)
 
-    return vmin,vmax
+def main(grid):
+    vmin,vmax = volume_min_max(grid)
 
-
-if __name__ == "__main__":
-    case = sys.argv[1]
-    grid = EclGrid( case )
-
-    vmin,vmax = volum_min_max( grid )
-
-    dz_limit = 0.1
-    region = EclRegion( grid, False )
-    region.select_thin( dz_limit )
+    dz_limit = 0.3
+    region = EclRegion(grid, False)
+    region.select_thin(dz_limit)
 
     print "Smallest cell     : %g" % vmin
     print "Largest cell      : %g" % vmax
     print "Thin active cells : %d" % region.active_size()
 
-    for ai in region.get_active_list( ):
-        ijk = grid.get_ijk( active_index = ai )
-        print ijk
+    for ai in region.get_active_list():
+        c = grid.cell(active_index=ai)
+        print('dz(%2d, %2d, %2d) = %.3f' % (c.i, c.j, c.k, c.dz))
 
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        exit('usage: grid_info.py path/to/file.EGRID')
+    case = sys.argv[1]
+    grid = EclGrid(case)
+    main(grid)

--- a/python/python/ecl/ecl/CMakeLists.txt
+++ b/python/python/ecl/ecl/CMakeLists.txt
@@ -28,6 +28,7 @@ set(PYTHON_SOURCES
     ecl_sum_var_type.py
     ecl_type.py
     ecl_grid_generator.py
+    cell.py
 )
 
 add_python_package("python.ecl.ecl" ${PYTHON_INSTALL_PREFIX}/ecl/ecl "${PYTHON_SOURCES}" True)

--- a/python/python/ecl/ecl/__init__.py
+++ b/python/python/ecl/ecl/__init__.py
@@ -86,6 +86,7 @@ class EclPrototype(Prototype):
 
 ECL_LIB = ecl.load("libecl")
 
+from .cell import Cell
 from .ecl_util import EclFileEnum, EclFileFlagEnum, EclPhaseEnum, EclUnitTypeEnum , EclUtil
 from .ecl_type import EclTypeEnum, EclDataType
 from .ecl_sum_var_type import EclSumVarType

--- a/python/python/ecl/ecl/cell.py
+++ b/python/python/ecl/ecl/cell.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+#  Copyright (C) 2017  Statoil ASA, Norway.
+#
+#  This file is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
+
+class Cell(object):
+
+    def __init__(self, grid, global_index):
+        self._grid = grid
+        self._idx = global_index
+        self._ijk = grid.get_ijk(global_index=self._idx)
+        self._aidx = grid.get_active_index(global_index=self._idx)
+
+    @property
+    def volume(self):
+        return self._grid.cell_volume(global_index=self._idx)
+
+    @property
+    def global_index(self):
+        return self._idx
+
+    @property
+    def active_index(self):
+        return self._aidx
+
+    @property
+    def ijk(self):
+        return self._ijk
+    @property
+    def i(self):
+        return self._ijk[0]
+    @property
+    def j(self):
+        return self._ijk[1]
+    @property
+    def k(self):
+        return self._ijk[2]
+
+    @property
+    def active(self):
+        return self._aidx >= 0
+
+    def eval(self, kw):
+        return self._grid.grid_value(kw, self.i, self.j, self.k)
+
+    @property
+    def fracture(self):
+        return self._grid.active_fracture_index(global_index=self._idx)
+
+    @property
+    def dz(self):
+        return self._grid.cell_dz(global_index=self._idx)
+
+    @property
+    def dimension(self):
+        return self._grid.get_cell_dims(global_index=self._idx)
+
+    @property
+    def valid_geometry(self):
+        return self._grid.valid_cell_geometry(global_index=self._idx)
+
+    @property
+    def valid(self):
+        return not self._grid.cell_invalid(global_index=self._idx)
+
+    def __contains__(self, coord):
+        """
+        Will check if this cell contains point given by world
+        coordinates (x,y,z)=coord.
+        """
+        if len(coord) != 3:
+            raise ValueError('Cell contains takes a triple (x,y,z), was given %s.' % coord)
+        x,y,z = coord
+        return self._grid._cell_contains(self._idx, x,y,z)
+
+    def __eq__(self, other):
+        if isinstance(other, Cell):
+            idx_eq = self.global_index == other.global_index
+            return idx_eq and self._grid == other._grid
+        return NotImplemented
+
+    def __neq__(self, other):
+        if isinstance(other, Cell):
+            return not self == other
+        return NotImplemented
+
+    def hash(self):
+        return hash((self._idx, self._aidx, self.ijk))
+
+    @property
+    def coordinate(self):
+        return self._grid.get_xyz(global_index=self._idx)
+
+    @property
+    def corners(self):
+        """
+        Return xyz for each of the eight vertices, indexed by:
+
+        lower layer:   upper layer
+
+         2---3           6---7
+         |   |           |   |
+         0---1           4---5
+        """
+        cs = lambda c : self._grid.get_cell_corner(c, global_index=self._idx)
+        return [cs(i) for i in range(8)]
+
+    def __repr__(self):
+        act = 'active' if self.active else 'inactive'
+        pos = '(%.3f, %.3f, %.3f)' % self.coordinate
+        cnt = '%d, %d, %d, %s, %s, grid=%s' % (self.i, self.j, self.k,
+                                               act, pos,
+                                               self._grid.get_name())
+
+        return 'Cell(%s)' % cnt

--- a/python/python/ecl/ecl/ecl_grid.py
+++ b/python/python/ecl/ecl/ecl_grid.py
@@ -34,7 +34,7 @@ import itertools
 from cwrap import CFILE, BaseCClass
 from ecl.util import monkey_the_camel
 from ecl.util import IntVector
-from ecl.ecl import EclPrototype, EclDataType, EclKW, FortIO, EclUnitTypeEnum
+from ecl.ecl import EclPrototype, EclDataType, EclKW, FortIO, EclUnitTypeEnum, Cell
 
 
 class EclGrid(BaseCClass):
@@ -385,6 +385,33 @@ class EclGrid(BaseCClass):
         """
         n = self._get_name()
         return str(n) if n else ''
+
+    def cell(self, global_index=None, active_index=None, i=None, j=None, k=None):
+        if global_index is not None:
+            return Cell(self, global_index)
+        if active_index is not None:
+            return Cell(self, self.global_index(active_index=active_index))
+        if i is not None:
+            return Cell(self, self.global_index(ijk=(i,j,k)))
+
+    def __getitem__(self, global_index):
+        if isinstance(global_index, tuple):
+            i,j,k = global_index
+            return self.cell(i=i, j=j, k=k)
+        return self.cell(global_index=global_index)
+
+    def __iter__(self):
+        for i in range(len(self)):
+            yield self[i]
+
+    def cells(self, active=False):
+        """Iterator over all the (active) cells"""
+        if not active:
+            for c in self:
+                yield c
+        else:
+            for i in range(self.get_num_active()):
+                yield self.cell(active_index=i)
 
     def global_index(self, active_index=None, ijk=None):
         """

--- a/python/tests/ecl/CMakeLists.txt
+++ b/python/tests/ecl/CMakeLists.txt
@@ -19,6 +19,7 @@ set(TEST_SOURCES
     test_fortio.py
     test_grdecl.py
     test_grid.py
+    test_cell.py
     test_grid_statoil.py
     test_grid_generator.py
     test_indexed_read.py
@@ -48,6 +49,7 @@ set(TEST_SOURCES
 add_python_package("python.tests.ecl"  ${PYTHON_INSTALL_PREFIX}/tests/ecl "${TEST_SOURCES}" False)
 
 addPythonTest(tests.ecl.test_fk_user_data.FKTest)
+addPythonTest(tests.ecl.test_cell.CellTest)
 addPythonTest(tests.ecl.test_grid.GridTest LABELS SLOW_1)
 addPythonTest(tests.ecl.test_grid_generator.GridGeneratorTest LABELS SLOW_2)
 addPythonTest(tests.ecl.test_ecl_kw.KWTest LABELS SLOW_2)

--- a/python/tests/ecl/test_cell.py
+++ b/python/tests/ecl/test_cell.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+#  Copyright (C) 2017  Statoil ASA, Norway.
+#
+#  This file is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
+
+from ecl.ecl import Cell, EclGrid
+from ecl.test import ExtendedTestCase
+
+class CellTest(ExtendedTestCase):
+
+    def setUp(self):
+        fk = self.createTestPath('local/ECLIPSE/faarikaal/faarikaal1.EGRID')
+        self.grid = EclGrid(fk)
+        self.cell = self.grid[3455]
+        self.actives = [c for c in self.grid if c.active]
+
+    def test_init(self):
+        cell = self.grid[0]
+        self.assertEqual(0, cell.global_index)
+
+    def test_actives(self):
+        self.assertEqual(4160, len(self.actives))
+
+    def test_volumes(self):
+        actives = self.actives
+        vols = [c.volume for c in actives]
+        vmin, vmax = min(vols), max(vols)
+        self.assertFloatEqual(vmin, 1332.328921)
+        self.assertFloatEqual(vmax, 10104.83204)
+        self.assertFloatEqual(actives[2000].dz, 1.68506)
+
+        act_dim = (48.5676, 54.1515, 1.685)  # cell dimension in meter
+        cel_dim = self.cell.dimension
+        self.assertEqual(3, len(cel_dim))
+        for d in range(2):
+            self.assertFloatEqual(act_dim[d], cel_dim[d])
+
+    def test_indices(self):
+        c = self.cell
+        self.assertEqual(3455, c.global_index)
+        self.assertEqual(2000, c.active_index)
+        self.assertEqual((4,1,82), c.ijk)
+        self.assertEqual(c.ijk, (c.i, c.j, c.k))
+
+    def test_coordinates(self):
+        c = self.cell
+        corners = c.corners
+        self.assertEqual(8, len(corners))
+        se0 = corners[5] # upper south east
+        se0_act = (606900.002, 5202050.07, 5149.26)
+        for i in range(3):
+            self.assertFloatEqual(se0[i], se0_act[i])
+
+        coordinate = c.coordinate
+        coor_act = (606866.883, 5202064.939, 5154.52)
+
+        for i in range(3):
+            self.assertFloatEqual(coordinate[i], coor_act[i])
+
+        xyz = c.coordinate
+        self.assertIn(xyz, c)
+
+    def test_eq(self):
+        c1 = self.cell
+        c2 = self.grid[4,1,82]
+        c3 = self.grid[1,1,82]
+        self.assertEqual(c1,c2)
+        self.assertEqual(c2,c1)
+        self.assertNotEqual(c1, 'notacell')
+        self.assertNotEqual(c1,c3)
+        self.assertNotEqual(c3,c1)
+
+    def test_getitem_3(self):
+        c = self.cell
+        d = self.grid[4,1,82]
+        self.assertEqual(c, d)
+
+    def test_validity(self):
+        self.assertTrue(self.cell.valid_geometry)
+        self.assertTrue(self.cell.valid)
+
+    def test_repr(self):
+        c = self.cell
+        r = repr(c)
+        self.assertTrue(r.startswith('Cell(4, 1, 82, active, '))
+        self.assertIn('faarikaal1.EGRID', r)

--- a/python/tests/ecl/test_grid.py
+++ b/python/tests/ecl/test_grid.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python
-#  Copyright (C) 2014  Statoil ASA, Norway. 
-#   
+#  Copyright (C) 2014  Statoil ASA, Norway.
+#
 #  The file 'test_grid.py' is part of ERT - Ensemble based Reservoir Tool.
-#   
-#  ERT is free software: you can redistribute it and/or modify 
-#  it under the terms of the GNU General Public License as published by 
-#  the Free Software Foundation, either version 3 of the License, or 
-#  (at your option) any later version. 
-#   
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-#  FITNESS FOR A PARTICULAR PURPOSE.   
-#   
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 import os.path
 from unittest import skipIf
@@ -120,7 +120,7 @@ def average(points):
 # external test data. Tests involving Statoil test data are in the
 # test_grid_statoil module.
 class GridTest(ExtendedTestCase):
-    
+
     def test_oom_grid(self):
         nx = 2000
         ny = 2000
@@ -130,7 +130,7 @@ class GridTest(ExtendedTestCase):
             grid = GridGen.createRectangular( (nx,ny,nz), (1,1,1))
 
 
-    
+
     def test_posXYEdge(self):
         nx = 10
         ny = 11
@@ -139,40 +139,37 @@ class GridTest(ExtendedTestCase):
         self.assertEqual( grid.findCellCornerXY(nx,0,0) , nx)
         self.assertEqual( grid.findCellCornerXY(0 , ny , 0) , (nx + 1 ) * ny )
         self.assertEqual( grid.findCellCornerXY(nx,ny,0) , (nx + 1 ) * (ny + 1) - 1)
-        
+
         self.assertEqual( grid.findCellCornerXY(0.25,0,0)  , 0 )
         self.assertEqual( grid.findCellCornerXY(0,0.25,0)  , 0 )
-    
+
         self.assertEqual( grid.findCellCornerXY(nx - 0.25,0,0)  , nx )
         self.assertEqual( grid.findCellCornerXY(nx , 0.25,0)  , nx )
-    
+
         self.assertEqual( grid.findCellCornerXY(0 , ny - 0.25, 0) , (nx + 1 ) * ny )
         self.assertEqual( grid.findCellCornerXY(0.25 , ny , 0) , (nx + 1 ) * ny )
-    
+
         self.assertEqual( grid.findCellCornerXY(nx -0.25 ,ny,0) , (nx + 1 ) * (ny + 1) - 1)
         self.assertEqual( grid.findCellCornerXY(nx , ny - 0.25,0) , (nx + 1 ) * (ny + 1) - 1)
-    
-    
+
+
     def test_dims(self):
         grid = GridGen.createRectangular( (10,20,30) , (1,1,1) )
         self.assertEqual( grid.getNX() , 10 )
         self.assertEqual( grid.getNY() , 20 )
         self.assertEqual( grid.getNZ() , 30 )
         self.assertEqual( grid.getGlobalSize() , 30*10*20 )
-    
+
         self.assertEqual( grid.getDims() , (10,20,30,6000) )
-    
-    
+
     def test_create(self):
         with self.assertRaises(ValueError):
             grid = GridGen.createRectangular( (10,20,30) , (1,1,1) , actnum = [0,1,1,2])
-            
+
         with self.assertRaises(ValueError):
             grid = GridGen.createRectangular( (10,20,30) , (1,1,1) , actnum = IntVector(initial_size = 10))
-    
         grid = GridGen.createRectangular( (10,20,30) , (1,1,1) ) # actnum=None -> all active
         self.assertEqual( grid.getNumActive( ) , 30*20*10)
-        
         actnum = IntVector(default_value = 1 , initial_size = 6000)
         actnum[0] = 0
         actnum[1] = 0
@@ -198,101 +195,101 @@ class GridTest(ExtendedTestCase):
         grid = GridGen.createRectangular( (10,20,30) , (1,1,1) )
         with self.assertRaises(IndexError):
             grid.getNodePos(-1,0,0)
-    
+
         with self.assertRaises(IndexError):
             grid.getNodePos(11,0,0)
-    
+
         p0 = grid.getNodePos(0,0,0)
         self.assertEqual( p0 , (0,0,0))
-    
+
         p7 = grid.getNodePos(10,20,30)
         self.assertEqual( p7 , (10,20,30))
-    
-    
+
+
     def test_truncated_file(self):
         grid = GridGen.createRectangular( (10,20,30) , (1,1,1) )
         with TestAreaContext("python/ecl_grid/truncated"):
             grid.save_EGRID( "TEST.EGRID")
-    
+
             size = os.path.getsize( "TEST.EGRID")
             with open("TEST.EGRID" , "r+") as f:
                 f.truncate( size / 2 )
-    
+
             with self.assertRaises(IOError):
                 EclGrid("TEST.EGRID")
-    
+
     def test_posXY1(self):
         nx = 4
         ny = 1
         nz = 1
         grid = GridGen.createRectangular( (nx,ny,nz) , (1,1,1) )
-        (i,j) = grid.findCellXY( 0.5 , 0.5, 0 )   
+        (i,j) = grid.findCellXY( 0.5 , 0.5, 0 )
         self.assertEqual(i , 0)
         self.assertEqual(j , 0)
-    
-        (i,j) = grid.findCellXY( 3.5 , 0.5, 0 )   
+
+        (i,j) = grid.findCellXY( 3.5 , 0.5, 0 )
         self.assertEqual(i , 3)
         self.assertEqual(j , 0)
-    
-    
+
+
     def test_init_ACTNUM(self):
         nx = 10
         ny = 23
         nz = 7
         grid = GridGen.createRectangular( (nx,ny,nz) , (1,1,1) )
         actnum = grid.exportACTNUM()
-        
+
         self.assertEqual( len(actnum) , nx*ny*nz )
         self.assertEqual( actnum[0] , 1 )
         self.assertEqual( actnum[nx*ny*nz - 1] , 1 )
-        
+
         actnum_kw = grid.exportACTNUMKw( )
         self.assertEqual(len(actnum_kw) , len(actnum))
         for a1,a2 in zip(actnum, actnum_kw):
             self.assertEqual(a1, a2)
-    
-    
+
+
     def test_posXY(self):
         nx = 10
         ny = 23
         nz = 7
         grid = GridGen.createRectangular( (nx,ny,nz) , (1,1,1) )
         with self.assertRaises(IndexError):
-            grid.findCellXY( 1 , 1, -1 )   
-    
+            grid.findCellXY( 1 , 1, -1 )
+
         with self.assertRaises(IndexError):
-            grid.findCellXY( 1 , 1, nz + 1 )   
-    
+            grid.findCellXY( 1 , 1, nz + 1 )
+
         with self.assertRaises(ValueError):
             grid.findCellXY(15 , 78 , 2)
-        
-            
+
+
         i,j = grid.findCellXY( 1.5 , 1.5 , 2 )
         self.assertEqual(i , 1)
         self.assertEqual(j , 1)
-    
-    
+
+
         for i in range(nx):
             for j in range(ny):
                 p = grid.findCellXY(i + 0.5 , j+ 0.5 , 0)
                 self.assertEqual( p[0] , i )
                 self.assertEqual( p[1] , j )
-        
+
         c = grid.findCellCornerXY( 0.10 , 0.10 , 0 )
         self.assertEqual(c , 0)
-        
+
         c = grid.findCellCornerXY( 0.90 , 0.90 , 0 )
         self.assertEqual( c , (nx + 1) + 1 )
-    
+
         c = grid.findCellCornerXY( 0.10 , 0.90 , 0 )
         self.assertEqual( c , (nx + 1) )
-    
+
         c = grid.findCellCornerXY( 0.90 , 0.90 , 0 )
         self.assertEqual( c , (nx + 1) + 1 )
-    
+
         c = grid.findCellCornerXY( 0.90 , 0.10 , 0 )
         self.assertEqual( c , 1 )
-        
+
     def test_compressed_copy(self):
         nx = 10
         ny = 10
@@ -301,19 +298,19 @@ class GridTest(ExtendedTestCase):
         kw1 = EclKW("KW" , 1001 , EclDataType.ECL_INT )
         with self.assertRaises(ValueError):
             cp = grid.compressedKWCopy( kw1 )
-    
-    
+
+
     def test_dxdydz(self):
         nx = 10
         ny = 10
         nz = 10
         grid = GridGen.createRectangular( (nx,ny,nz) , (2,3,4) )
-    
+
         (dx,dy,dz) = grid.getCellDims( active_index = 0 )
         self.assertEqual( dx , 2 )
         self.assertEqual( dy , 3 )
         self.assertEqual( dz , 4 )
-        
+
     def test_numpy3D(self):
         nx = 10
         ny = 7
@@ -331,7 +328,7 @@ class GridTest(ExtendedTestCase):
         actnum[1] = 1
         actnum[2] = 1
         actnum[3] = 1
-        
+
         grid = GridGen.createRectangular( (nx,ny,nz) , (1,1,1), actnum = actnum)
         self.assertEqual( len(grid) , nx*ny*nz )
         self.assertEqual( grid.getNumActive( ) , 4 )
@@ -359,12 +356,12 @@ class GridTest(ExtendedTestCase):
             g2 = EclGrid("CASE.EGRID")
             self.assertFloatEqual( g2.cell_volume( global_index = 0 ) , 3.28084*3.28084*3.28084)
 
-            
+
             grid.save_EGRID( "CASE.EGRID" )
             f = EclFile("CASE.EGRID")
             g = f["GRIDUNIT"][0]
             self.assertEqual( g[0].strip( ) , "METRES" )
-            
+
             grid.save_EGRID( "CASE.EGRID" , output_unit = EclUnitTypeEnum.ECL_LAB_UNITS)
             f = EclFile("CASE.EGRID")
             g = f["GRIDUNIT"][0]

--- a/python/tests/ecl/test_grid.py
+++ b/python/tests/ecl/test_grid.py
@@ -176,6 +176,30 @@ class GridTest(ExtendedTestCase):
         grid = GridGen.createRectangular( (10,20,30) , (1,1,1) , actnum = actnum)
         self.assertEqual( grid.getNumActive( ) , 30*20*10 - 2)
 
+    def test_all_iters(self):
+        fk = self.createTestPath('local/ECLIPSE/faarikaal/faarikaal1.EGRID')
+        grid = EclGrid(fk)
+        cell = grid[3455]
+        self.assertEqual(3455, cell.global_index)
+        cell = grid[(4,1,82)]
+        self.assertEqual(3455, cell.global_index)
+        self.assertEqual(grid.cell(global_index=3455),
+                         grid.cell(active_index=2000))
+        self.assertEqual(grid.cell(global_index=3455),
+                         grid.cell(i=4, j=1, k=82))
+
+        na = grid.get_num_active()
+        self.assertEqual(na, 4160)
+        cnt = 0
+        for c in grid.cells(active=True):
+            cnt += 1
+            self.assertTrue(c.active)
+        self.assertEqual(cnt, 4160)
+
+        cnt = len([c for c in grid.cells()])
+        self.assertEqual(cnt, len(grid))
+
+
     def test_repr_and_name(self):
         grid = GridGen.createRectangular((2,2,2), (10,10,10), actnum=[0,0,0,0,1,1,1,1])
         pfx = 'EclGrid('


### PR DESCRIPTION
It is somewhat cumbersome to get the volume, coordinates and indices of a bunch of cells.

This adds a small Python class `Cell` that you can obtain from a grid by either using `grid[123]`, or from `grid.cell(i=3, j=4, k=5)`.

A `Cell` can give you volume, dz, coordinates, corners, indices etc.

This is a _proof of concept_ so please be constructive and think carefully about what a good API for a user would look like.

One example was updated to see some uses:
```python
vols = [c.volume for c in grid if c.active]

upper = grid[123].corners[:4] # upper or lower
# ...
        c = grid.cell(active_index=ai)
        print('dz(%2d, %2d, %2d) = %.3f' % (c.i, c.j, c.k, c.dz))

# supports __bool__ and __eq__:
vols = [c.volume for c in grid if c]  # c is same as c.active
c = grid[123]
d = grid[1,2,3]
if c == d:
    print('Yes, c and d are the same')
if c:
    print('c is active')
else:
    print('c is inactive')

xyz = (601292.32, 1412.231, 3242.3134)
if xyz in c:
    print('c contains world coordinate given')
```