### PR TITLE
re-add accidentially removed cwrap package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,13 @@ Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: libecl Eclipse IO library
  libecl is a package for reading and writing the result files from the Eclipse reservoir simulator.
 
+Package: python-cwrap
+Section: python
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: Utilities for wrapping C code from python
+ python-cwrap is a package helping to write python bindings for C libraries
+
 Package: python-ecl
 Section: python
 Architecture: any

--- a/debian/python-cwrap.install
+++ b/debian/python-cwrap.install
@@ -1,0 +1,1 @@
+usr/lib/python2.7/*/cwrap/*


### PR DESCRIPTION
I accidentially removed this package from the debian packaging. Re-add it.