### PR TITLE
cwrap tests are conditioned to INSTALL_WRAP flag.

### DIFF
--- a/python/tests/CMakeLists.txt
+++ b/python/tests/CMakeLists.txt
@@ -9,12 +9,14 @@ add_subdirectory(geometry)
 add_subdirectory(util)
 add_subdirectory(ecl)
 add_subdirectory(well)
-add_subdirectory(cwrap)
 add_subdirectory(global)
 
 if (INSTALL_ERT_LEGACY)
    add_subdirectory(legacy)
 endif()
 
+if (INSTALL_CWRAP)
+  add_subdirectory(cwrap)
+endif()
 
 configure_file( test_install.in ${EXECUTABLE_OUTPUT_PATH}/test_install @ONLY )


### PR DESCRIPTION
**Task**
Ensure hte `cwrap` tests are not run if `-DINSTALL_CWRAP=OFF`.

[ ] : Statoil tests pass