### PR TITLE
Added switch to disable internal cwrap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ option( RST_DOC             "Build RST documentation"                           
 option( ERT_BUILD_CXX       "Build some CXX wrappers"                                 ON)
 option( USE_RPATH           "Don't strip RPATH from libraries and binaries"           OFF)
 option( INSTALL_ERT_LEGACY  "Add ert legacy wrappers"                                 OFF)
-
+option( INSTALL_CWRAP       "Should the cwrap code be installed"                      ON)
 
 set(STATOIL_TESTDATA_ROOT "" CACHE PATH  "Root to Statoil internal testdata")
 if (EXISTS ${STATOIL_TESTDATA_ROOT})

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -7,12 +7,17 @@ init_python( 2.7 )
 
 find_python_package(numpy 1.7.1 ${PYTHON_INSTALL_PREFIX})
 if (NOT DEFINED PY_numpy)
-   message(WARNING "numpy module not found - Python wrappers not enabled")
+   message(WARNING "numpy module not found - Python wrappers not enabled. Install with: \"pip install numpy\"")
    set( BUILD_PYTHON OFF PARENT_SCOPE )
    return()
 endif()
 
 find_python_package(cwrap 1 ${PYTHON_INSTALL_PREFIX})
+if (NOT DEFINED PY_cwrap)
+  if (NOT INSTALL_CWRAP)
+    message(WARNING "cwrap module not found Python wrappers not enabled. Install with: \"pip install cwrap\"")
+  endif()
+endif()
 
 if (BUILD_TESTS)
    add_subdirectory( tests )

--- a/python/python/CMakeLists.txt
+++ b/python/python/CMakeLists.txt
@@ -1,6 +1,6 @@
 configure_file(test_env.py.in   ${PROJECT_BINARY_DIR}/${PYTHON_INSTALL_PREFIX}/test_env.py )
 
-if (NOT PY_cwrap)
+if (INSTALL_CWRAP)
     add_subdirectory(cwrap)
 endif ()
 


### PR DESCRIPTION
**Task**
Preparations for using external cwrap. Combined with ert#86 the default will be to build with external, i.e. `pip install` cwrap on Travis when this and ert#86 have been merged. 



**Pre un-WIP checklist**
- [ ] Statoil tests pass locally

Statoil/ert#86
