### PR TITLE
Ecl sum keyword vector

### DIFF
--- a/lib/ecl/ecl_sum_data.c
+++ b/lib/ecl/ecl_sum_data.c
@@ -17,6 +17,7 @@
 */
 
 #include <string.h>
+#include <math.h>
 
 #include <ert/util/util.h>
 #include <ert/util/vector.h>
@@ -1203,8 +1204,8 @@ void ecl_sum_data_fwrite_interp_csv_line(const ecl_sum_data_type * data, time_t 
   ecl_sum_data_init_interp_from_sim_time(data, sim_time, &time_index1, &time_index2, &weight1, &weight2);
 
   for (int i = 0; i < num_keywords; i++) {
-    int params_index = ecl_sum_vector_iget_param_index(keylist, i);
-    if (params_index >= 0) {
+    if (ecl_sum_vector_iget_valid(keylist, i)) {
+      int params_index = ecl_sum_vector_iget_param_index(keylist, i);
       bool is_rate = ecl_sum_vector_iget_is_rate(keylist, i);
       double value = ecl_sum_data_vector_iget( data, sim_time, params_index , is_rate, time_index1, time_index2, weight1, weight2);
 
@@ -1221,22 +1222,31 @@ void ecl_sum_data_fwrite_interp_csv_line(const ecl_sum_data_type * data, time_t 
   }
 }
 
+
+/*
+  If the keylist contains invalid indices the corresponding element in the
+  results vector will *not* be updated; i.e. it is smart to initialize the
+  results vector with an invalid-value marker before calling this function:
+
+  double_vector_type * results = double_vector_alloc( ecl_sum_vector_get_size(keys), NAN);
+  ecl_sum_data_get_interp_vector( data, sim_time, keys, results);
+
+*/
+
 void ecl_sum_data_get_interp_vector( const ecl_sum_data_type * data , time_t sim_time, const ecl_sum_vector_type * keylist, double_vector_type * results){
   int num_keywords = ecl_sum_vector_get_size(keylist);
   double weight1, weight2;
   int    time_index1, time_index2;
-  double missing_value = -1;
 
   ecl_sum_data_init_interp_from_sim_time(data, sim_time, &time_index1, &time_index2, &weight1, &weight2);
   double_vector_reset( results );
   for (int i = 0; i < num_keywords; i++) {
-    int params_index = ecl_sum_vector_iget_param_index(keylist, i);
-    if (params_index >= 0) {
+    if (ecl_sum_vector_iget_valid(keylist, i)) {
+      int params_index = ecl_sum_vector_iget_param_index(keylist, i);
       bool is_rate = ecl_sum_vector_iget_is_rate(keylist, i);
       double value = ecl_sum_data_vector_iget( data, sim_time, params_index, is_rate, time_index1, time_index2, weight1, weight2);
       double_vector_iset( results, i , value );
-    } else
-      double_vector_iset( results, i , missing_value);
+    }
   }
 }
 

--- a/lib/ecl/ecl_sum_vector.c
+++ b/lib/ecl/ecl_sum_vector.c
@@ -65,11 +65,23 @@ static void ecl_sum_vector_add_invalid_key(ecl_sum_vector_type * vector, const c
 }
 
 
+/*
+  This function will allocate a keyword vector for the keys in the @ecl_sum
+  argument passed in, it will contain all the same keys as in the input argument
+  @src_vector. If the @src_vector contains keys which are not present in
+  @ecl_sum an entry marked as *invalid* will be added. The whole point about
+  this function is to ensure that calls to:
 
-ecl_sum_vector_type * ecl_sum_vector_alloc_layout_copy(const ecl_sum_vector_type * vector, const ecl_sum_type * ecl_sum) {
+       ecl_sum_fwrite_interp_csv_line( )
+
+  will result in nicely aligned output even if the different summary cases do
+  not have the exact same keys.
+*/
+
+ecl_sum_vector_type * ecl_sum_vector_alloc_layout_copy(const ecl_sum_vector_type * src_vector, const ecl_sum_type * ecl_sum) {
   ecl_sum_vector_type * new_vector = ecl_sum_vector_alloc(ecl_sum);
-  for (int i=0; i < stringlist_get_size(vector->key_list); i++) {
-    const char * key = stringlist_iget(vector->key_list, i);
+  for (int i=0; i < stringlist_get_size(src_vector->key_list); i++) {
+    const char * key = stringlist_iget(src_vector->key_list, i);
     if (ecl_sum_has_general_var(ecl_sum, key))
       ecl_sum_vector_add_key(new_vector, key);
     else
@@ -118,6 +130,10 @@ int ecl_sum_vector_get_size(const ecl_sum_vector_type * ecl_sum_vector){
 
 bool ecl_sum_vector_iget_is_rate(const ecl_sum_vector_type * ecl_sum_vector, int index){
     return bool_vector_iget(ecl_sum_vector->is_rate_list, index);
+}
+
+bool ecl_sum_vector_iget_valid(const ecl_sum_vector_type * ecl_sum_vector, int index) {
+  return (int_vector_iget(ecl_sum_vector->node_index_list, index) >= 0);
 }
 
 int ecl_sum_vector_iget_param_index(const ecl_sum_vector_type * ecl_sum_vector, int index){

--- a/lib/ecl/ecl_sum_vector.c
+++ b/lib/ecl/ecl_sum_vector.c
@@ -58,6 +58,27 @@ ecl_sum_vector_type * ecl_sum_vector_alloc(const ecl_sum_type * ecl_sum){
     return ecl_sum_vector;
 }
 
+static void ecl_sum_vector_add_invalid_key(ecl_sum_vector_type * vector, const char * key) {
+  int_vector_append(vector->node_index_list, -1);
+  bool_vector_append(vector->is_rate_list, false);
+  stringlist_append_copy(vector->key_list, key);
+}
+
+
+
+ecl_sum_vector_type * ecl_sum_vector_alloc_layout_copy(const ecl_sum_vector_type * vector, const ecl_sum_type * ecl_sum) {
+  ecl_sum_vector_type * new_vector = ecl_sum_vector_alloc(ecl_sum);
+  for (int i=0; i < stringlist_get_size(vector->key_list); i++) {
+    const char * key = stringlist_iget(vector->key_list, i);
+    if (ecl_sum_has_general_var(ecl_sum, key))
+      ecl_sum_vector_add_key(new_vector, key);
+    else
+      ecl_sum_vector_add_invalid_key(new_vector, key);
+  }
+  return new_vector;
+}
+
+
 
 bool ecl_sum_vector_add_key( ecl_sum_vector_type * ecl_sum_vector, const char * key){
   if (ecl_sum_has_general_var( ecl_sum_vector->ecl_sum , key)) {
@@ -72,8 +93,6 @@ bool ecl_sum_vector_add_key( ecl_sum_vector_type * ecl_sum_vector, const char * 
   } else
     return false;
 }
-
-
 
 void ecl_sum_vector_add_keys( ecl_sum_vector_type * ecl_sum_vector, const char * pattern){
     stringlist_type * keylist = ecl_sum_alloc_matching_general_var_list(ecl_sum_vector->ecl_sum , pattern);

--- a/lib/include/ert/ecl/ecl_sum_vector.h
+++ b/lib/include/ert/ecl/ecl_sum_vector.h
@@ -38,6 +38,8 @@ typedef struct ecl_sum_vector_struct ecl_sum_vector_type;
   bool ecl_sum_vector_iget_is_rate(const ecl_sum_vector_type * ecl_sum_vector, int index);
   int ecl_sum_vector_iget_param_index(const ecl_sum_vector_type * ecl_sum_vector, int index);
   int ecl_sum_vector_get_size(const ecl_sum_vector_type * ecl_sum_vector);
+  bool ecl_sum_vector_iget_valid(const ecl_sum_vector_type * ecl_sum_vector, int index);
+
 
   UTIL_IS_INSTANCE_HEADER( ecl_sum_vector);
 

--- a/python/python/ecl/ecl/ecl_sum.py
+++ b/python/python/ecl/ecl/ecl_sum.py
@@ -538,9 +538,9 @@ class EclSum(BaseCClass):
             raise ValueError("Must supply either days or date")
 
 
-    def get_interp_row(self, key_list, sim_time):
+    def get_interp_row(self, key_list, sim_time, invalid_value = -1):
         ctime = CTime(sim_time)
-        data = DoubleVector( initial_size = len(key_list) )
+        data = DoubleVector( initial_size = len(key_list) , default_value = invalid_value)
         EclSum._get_interp_vector(self, ctime, key_list, data)
         return data
 

--- a/python/python/ecl/ecl/ecl_sum_keyword_vector.py
+++ b/python/python/ecl/ecl/ecl_sum_keyword_vector.py
@@ -32,6 +32,7 @@ from ecl.ecl import EclPrototype
 class EclSumKeyWordVector(BaseCClass):
     TYPE_NAME       = "ecl_sum_vector"
     _alloc          = EclPrototype("void* ecl_sum_vector_alloc(ecl_sum)", bind=False)
+    _alloc_copy     = EclPrototype("ecl_sum_vector_obj ecl_sum_vector_alloc_layout_copy(ecl_sum_vector, ecl_sum)")
     _free           = EclPrototype("void ecl_sum_vector_free(ecl_sum_vector)")
     _add            = EclPrototype("bool ecl_sum_vector_add_key(ecl_sum_vector,  char*)")
     _add_multiple   = EclPrototype("void ecl_sum_vector_add_keys(ecl_sum_vector,  char*)")
@@ -67,6 +68,10 @@ class EclSumKeyWordVector(BaseCClass):
 
     def __repr__(self):
         return self._create_repr('len=%d' % len(self))
+
+    def copy(self, ecl_sum):
+        return self._alloc_copy(ecl_sum)
+
 
 monkey_the_camel(EclSumKeyWordVector, 'addKeyword', EclSumKeyWordVector.add_keyword)
 monkey_the_camel(EclSumKeyWordVector, 'addKeywords', EclSumKeyWordVector.add_keywords)


### PR DESCRIPTION
**Task**
When exporting multiple cases in tabular form it is essential that they have the same keys. With this PR we will emit an empty string for missing keys, to ensure that alignment is correct.

Part of: ERT-1435

**Pre un-WIP checklist**
- [x] Statoil tests pass locally