### PR TITLE
Fixed bug in ecl_kw.assign

### DIFF
--- a/python/python/ecl/ecl/ecl_kw.py
+++ b/python/python/ecl/ecl/ecl_kw.py
@@ -719,7 +719,7 @@ class EclKW(BaseCClass):
         """
         if self.isNumeric():
             if type(value) == type(self):
-                if mask:
+                if mask is not None:
                     mask.copy_kw(self, value, force_active)
                 else:
                     if self.assert_binary(value):
@@ -727,7 +727,7 @@ class EclKW(BaseCClass):
                     else:
                         raise TypeError("Type / size mismatch")
             else:
-                if mask:
+                if mask is not None:
                     mask.set_kw(self, value, force_active)
                 else:
                     if self.data_type.is_int():
@@ -747,7 +747,7 @@ class EclKW(BaseCClass):
         See method assign() for documentation of optional arguments
         @mask and @force_active.
         """
-        if mask:
+        if mask is not None:
             mask.iadd_kw(self, other, force_active)
         else:
             return self.__iadd__(other)
@@ -757,7 +757,7 @@ class EclKW(BaseCClass):
         See method assign() for documentation of optional arguments
         @mask and @force_active.
         """
-        if mask:
+        if mask is not None:
             mask.isub_kw(self, other, force_active)
         else:
             return self.__isub__(other)
@@ -767,7 +767,7 @@ class EclKW(BaseCClass):
         See method assign() for documentation of optional arguments
         @mask and @force_active.
         """
-        if mask:
+        if mask is not None:
             mask.imul_kw(self, other, force_active)
         else:
             return self.__imul__(other)
@@ -777,7 +777,7 @@ class EclKW(BaseCClass):
         See method assign() for documentation of optional arguments
         @mask and @force_active.
         """
-        if mask:
+        if mask is not None:
             mask.idiv_kw(self, other, force_active)
         else:
             return self.__idiv__(other)
@@ -805,7 +805,7 @@ class EclKW(BaseCClass):
         See method assign() for documentation of optional arguments
         @mask and @force_active.
         """
-        if mask:
+        if mask is not None:
             active_list = mask.kw_index_list(self, force_active)
             if arg:
                 for index in active_list:

--- a/python/python/ecl/ecl/ecl_region.py
+++ b/python/python/ecl/ecl/ecl_region.py
@@ -207,12 +207,9 @@ class EclRegion(BaseCClass):
 
 
     def __nonzero__(self):
-        global_list = self.getGlobalList()
-        if len(global_list) > 0:
-            return True
-        else:
-            return False
-
+        global_list = self.get_global_list()
+        return len(global_list) > 0
+    
 
     def __iand__(self , other):
         """

--- a/python/tests/ecl/test_grid.py
+++ b/python/tests/ecl/test_grid.py
@@ -161,7 +161,6 @@ class GridTest(ExtendedTestCase):
         self.assertEqual( grid.getGlobalSize() , 30*10*20 )
     
         self.assertEqual( grid.getDims() , (10,20,30,6000) )
-        
     
     
     def test_create(self):
@@ -171,6 +170,9 @@ class GridTest(ExtendedTestCase):
         with self.assertRaises(ValueError):
             grid = GridGen.createRectangular( (10,20,30) , (1,1,1) , actnum = IntVector(initial_size = 10))
     
+        grid = GridGen.createRectangular( (10,20,30) , (1,1,1) ) # actnum=None -> all active
+        self.assertEqual( grid.getNumActive( ) , 30*20*10)
+        
         actnum = IntVector(default_value = 1 , initial_size = 6000)
         actnum[0] = 0
         actnum[1] = 0

--- a/python/tests/ecl/test_region.py
+++ b/python/tests/ecl/test_region.py
@@ -70,8 +70,20 @@ class RegionTest(ExtendedTestCase):
         self.assertFalse( region )
         self.assertEqual( 0, region.active_size( ))
         self.assertEqual( 0, region.global_size( ))
+
         region.select_all( )
         self.assertTrue( region )
-
         self.assertEqual( 50, region.active_size( ))
         self.assertEqual( 100, region.global_size( ))
+        
+        region.deselect_all()
+        self.assertFalse( region )
+        self.assertEqual( 0, region.active_size( ))
+        self.assertEqual( 0, region.global_size( ))
+        
+        region = EclRegion(grid, False)
+        region.select_inactive()
+        self.assertTrue( region )
+        self.assertEqual( 0 , region.active_size( ))
+        self.assertEqual( 50, region.global_size( ))
+        


### PR DESCRIPTION
**Task**
If an empty mask is passed to assign, no cell of the grid should be affected

**Approach**
Explicitly check if the the mask is None instead of relying on the implicit conversion to bool.

From a more philosophical point of view, one might argue that an empty region is not really an "invalid" (False) region. So, an alternative solution could be to just get rid of the `__nonzero__` method in ecl_region.py

**Pre un-WIP checklist**
- [x] Statoil tests pass locally
