### PR TITLE
WIP: Fix RFT bug

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -689,6 +689,7 @@ add_test(NAME ecl_rft_rft    COMMAND ecl_rft ${_eclpath}/Gurbat/ECLIPSE.RFT RFT)
 add_test(NAME ecl_rft_rft_rw COMMAND ecl_rft ${_eclpath}/Gurbat/ECLIPSE.RFT RFT_RW)
 add_test(NAME ecl_rft_plt    COMMAND ecl_rft ${_eclpath}/RFT/TEST1_1A.RFT PLT)
 add_test(NAME ecl_rft_mswplt COMMAND ecl_rft ${_eclpath}/RFT/RFT2.RFT MSW-PLT)
+add_test(NAME ecl_rft_alloc  COMMAND ecl_rft ${_eclpath}/RFT/NORNE_ATW2013_RFTPLT_V2.RFT SIMPLE)
 
 add_executable(ecl_grid_copy_statoil ecl/tests/ecl_grid_copy_statoil.c)
 target_link_libraries(ecl_grid_copy_statoil ecl)

--- a/lib/ecl/ecl_rft_node.c
+++ b/lib/ecl/ecl_rft_node.c
@@ -161,7 +161,12 @@ static ecl_kw_type * ecl_rft_node_get_pressure_kw( ecl_rft_node_type * rft_node 
     if (ecl_kw_element_sum_float( conpres_kw ) > 0.0 )
       return conpres_kw;
     else
-      return ecl_file_view_iget_named_kw( rft , PRESSURE_KW , 0);
+      if (ecl_file_view_has_kw(rft, PRESSURE_KW))
+        return ecl_file_view_iget_named_kw( rft , PRESSURE_KW , 0);
+      else {
+        fprintf(stderr, "WARNING: %s returned a CONPRES_KW with all values at zero. PRESSURE_KW not found.\n", __func__);
+        return conpres_kw;
+      } 
   }
 }
 

--- a/lib/ecl/tests/ecl_rft.c
+++ b/lib/ecl/tests/ecl_rft.c
@@ -150,6 +150,11 @@ void test_plt( const char * plt_file ) {
 }
 
 
+void test_simple_load_rft(const char * filename) {
+  ecl_rft_file_type * rft_file = ecl_rft_file_alloc_case(filename);
+  ecl_rft_file_free( rft_file );
+}
+
 
 int main( int argc , char ** argv) {
   const char * rft_file = argv[1];
@@ -164,8 +169,10 @@ int main( int argc , char ** argv) {
     test_plt( rft_file );
   else if (strcmp( mode_string , "MSW-PLT") == 0)
     test_plt_msw( rft_file );
+  else if (strcmp( mode_string , "SIMPLE") == 0)
+    test_simple_load_rft(rft_file);
   else
     test_error_exit("Second argument:%s not recognized. Valid values are: RFT and PLT" , mode_string);
-  
+
   exit(0);
 }


### PR DESCRIPTION
**Task**
ERT-1412: When using the command ecl_rft_file_alloc_case() with parameter : filename = /d/proj/bg/enkf/ErtTestData/ECLIPSE/RFT/NORNE_ATW2013_RFTPLT_V2.RFT, ERT will crash hard. 


**Approach**
 ecl_rft_file_alloc_case crashed is set to crash if for a certain blockview, the blockview:
1) Does not contain a conpres_kw
2) Has a conpres_kw, but all values are 0, and there is no PRESSURE_kw. 

The case 2 applies for the filename mentioned under "Task".  For the case 2, the program will not crash hard, but instead issue a warning. 

**Pre un-WIP checklist**
- [x] Statoil tests pass locally
