### PR TITLE
Only build bundled cwrap if it's not found

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -12,6 +12,7 @@ if (NOT DEFINED PY_numpy)
    return()
 endif()
 
+find_python_package(cwrap 1 ${PYTHON_INSTALL_PREFIX})
 
 if (BUILD_TESTS)
    add_subdirectory( tests )

--- a/python/python/CMakeLists.txt
+++ b/python/python/CMakeLists.txt
@@ -1,6 +1,9 @@
 configure_file(test_env.py.in   ${PROJECT_BINARY_DIR}/${PYTHON_INSTALL_PREFIX}/test_env.py )
 
-add_subdirectory(cwrap)
+if (NOT PY_cwrap)
+    add_subdirectory(cwrap)
+endif ()
+
 add_subdirectory( ecl )
 
 if (INSTALL_ERT_LEGACY)


### PR DESCRIPTION
By default on fresh installs, this should build the embedded cwrap, but
on systems where cwrap already is available it's harmful to overwrite
the install.

This should probably be backported to the 2.2 release.

**Task**
Don't unconditionally build cwrap.

**Approach**
Only enable the build if cwrap is not available.


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
