### PR TITLE
nex2ecl command-line options -f, -h, and -o

### DIFF
--- a/applications/CMakeLists.txt
+++ b/applications/CMakeLists.txt
@@ -10,7 +10,7 @@ if (BUILD_APPLICATIONS)
     target_link_libraries(grdecl_grid   ecl)
     target_link_libraries(summary       ecl)
 
-    if (BUILD_NEXUS)
+    if (BUILD_NEXUS AND ERT_HAVE_GETOPT)
         add_executable(nex2ecl   nexus/nex2ecl.cpp)
         target_link_libraries(nex2ecl    ecl)
         target_include_directories(nex2ecl PRIVATE ../lib/nexus/include)

--- a/applications/nexus/nex2ecl.cpp
+++ b/applications/nexus/nex2ecl.cpp
@@ -16,37 +16,148 @@
 */
 
 #include <cctype>
-
-#include <string>
-
+#include <getopt.h>
 #include <iostream>
+#include <string>
 
 #include <ert/util/util.h>
 
 #include "nexus/util.hpp"
 
+namespace {
 
-void create_ecl_sum(char *file_path) {
-    std::string filename(file_path);
-    auto ending = filename.rfind(".plt");
-    if (ending == std::string::npos) {
-        filename += ".plt";
-    }
+static const constexpr char *usage =
+R"(nex2ecl [options]... <nexus_plt_file>
+Try 'nex2ecl --help' for more information.)";
 
-    nex::NexusPlot plt = nex::load(filename);
+static const constexpr char *help =
+R"(Usage:
+  nex2ecl [options]... <nexus_plt_file>
+  nex2ecl -h | --help
+Options:
+  -f --format                Format the output.
+  -h --help                  Show this screen.
+  -o --output <file>|<path>  Write output to files prefixed by <file> or place
+                             output at <path>.
+)";
 
-    char * basename;
-    util_alloc_file_components( file_path , NULL, &basename , NULL);
-    util_strupr( basename );
+static struct option long_options[] = {
+    {"format", no_argument,       nullptr, 'f'},
+    {"help",   no_argument,       nullptr, 'h'},
+    {"output", required_argument, nullptr, 'o'}
+};
 
-    ecl_sum_type *ecl_sum = nex::ecl_summary(basename, plt);
-    ecl_sum_fwrite(ecl_sum);
-    ecl_sum_free(ecl_sum);
-    free( basename );
 }
 
+void create_ecl_sum( std::string input_path,
+                     std::string output_path,
+                     bool format_output ) {
+    auto ending = input_path.rfind(".plt");
+    if (ending == std::string::npos) {
+        input_path += ".plt";
+    }
 
-int main(int argc, char **argv) {
-    create_ecl_sum(argv[1]);
-    exit(0);
+    std::string ecl_case_name {};
+    {
+        char *plt_basename;
+        util_alloc_file_components( input_path.c_str(),
+                                    NULL,
+                                    &plt_basename,
+                                    NULL );
+        util_strupr( plt_basename );
+
+        if ( output_path.empty() ) {
+            ecl_case_name = std::string( plt_basename );
+        } else if ( util_is_directory(output_path.c_str()) ) {
+            ecl_case_name = output_path + std::string( plt_basename );
+        } else {
+            char *path = 0, *basename = 0;
+            util_alloc_file_components(output_path.c_str(), &path, &basename, NULL);
+
+            if ( !basename ) {
+                std::cerr << "Failed to parse output path "
+                          << output_path << "." << std::endl;
+                exit(1);
+            }
+
+            if ( path && !util_is_directory(path) ) {
+                std::cerr << path << " does not exists." << std::endl;
+                exit(1);
+            }
+
+            util_strupr( basename );
+
+            if ( path ) {
+                ecl_case_name += std::string( path );
+                ecl_case_name += UTIL_PATH_SEP_CHAR;
+            }
+            ecl_case_name += std::string( basename );
+
+            if ( path ) free( path );
+            if ( basename ) free( basename );
+        }
+
+        free( plt_basename );
+    }
+
+    nex::NexusPlot plt = nex::load( input_path );
+    ecl_sum_type *ecl_sum = nex::ecl_summary( ecl_case_name.c_str(),
+                                              format_output,
+                                              plt );
+    ecl_sum_fwrite(ecl_sum);
+    ecl_sum_free(ecl_sum);
+}
+
+int main( int argc, char **argv ) {
+    if (argc == 1) {
+        std::cout << usage << std::endl;
+        exit(1);
+    }
+
+    bool format_output = false;
+    std::string output_path {};
+    std::string input_path {};
+
+    /*
+     * Parse options
+     */
+
+    int c;
+    for (;;) {
+        c = getopt_long (argc, argv, "fho:", long_options, 0);
+        if (c == -1) // No more options
+            break;
+
+        switch (c) {
+        case 0:
+            break;
+        case 'f':
+            format_output = true;
+            break;
+        case 'h':
+            std::cout << help;
+            exit(0);
+        case 'o':
+            output_path = std::string( optarg );
+            break;
+        case '?':
+            exit(1);
+        default:
+            exit(1);
+        }
+    }
+    if (optind != argc - 1) {
+        std::cout << usage << std::endl;
+        exit(1);
+    }
+
+    input_path = std::string( argv[optind] );
+
+    try {
+        create_ecl_sum( input_path, output_path, format_output );
+    }
+    catch (const std::exception& e) {
+        std::cerr << e.what() << std::endl;
+        exit(1);
+    }
 }

--- a/lib/nexus/include/nexus/nexus_plot.hpp
+++ b/lib/nexus/include/nexus/nexus_plot.hpp
@@ -82,7 +82,8 @@ struct NexusPlot {
 };
 
 NexusPlot load( const std::string& );
-ecl_sum_type* ecl_summary( const std::string&, const NexusPlot& );
+ecl_sum_type* ecl_summary( const std::string&, bool format_output,
+                           const NexusPlot& );
 
 }
 

--- a/lib/nexus/nexus_plot.cpp
+++ b/lib/nexus/nexus_plot.cpp
@@ -309,8 +309,9 @@ void field_smspec( std::vector< eclvar >& nodes, ecl_sum_type* ecl_sum,
 } // anonymous namespace
 
 
-ecl_sum_type* nex::ecl_summary(const std::string& ecl_case, const NexusPlot& plt) {
-    bool fmt_output = true;
+ecl_sum_type* nex::ecl_summary(const std::string& ecl_case,
+                               bool format_output,
+                               const NexusPlot& plt) {
     bool unified = true;
     const char* key_join_string = ":";
     std::time_t sim_start = util_make_date_utc( plt.header.day,
@@ -319,7 +320,7 @@ ecl_sum_type* nex::ecl_summary(const std::string& ecl_case, const NexusPlot& plt
     bool time_in_days = true;
 
     ecl_sum_type * ecl_sum = ecl_sum_alloc_writer( ecl_case.c_str(),
-        fmt_output,
+        format_output,
         unified,
         key_join_string,
         sim_start,

--- a/lib/nexus/tests/nexus_nexus2ecl.cpp
+++ b/lib/nexus/tests/nexus_nexus2ecl.cpp
@@ -41,11 +41,11 @@ void test_create_ecl_sum(char *root_folder) {
 
     /* Write */
 
-    ecl_sum_type *ecl_sum = nex::ecl_summary( "ECL_CASE", plt );
+    ecl_sum_type *ecl_sum = nex::ecl_summary( "ECL_CASE", false, plt );
     test_assert_true( ecl_sum_is_instance( ecl_sum ));
     ecl_sum_fwrite( ecl_sum );
     ecl_sum_free( ecl_sum );
-    test_assert_true( util_file_exists( "ECL_CASE.FSMSPEC"));
+    test_assert_true( util_file_exists( "ECL_CASE.SMSPEC"));
 
     /* Load */
 


### PR DESCRIPTION
The nex2ecl application is extended to handle command-line options for
format `(-f|--format)`, help `(-h|--help)`, and output path `(-o|--output)`.