### PR TITLE
Nexus unit conversions

### DIFF
--- a/lib/nexus/include/nexus/unit.hpp
+++ b/lib/nexus/include/nexus/unit.hpp
@@ -12,7 +12,8 @@ namespace nex {
             lab,
             metric_kPa,
             metric_kg_cm2,
-            metric_bars
+            metric_bars,
+            unit_type_count
         };
 
 
@@ -59,12 +60,18 @@ namespace nex {
             // transmissibility,
             viscosity,
             volume,
-            water_cut
+            water_cut,
+            measure_enum_size
         };
 
         UnitSystem( std::array< char, 6 > );
         UnitSystem( std::string );
         UnitSystem( UnitType );
+
+        Measure measure( const std::string& ) const;
+
+        float conversion( Measure ) const;
+        float conversion( const std::string& ) const;
 
         std::string unit_str( Measure ) const;
         std::string unit_str( const std::string& ) const;

--- a/lib/nexus/tests/nexus_unit.cpp
+++ b/lib/nexus/tests/nexus_unit.cpp
@@ -1,5 +1,6 @@
 
 #include <iostream>
+#include <random>
 
 #include <ert/util/test_util.hpp>
 
@@ -10,11 +11,13 @@ void test_metric_bars_units() {
     const nex::UnitSystem u( nex::UnitSystem::UnitType::metric_bars );
 
     auto compressibility             = u.unit_str(nex::UnitSystem::Measure::compressibility);
+    auto concentration               = u.unit_str(nex::UnitSystem::Measure::concentration);
     auto density                     = u.unit_str(nex::UnitSystem::Measure::density);
     auto formation_volume_factor_gas = u.unit_str(nex::UnitSystem::Measure::formation_volume_factor_gas);
     auto formation_volume_factor_oil = u.unit_str(nex::UnitSystem::Measure::formation_volume_factor_oil);
     auto fraction                    = u.unit_str(nex::UnitSystem::Measure::fraction);
     auto gas_liquid_ratio            = u.unit_str(nex::UnitSystem::Measure::gas_liquid_ratio);
+    auto identity                    = u.unit_str(nex::UnitSystem::Measure::identity);
     auto length                      = u.unit_str(nex::UnitSystem::Measure::length);
     auto moles                       = u.unit_str(nex::UnitSystem::Measure::moles);
     auto permeability                = u.unit_str(nex::UnitSystem::Measure::permeability);
@@ -33,22 +36,24 @@ void test_metric_bars_units() {
     auto water_cut                   = u.unit_str(nex::UnitSystem::Measure::water_cut);
 
     test_assert_string_equal( compressibility.c_str(),             "BARS-1");
+    test_assert_string_equal( concentration.c_str(),               "KG/SM3");
     test_assert_string_equal( density.c_str(),                     "KG/M3");
     test_assert_string_equal( formation_volume_factor_gas.c_str(), "RM3/SM3");
     test_assert_string_equal( formation_volume_factor_oil.c_str(), "RM3/SM3");
     test_assert_string_equal( fraction.c_str(),                    "");
     test_assert_string_equal( gas_liquid_ratio.c_str(),            "SM3/SM3");
+    test_assert_string_equal( identity.c_str(),                    "");
     test_assert_string_equal( length.c_str(),                      "M");
     test_assert_string_equal( moles.c_str(),                       "KG-M");
     test_assert_string_equal( permeability.c_str(),                "MD");
     test_assert_string_equal( pressure.c_str(),                    "BARS");
     test_assert_string_equal( pressure_absolute.c_str(),           "BARSA");
     test_assert_string_equal( reservoir_rates.c_str(),             "RM3/DAY");
-    test_assert_string_equal( reservoir_volumes.c_str(),           "kRM3");
+    test_assert_string_equal( reservoir_volumes.c_str(),           "RM3");
     test_assert_string_equal( surface_rates_gas.c_str(),           "SM3/DAY");
     test_assert_string_equal( surface_rates_liquid.c_str(),        "SM3/DAY");
-    test_assert_string_equal( surface_volumes_gas.c_str(),         "kSM3");
-    test_assert_string_equal( surface_volumes_liquid.c_str(),      "kSM3");
+    test_assert_string_equal( surface_volumes_gas.c_str(),         "SM3");
+    test_assert_string_equal( surface_volumes_liquid.c_str(),      "SM3");
     test_assert_string_equal( temperature.c_str(),                 "C");
     test_assert_string_equal( time.c_str(),                        "DAY");
     test_assert_string_equal( viscosity.c_str(),                   "CP");
@@ -57,7 +62,48 @@ void test_metric_bars_units() {
 }
 
 
+namespace {
+    void test_single_conversion( const nex::UnitSystem& u,
+                            nex::UnitSystem::Measure measure,
+                            float n,
+                            float expected_conversion ) {
+        float c = n * u.conversion( measure );
+        test_assert_float_equal( n, c / expected_conversion );
+    }
+}
+
+void test_metric_conversions() {
+    const nex::UnitSystem u( nex::UnitSystem::UnitType::metric_bars );
+    std::default_random_engine gen;
+    std::uniform_real_distribution<float> dist( -1e20, 1e20 );
+
+    test_single_conversion( u, nex::UnitSystem::Measure::compressibility,             dist(gen), 1.0f    );
+    test_single_conversion( u, nex::UnitSystem::Measure::density,                     dist(gen), 1.0f    );
+    test_single_conversion( u, nex::UnitSystem::Measure::formation_volume_factor_gas, dist(gen), 1.0f    );
+    test_single_conversion( u, nex::UnitSystem::Measure::formation_volume_factor_oil, dist(gen), 1.0f    );
+    test_single_conversion( u, nex::UnitSystem::Measure::fraction,                    dist(gen), 1.0f    );
+    test_single_conversion( u, nex::UnitSystem::Measure::gas_liquid_ratio,            dist(gen), 1.0f    );
+    test_single_conversion( u, nex::UnitSystem::Measure::identity,                    dist(gen), 1.0f    );
+    test_single_conversion( u, nex::UnitSystem::Measure::length,                      dist(gen), 1.0f    );
+    test_single_conversion( u, nex::UnitSystem::Measure::moles,                       dist(gen), 1.0f    );
+    test_single_conversion( u, nex::UnitSystem::Measure::permeability,                dist(gen), 1.0f    );
+    test_single_conversion( u, nex::UnitSystem::Measure::pressure,                    dist(gen), 1.0f    );
+    test_single_conversion( u, nex::UnitSystem::Measure::pressure_absolute,           dist(gen), 1.0f    );
+    test_single_conversion( u, nex::UnitSystem::Measure::reservoir_rates,             dist(gen), 1.0f    );
+    test_single_conversion( u, nex::UnitSystem::Measure::reservoir_volumes,           dist(gen), 1000.0f );
+    test_single_conversion( u, nex::UnitSystem::Measure::surface_rates_gas,           dist(gen), 1.0f    );
+    test_single_conversion( u, nex::UnitSystem::Measure::surface_rates_liquid,        dist(gen), 1.0f    );
+    test_single_conversion( u, nex::UnitSystem::Measure::surface_volumes_gas,         dist(gen), 1000.0f );
+    test_single_conversion( u, nex::UnitSystem::Measure::surface_volumes_liquid,      dist(gen), 1000.0f );
+    test_single_conversion( u, nex::UnitSystem::Measure::temperature,                 dist(gen), 1.0f    );
+    test_single_conversion( u, nex::UnitSystem::Measure::time,                        dist(gen), 1.0f    );
+    test_single_conversion( u, nex::UnitSystem::Measure::viscosity,                   dist(gen), 1.0f    );
+    test_single_conversion( u, nex::UnitSystem::Measure::volume,                      dist(gen), 1.0f    );
+    test_single_conversion( u, nex::UnitSystem::Measure::water_cut,                   dist(gen), 1.0f    );
+}
+
 int main(int argc, char **argv) {
     test_metric_bars_units();
+    test_metric_conversions();
     exit(0);
 }

--- a/lib/nexus/unit.cpp
+++ b/lib/nexus/unit.cpp
@@ -32,12 +32,12 @@ static const constexpr char* metric_bars_table[] = {
     /* pressure                    */ "BARS",
     /* pressure_absolute           */ "BARSA",
     /* reservoir_rates             */ "RM3/DAY",
-    /* reservoir_volumes           */ "kRM3",
+    /* reservoir_volumes           */ "RM3",
     // /* saturation                  */ "FRACTION",
     /* surface_rates_gas           */ "SM3/DAY",
     /* surface_rates_liquid        */ "SM3/DAY",
-    /* surface_volumes_gas         */ "kSM3",
-    /* surface_volumes_liquid      */ "kSM3",
+    /* surface_volumes_gas         */ "SM3",
+    /* surface_volumes_liquid      */ "SM3",
     /* temperature                 */ "C",
     /* time                        */ "DAY",
     // /* tracer_consentrations       */ "FRACTION",
@@ -47,9 +47,37 @@ static const constexpr char* metric_bars_table[] = {
     /* water_cut                   */ "SM3/SM3"
 };
 
+static const constexpr float conversion_table
+[static_cast<int>( UnitSystem::Measure::measure_enum_size )]
+[static_cast<int>( UnitSystem::UnitType::unit_type_count )] = {
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* compressibility             */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* concentration               */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* density                     */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* formation_volume_factor_gas */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* formation_volume_factor_oil */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* fraction                    */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* gas_liquid_ratio            */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* identity                    */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* length                      */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* moles                       */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* permeability                */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* pressure                    */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* pressure_absolute           */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* reservoir_rates             */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1000.0f }, /* reservoir_volumes           */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* surface_rates_gas           */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* surface_rates_liquid        */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1000.0f }, /* surface_volumes_gas         */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1000.0f }, /* surface_volumes_liquid      */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* temperature                 */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* time                        */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* viscosity                   */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* volum                       */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }  /* water_cut                   */
+};
 
 static const std::map< std::string, UnitSystem::Measure >
-varname_to_unit_str = {
+varname_to_measure = {
     {"QOP" , UnitSystem::Measure::surface_rates_liquid   },
     {"QWP" , UnitSystem::Measure::surface_rates_liquid   },
     {"QGP" , UnitSystem::Measure::surface_rates_gas      },
@@ -121,17 +149,31 @@ UnitSystem::UnitSystem( UnitType unit ) {
     }
 }
 
-std::string UnitSystem::unit_str( Measure measure ) const {
-    return this->unit_str_table[static_cast<int>(measure)];
+UnitSystem::Measure UnitSystem::measure( const std::string& varname ) const {
+    auto it = varname_to_measure.find( varname );
+    if ( it != varname_to_measure.end() )
+        return it->second;
+    std::cerr << "Warning: no unit found for nexus variable " << varname
+              << std::endl;
+    return Measure::identity;
+}
+
+float UnitSystem::conversion( Measure m ) const {
+    int ui = static_cast<int>( this->unit );
+    int mi = static_cast<int>( m );
+    return conversion_table[mi][ui];
+}
+
+float UnitSystem::conversion( const std::string& varname ) const {
+    return this->conversion( this->measure(varname) );
+}
+
+std::string UnitSystem::unit_str( Measure m ) const {
+    return this->unit_str_table[ static_cast<int>(m) ];
 }
 
 std::string UnitSystem::unit_str( const std::string& varname ) const {
-    auto it = varname_to_unit_str.find( varname );
-    if (it != varname_to_unit_str.end())
-        return this->unit_str_table[static_cast<int>(it->second)];
-    std::cerr << "Warning: no unit found for nexus variable " << varname
-              << std::endl;
-    return "";
+    return this->unit_str( this->measure(varname) );
 }
 
 


### PR DESCRIPTION
Member function conversion is added to nexus/UnitSystem. This is to
facilitate conversions from nexus units to ecl units, in particular kRM3
to RM3 and kSM3 to SM3. Currently only the conversions for nexus unit
system METBAR is supported. The conversion table is located in
`lib/nexus/unit.cpp`.

This PR requires PR https://github.com/Statoil/libecl/pull/243