### PR TITLE
Add support for requested keywords in nex2ecl

### DIFF
--- a/lib/nexus/nexus_plot.cpp
+++ b/lib/nexus/nexus_plot.cpp
@@ -277,7 +277,14 @@ static const std::map< std::string, std::string > kw_nex2ecl {
     { "CCPP", "CPT" },
     { "CCPI", "CIT" },
     { "QPI" , "CIR" },
-    { "CPI" , "CIC" }
+    { "CPI" , "CIC" },
+    { "BHP" , "BHP" },
+    { "THP" , "THP" },
+    { "WPAV", "BP"  },
+    { "OIP" , "OIP" },
+    { "WIP" , "WIP" },
+    { "GIP" , "GIP" },
+    { "PAVH", "PR"  },
 };
 
 struct eclvar {

--- a/lib/nexus/tests/nexus_unit.cpp
+++ b/lib/nexus/tests/nexus_unit.cpp
@@ -90,11 +90,11 @@ void test_metric_conversions() {
     test_single_conversion( u, nex::UnitSystem::Measure::pressure,                    dist(gen), 1.0f    );
     test_single_conversion( u, nex::UnitSystem::Measure::pressure_absolute,           dist(gen), 1.0f    );
     test_single_conversion( u, nex::UnitSystem::Measure::reservoir_rates,             dist(gen), 1.0f    );
-    test_single_conversion( u, nex::UnitSystem::Measure::reservoir_volumes,           dist(gen), 1000.0f );
+    test_single_conversion( u, nex::UnitSystem::Measure::reservoir_volumes,           dist(gen), 1.0f    );
     test_single_conversion( u, nex::UnitSystem::Measure::surface_rates_gas,           dist(gen), 1.0f    );
     test_single_conversion( u, nex::UnitSystem::Measure::surface_rates_liquid,        dist(gen), 1.0f    );
-    test_single_conversion( u, nex::UnitSystem::Measure::surface_volumes_gas,         dist(gen), 1000.0f );
-    test_single_conversion( u, nex::UnitSystem::Measure::surface_volumes_liquid,      dist(gen), 1000.0f );
+    test_single_conversion( u, nex::UnitSystem::Measure::surface_volumes_gas,         dist(gen), 1.0f    );
+    test_single_conversion( u, nex::UnitSystem::Measure::surface_volumes_liquid,      dist(gen), 1.0f    );
     test_single_conversion( u, nex::UnitSystem::Measure::temperature,                 dist(gen), 1.0f    );
     test_single_conversion( u, nex::UnitSystem::Measure::time,                        dist(gen), 1.0f    );
     test_single_conversion( u, nex::UnitSystem::Measure::viscosity,                   dist(gen), 1.0f    );

--- a/lib/nexus/unit.cpp
+++ b/lib/nexus/unit.cpp
@@ -64,11 +64,11 @@ static const constexpr float conversion_table
     { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* pressure                    */
     { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* pressure_absolute           */
     { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* reservoir_rates             */
-    { 0.0f, 0.0f, 0.0f, 0.0f, 1000.0f }, /* reservoir_volumes           */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* reservoir_volumes           */
     { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* surface_rates_gas           */
     { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* surface_rates_liquid        */
-    { 0.0f, 0.0f, 0.0f, 0.0f, 1000.0f }, /* surface_volumes_gas         */
-    { 0.0f, 0.0f, 0.0f, 0.0f, 1000.0f }, /* surface_volumes_liquid      */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* surface_volumes_gas         */
+    { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* surface_volumes_liquid      */
     { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* temperature                 */
     { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* time                        */
     { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f    }, /* viscosity                   */

--- a/lib/nexus/unit.cpp
+++ b/lib/nexus/unit.cpp
@@ -99,7 +99,14 @@ varname_to_measure = {
     {"CCPP", UnitSystem::Measure::surface_volumes_liquid },
     {"CCPI", UnitSystem::Measure::surface_volumes_liquid },
     {"QPI" , UnitSystem::Measure::surface_rates_liquid   },
-    {"CPI" , UnitSystem::Measure::concentration          }
+    {"CPI" , UnitSystem::Measure::concentration          },
+    {"BHP" , UnitSystem::Measure::pressure               },
+    {"THP" , UnitSystem::Measure::pressure               },
+    {"WPAV", UnitSystem::Measure::pressure               },
+    {"OIP" , UnitSystem::Measure::surface_volumes_liquid },
+    {"WIP" , UnitSystem::Measure::surface_volumes_liquid },
+    {"GIP" , UnitSystem::Measure::surface_volumes_gas    },
+    {"PAVH", UnitSystem::Measure::pressure               }
 };
 
 


### PR DESCRIPTION
Added support for following keywords:

**Task**
[nex]	--> [ecl]

[ BHP ] --> WBHP	"Bottom hole pressure"
[ THP ] --> WTHP	"Well tubing head pressure"
[ WPAV ]--> WBP		"One-point Pressure Average"
Nexus: Standard is to calculate the average pressure based on solely the
perforation blocks for a well.


[ OIP ] --> FOIP	"Oil In Place (in liquid and wet gas phases)"
[ WIP ] --> FWIP	"Water In Place"
[ GIP ] --> FGIP	"Gas In Place (in liquid and gas phases)"
[ PAVH ] --> FPR	"Average field pressure"
Nexus: Average pressure weighted by hydrocarbon
pore volume.

