### PR TITLE
Removed internal locking from hash table implementation.

### DIFF
--- a/lib/include/ert/util/hash.h
+++ b/lib/include/ert/util/hash.h
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2011  Statoil ASA, Norway. 
-    
-   The file 'hash.h' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'hash.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #ifndef ERT_HASH_H
@@ -35,10 +35,7 @@ typedef void (hash_apply_ftype) (void * );
 UTIL_SAFE_CAST_HEADER(hash);
 UTIL_SAFE_CAST_HEADER_CONST(hash);
 
-void              hash_lock  (hash_type * );
-void              hash_unlock(hash_type * );
 hash_type       * hash_alloc(void);
-hash_type       * hash_alloc_unlocked(void);
 void              hash_iter_complete(hash_type * );
 void              hash_free(hash_type *);
 void              hash_free__(void *);
@@ -55,12 +52,12 @@ void              hash_safe_del(hash_type * , const char * );
 void              hash_clear(hash_type *);
 int               hash_get_size(const hash_type *);
 void              hash_set_keylist(const hash_type * , char **);
-char           ** hash_alloc_keylist(hash_type *);
-stringlist_type * hash_alloc_stringlist(hash_type * );
+char           ** hash_alloc_keylist(const hash_type *);
+stringlist_type * hash_alloc_stringlist(const hash_type * );
 
-char           ** hash_alloc_sorted_keylist (hash_type *hash , int ( hash_get_cmp_value ) (const void *));
-char           ** hash_alloc_key_sorted_list(hash_type *hash, int (*cmp)(const void *, const void *));
-bool              hash_key_list_compare( hash_type * hash1, hash_type * hash2);
+char           ** hash_alloc_sorted_keylist (const hash_type *hash , int ( hash_get_cmp_value ) (const void *));
+char           ** hash_alloc_key_sorted_list(const hash_type *hash, int (*cmp)(const void *, const void *));
+bool              hash_key_list_compare(const hash_type * hash1, const hash_type * hash2);
 void              hash_insert_hash_owned_ref(hash_type *, const char * , const void *, free_ftype *);
 void              hash_resize(hash_type *hash, int new_size);
 

--- a/lib/util/set.c
+++ b/lib/util/set.c
@@ -40,7 +40,7 @@ static UTIL_SAFE_CAST_FUNCTION( set , SET_TYPE_ID )
 set_type * set_alloc(int size, const char ** keyList) {
   set_type * set = (set_type*) malloc(sizeof * set);
   UTIL_TYPE_ID_INIT( set , SET_TYPE_ID );
-  set->key_hash  = hash_alloc_unlocked();
+  set->key_hash  = hash_alloc();
   {
     int ikey;
     for (ikey = 0; ikey < size; ikey++)


### PR DESCRIPTION
**Task**
The hash table implementation has had an internal pthreads based locking to ensure that there are no race conditions when accessing/updating a hash table. That  was a failure - locking should be handled by calling scope.

For more than five years the assumption has been that calling scope should indeed be responsible for locking - and the internal implementation has been to abort with a message if `try_lock( )` calls fail. No failures have been reported from this code, so in this PR the locking is entirely removed from the hash table implementation. The advantages from removing this locking is twofold:

1. Reduced complexity of the hash table implementation.
2. `hash_get( )` and `hash_has_key( )` can take a `const` hash pointer. 

Statoil/libres#171

