### PR TITLE
Will silently ignore ImportError for test env.

### DIFF
--- a/python/python/ecl/test/extended_testcase.py
+++ b/python/python/ecl/test/extended_testcase.py
@@ -19,14 +19,8 @@ SOURCE_ROOT = None
 BUILD_ROOT = None
 try:
     from test_env import *
-    assert( os.path.isdir( TESTDATA_ROOT ))
-    assert( os.path.isdir( SOURCE_ROOT ))
-    assert( os.path.isdir( BUILD_ROOT ))
-    if not SHARE_ROOT is None:
-        assert( os.path.isdir( SHARE_ROOT ))
 except ImportError:
-    sys.stderr.write("Warning: could not import file test_env.py - this might lead to test failures.")
-
+    pass
 
 # Function wrapper which can be used to add decorator @log_test to test
 # methods. When a test has been decorated with @log_test it will print


### PR DESCRIPTION
**Task**
Remove/soften dependency on `test_env` module.

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
