### PR TITLE
Make sure TestArea is destructed as soon as a `with` block ends

### DIFF
--- a/python/python/ecl/test/test_area.py
+++ b/python/python/ecl/test/test_area.py
@@ -145,5 +145,7 @@ class TestAreaContext(object):
 
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        self.test_area.free()      # free the TestData object (and cd back to the original dir)
+        self.test_area.free = None # avoid double free
         del self.test_area
         return False

--- a/python/tests/util/test_work_area.py
+++ b/python/tests/util/test_work_area.py
@@ -93,3 +93,32 @@ class WorkAreaTest(ExtendedTestCase):
 
             t.sync()
             self.assertTrue( os.path.isfile( "file.txt"))
+            
+    def test_multiple_areas(self):
+        original_dir = os.getcwd()
+        context_dirs = []
+        for i in range(3):
+            loop_dir = os.getcwd()
+            self.assertEqual(loop_dir, original_dir, 
+                    'Wrong folder before creating TestAreaContext. Loop: {} -- CWD: {} '
+                    .format(i, loop_dir))
+            
+            with TestAreaContext("test_multiple_areas") as t:
+                t_dir = t.get_cwd()
+                
+                self.assertNotIn(t_dir, context_dirs, 
+                        'Multiple TestAreaContext objects in the same folder. Loop {} -- CWD: {}'
+                        .format(i, loop_dir))
+                context_dirs.append(t_dir)
+                
+                # It is possible to make the following assert fail, but whoever run the tests should
+                # try really really hard to make that happen
+                self.assertNotEqual(t_dir, original_dir, 
+                        'TestAreaContext in the current working directory. Loop: {} -- CWD: {}'
+                        .format(i, loop_dir))               
+            
+            loop_dir = os.getcwd()
+            self.assertEqual(loop_dir, original_dir, 
+                    'Wrong folder after creating TestAreaContext. Loop: {} -- CWD: {} '
+                            .format(i, loop_dir))
+                   


### PR DESCRIPTION
Destructing the TestArea most likely include a change of directory.
If the object is not destructed explicitly, the garbage collector would
do it, but asynchronously. And changing directory at an undefined point
in time might affect other part of the code


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
