### PR TITLE
WIP: Extended testcase class attributes

### DIFF
--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -1,0 +1,17 @@
+import os.path
+from ecl.test import ExtendedTestCase
+
+
+def source_root():
+    path_list = os.path.dirname(os.path.abspath(__file__)).split("/")
+    while True:
+        git_path = os.path.join(os.sep, "/".join(path_list), ".git")
+        if os.path.isdir(git_path):
+            return os.path.join(os.sep, *path_list)
+        path_list.pop()
+
+
+class EclTest(ExtendedTestCase):
+    SOURCE_ROOT = source_root()
+    TESTDATA_ROOT = os.path.join(SOURCE_ROOT, "test-data")
+

--- a/python/tests/ecl_tests/test_cell.py
+++ b/python/tests/ecl_tests/test_cell.py
@@ -16,9 +16,10 @@
 #  for more details.
 
 from ecl.ecl import Cell, EclGrid
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 
-class CellTest(ExtendedTestCase):
+
+class CellTest(EclTest):
 
     def setUp(self):
         fk = self.createTestPath('local/ECLIPSE/faarikaal/faarikaal1.EGRID')
@@ -96,3 +97,4 @@ class CellTest(ExtendedTestCase):
         r = repr(c)
         self.assertTrue(r.startswith('Cell(4, 1, 82, active, '))
         self.assertIn('faarikaal1.EGRID', r)
+

--- a/python/tests/ecl_tests/test_debug.py
+++ b/python/tests/ecl_tests/test_debug.py
@@ -14,9 +14,10 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
-from ecl.test import debug_msg, ExtendedTestCase
+from ecl.test import debug_msg
+from tests import EclTest
 
-class DebugTest(ExtendedTestCase):
+class DebugTest(EclTest):
 
     def test_create(self):
         msg = debug_msg( "DEBUG" )

--- a/python/tests/ecl_tests/test_deprecation.py
+++ b/python/tests/ecl_tests/test_deprecation.py
@@ -18,21 +18,22 @@ import warnings
 import time
 import datetime
 
-from ecl.test import ExtendedTestCase, TestAreaContext
+from ecl.test import TestAreaContext
 from ecl.ecl import EclFile, EclGrid, EclKW, EclDataType, EclGrid, EclRegion
 from ecl.ecl import FortIO, openFortIO, EclRFT, EclGridGenerator
 from ecl.test.ecl_mock import createEclSum
 from ecl.util import BoolVector
+from tests import EclTest
 
 # The class Deprecation_1_9_Test contains methods which will be marked
 # as deprecated in the 1.9.x versions.
 
 warnings.simplefilter("error" , DeprecationWarning)
 
-class Deprecation_2_1_Test(ExtendedTestCase):
+class Deprecation_2_1_Test(EclTest):
     pass
 
-class Deprecation_2_0_Test(ExtendedTestCase):
+class Deprecation_2_0_Test(EclTest):
 
     def test_EclFile_name_property(self):
         with TestAreaContext("name") as t:
@@ -43,7 +44,7 @@ class Deprecation_2_0_Test(ExtendedTestCase):
             t.sync()
             f = EclFile( "TEST" )
 
-class Deprecation_1_9_Test(ExtendedTestCase):
+class Deprecation_1_9_Test(EclTest):
 
     def test_EclRegion_properties(self):
         grid = EclGridGenerator.createRectangular( (10,10,10) , (1,1,1))

--- a/python/tests/ecl_tests/test_ecl_3dkw.py
+++ b/python/tests/ecl_tests/test_ecl_3dkw.py
@@ -19,11 +19,11 @@ import random
 
 from ecl.util import IntVector
 from ecl.ecl import Ecl3DKW , EclKW, EclDataType, EclFile, FortIO, EclFileFlagEnum , EclGrid
-from ecl.test import ExtendedTestCase , TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 
 
-
-class Ecl3DKWTest(ExtendedTestCase):
+class Ecl3DKWTest(EclTest):
 
     def test_create( self ):
         actnum = IntVector(default_value = 1 , initial_size = 1000)

--- a/python/tests/ecl_tests/test_ecl_cmp.py
+++ b/python/tests/ecl_tests/test_ecl_cmp.py
@@ -14,11 +14,12 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
 #  for more details.
 
-from ecl.test import ExtendedTestCase , TestAreaContext
+from ecl.test import TestAreaContext
 from ecl.test.ecl_mock import createEclSum
 from ecl.ecl import EclCmp
+from tests import EclTest
 
-class EclCmpTest(ExtendedTestCase):
+class EclCmpTest(EclTest):
     def setUp(self):
         self.root1 = self.createTestPath("Statoil/ECLIPSE/Gurbat/ECLIPSE")
         self.root2 = self.createTestPath("Statoil/ECLIPSE/Oseberg/F8MLT/F8MLT-F4")

--- a/python/tests/ecl_tests/test_ecl_file.py
+++ b/python/tests/ecl_tests/test_ecl_file.py
@@ -23,7 +23,8 @@ from unittest import skipIf
 from ecl.ecl import EclFile, FortIO, EclKW , openFortIO , openEclFile
 from ecl.ecl import EclFileFlagEnum, EclDataType, EclFileEnum
 from ecl.util import CWDContext
-from ecl.test import ExtendedTestCase , TestAreaContext, PathContext
+from ecl.test import TestAreaContext, PathContext
+from tests import EclTest
 
 def createFile( name , kw_list ):
     with openFortIO(name , mode = FortIO.WRITE_MODE) as f:
@@ -42,7 +43,7 @@ def loadKeywords( name ):
 
 
 
-class EclFileTest(ExtendedTestCase):
+class EclFileTest(EclTest):
 
     def assertFileType(self , filename , expected):
         file_type , step , fmt_file = EclFile.getFileType(filename)

--- a/python/tests/ecl_tests/test_ecl_file_statoil.py
+++ b/python/tests/ecl_tests/test_ecl_file_statoil.py
@@ -21,12 +21,12 @@ from unittest import skipIf
 from ecl.ecl import EclFile, FortIO, EclKW , openFortIO , openEclFile
 from ecl.ecl import EclFileFlagEnum, EclFileEnum
 
-from ecl.test import ExtendedTestCase , TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 
 
 
-
-class EclFileStatoilTest(ExtendedTestCase):
+class EclFileStatoilTest(EclTest):
     def setUp(self):
         self.test_file = self.createTestPath("Statoil/ECLIPSE/Gurbat/ECLIPSE.UNRST")
         self.test_fmt_file = self.createTestPath("Statoil/ECLIPSE/Gurbat/ECLIPSE.FUNRST")

--- a/python/tests/ecl_tests/test_ecl_init_file.py
+++ b/python/tests/ecl_tests/test_ecl_init_file.py
@@ -15,11 +15,11 @@
 #  for more details.
 
 
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 from ecl.ecl import (Ecl3DKW, EclKW, EclInitFile, EclFile, FortIO,
                      EclFileFlagEnum, EclGrid)
 
-class InitFileTest(ExtendedTestCase):
+class InitFileTest(EclTest):
 
 
     def setUp(self):

--- a/python/tests/ecl_tests/test_ecl_kw.py
+++ b/python/tests/ecl_tests/test_ecl_kw.py
@@ -22,7 +22,8 @@ import warnings
 from ecl.ecl import (EclKW, EclDataType, EclTypeEnum, EclFile, FortIO,
                      EclFileFlagEnum, openFortIO)
 
-from ecl.test import ExtendedTestCase, TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 
 
 def copy_long():
@@ -35,7 +36,7 @@ def copy_offset():
     copy = src.sub_copy(200, 100)
 
 
-class KWTest(ExtendedTestCase):
+class KWTest(EclTest):
 
     def test_name(self):
         kw = EclKW('TEST', 3, EclDataType.ECL_INT)

--- a/python/tests/ecl_tests/test_ecl_kw_statoil.py
+++ b/python/tests/ecl_tests/test_ecl_kw_statoil.py
@@ -18,8 +18,8 @@ import os
 import random
 from ecl.ecl import EclKW, EclDataType, EclFile, FortIO, EclFileFlagEnum
 
-from ecl.test import ExtendedTestCase , TestAreaContext
-
+from ecl.test import TestAreaContext
+from tests import EclTest
 
 def copy_long():
     src = EclKW("NAME", 100, EclDataType.ECL_FLOAT)
@@ -31,7 +31,7 @@ def copy_offset():
     copy = src.sub_copy(200, 100)
 
 
-class KWTest(ExtendedTestCase):
+class KWTest(EclTest):
     def test_fortio_size( self ):
         unrst_file_path = self.createTestPath("Statoil/ECLIPSE/Gurbat/ECLIPSE.UNRST")
         unrst_file = EclFile(unrst_file_path)

--- a/python/tests/ecl_tests/test_ecl_restart_file.py
+++ b/python/tests/ecl_tests/test_ecl_restart_file.py
@@ -15,10 +15,10 @@
 #  for more details.
 import datetime
 
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 from ecl.ecl import Ecl3DKW , EclKW, EclRestartFile , EclFile, FortIO, EclFileFlagEnum , EclGrid
 
-class RestartFileTest(ExtendedTestCase):
+class RestartFileTest(EclTest):
     def setUp(self):
         self.grid_file =   self.createTestPath("Statoil/ECLIPSE/Gurbat/ECLIPSE.EGRID")
         self.unrst_file   = self.createTestPath("Statoil/ECLIPSE/Gurbat/ECLIPSE.UNRST")

--- a/python/tests/ecl_tests/test_ecl_sum.py
+++ b/python/tests/ecl_tests/test_ecl_sum.py
@@ -21,10 +21,11 @@ import os.path
 from cwrap import CFILE
 from ecl.ecl import EclSum, EclSumKeyWordVector, EclFile
 from ecl.ecl import FortIO, openFortIO, openEclFile, EclKW
-from ecl.test import ExtendedTestCase, TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 
 
-class EclSumTest(ExtendedTestCase):
+class EclSumTest(EclTest):
 
 
     def setUp(self):

--- a/python/tests/ecl_tests/test_ecl_sum_tstep.py
+++ b/python/tests/ecl_tests/test_ecl_sum_tstep.py
@@ -1,10 +1,10 @@
 from datetime import datetime
 import random
 from ecl.ecl import EclSumTStep, EclSum
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 
 
-class EclSumTStepTest(ExtendedTestCase):
+class EclSumTStepTest(EclTest):
 
     def test_creation(self):
         ecl_sum = EclSum.writer("TEST", datetime(2010, 1, 1), 10, 10, 10)

--- a/python/tests/ecl_tests/test_ecl_sum_vector.py
+++ b/python/tests/ecl_tests/test_ecl_sum_vector.py
@@ -23,10 +23,10 @@ except ImportError:
 import warnings
 
 from ecl.ecl import EclSumVector, EclSum
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 
 
-class EclSumVectorTest(ExtendedTestCase):
+class EclSumVectorTest(EclTest):
 
 
     def setUp(self):

--- a/python/tests/ecl_tests/test_ecl_type.py
+++ b/python/tests/ecl_tests/test_ecl_type.py
@@ -1,11 +1,12 @@
-from ecl.test import TestAreaContext, ExtendedTestCase
+from ecl.test import TestAreaContext
+from tests import EclTest
 
 from ecl.ecl import EclDataType, EclTypeEnum
 
 def get_const_size_types():
     return EclTypeEnum.enums()[:-1:]
 
-class EclDataTypeTest(ExtendedTestCase):
+class EclDataTypeTest(EclTest):
 
     # All of the below should list their elements in the same order as
     # EclTypeEnum!

--- a/python/tests/ecl_tests/test_ecl_util.py
+++ b/python/tests/ecl_tests/test_ecl_util.py
@@ -15,10 +15,9 @@
 #  for more details.
 
 from ecl.ecl import EclGrid , EclUtil, EclTypeEnum , EclFileEnum, EclPhaseEnum, EclUnitTypeEnum
-from ecl.test import ExtendedTestCase 
+from tests import EclTest
 
-
-class EclUtilTest(ExtendedTestCase):
+class EclUtilTest(EclTest):
 
     def test_enums(self):
         source_file_path = "lib/include/ert/ecl/ecl_util.h"

--- a/python/tests/ecl_tests/test_fault_blocks.py
+++ b/python/tests/ecl_tests/test_fault_blocks.py
@@ -21,10 +21,11 @@ import warnings
 from ecl.ecl import EclGrid, EclKW , EclRegion, EclDataType
 from ecl.ecl.faults import FaultBlock, FaultBlockLayer, FaultBlockCell,FaultCollection
 from ecl.geo import Polyline , CPolylineCollection
-from ecl.test import ExtendedTestCase , TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 
 
-class FaultBlockTest(ExtendedTestCase):
+class FaultBlockTest(EclTest):
     def setUp(self):
         self.grid = EclGrid.createRectangular( (10,10,10) , (1,1,1) )
         self.kw = EclKW( "FAULTBLK" , self.grid.getGlobalSize() , EclDataType.ECL_INT )

--- a/python/tests/ecl_tests/test_fault_blocks_statoil.py
+++ b/python/tests/ecl_tests/test_fault_blocks_statoil.py
@@ -20,10 +20,10 @@ except ImportError:
     from unittest import skipIf
 
 from ecl.ecl import EclGrid, EclDataType , EclKW
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 from ecl.ecl.faults import FaultBlock, FaultBlockLayer
 
-class FaultBlockTest(ExtendedTestCase):
+class FaultBlockTest(EclTest):
     def setUp(self):
         self.grid = EclGrid( self.createTestPath("Statoil/ECLIPSE/Mariner/MARINER.EGRID"))
         fileH = open( self.createTestPath("Statoil/ECLIPSE/Mariner/faultblock.grdecl") )

--- a/python/tests/ecl_tests/test_faults.py
+++ b/python/tests/ecl_tests/test_faults.py
@@ -21,11 +21,11 @@ from ecl import util
 
 from ecl.ecl.faults import FaultCollection, Fault, FaultLine, FaultSegment,FaultBlockLayer
 from ecl.ecl import EclGrid, EclKW, EclDataType
-from ecl.test import ExtendedTestCase, TestAreaContext
+from ecl.test import TestAreaContext
 from ecl.geo import Polyline , CPolyline
+from tests import EclTest
 
-
-class FaultTest(ExtendedTestCase):
+class FaultTest(EclTest):
     @classmethod
     def setUpClass(cls):
         cls.grid = EclGrid.createRectangular( (151,100,50) , (1,1,1))

--- a/python/tests/ecl_tests/test_fk_user_data.py
+++ b/python/tests/ecl_tests/test_fk_user_data.py
@@ -16,9 +16,10 @@
 #  for more details.
 
 from ecl.ecl import EclGrid
-from ecl.test import ExtendedTestCase, TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 
-class FKTest(ExtendedTestCase):
+class FKTest(EclTest):
 
     def test_cell_containment(self):
 

--- a/python/tests/ecl_tests/test_fortio.py
+++ b/python/tests/ecl_tests/test_fortio.py
@@ -17,14 +17,15 @@
 import os
 from random import randint
 from ecl.ecl import FortIO, EclDataType, EclKW , openFortIO, EclFile
-from ecl.test import ExtendedTestCase, TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 
 
 
 
-class FortIOTest(ExtendedTestCase):
+class FortIOTest(EclTest):
 
-        
+
 
 
     def test_open_write(self):

--- a/python/tests/ecl_tests/test_geertsma.py
+++ b/python/tests/ecl_tests/test_geertsma.py
@@ -1,7 +1,8 @@
 import datetime
 from ecl.ecl import EclGrid, EclKW, EclDataType, openFortIO, FortIO, EclFile, EclSubsidence
 
-from ecl.test import ExtendedTestCase , TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 
 import numpy as np
 
@@ -46,7 +47,7 @@ def create_restart(grid, case, p1, p2=None):
             p.fwrite(f)
 
 
-class GeertsmaTest(ExtendedTestCase):
+class GeertsmaTest(EclTest):
 
     @staticmethod
     def test_geertsma_kernel():

--- a/python/tests/ecl_tests/test_grav.py
+++ b/python/tests/ecl_tests/test_grav.py
@@ -1,9 +1,10 @@
 import time
 from ecl.ecl import EclGrav, EclKW, EclGrid, EclFile, EclDataType, openFortIO, FortIO
-from ecl.test import ExtendedTestCase , TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 
 
-class EclGravTest(ExtendedTestCase):
+class EclGravTest(EclTest):
 
 
     def setUp(self):

--- a/python/tests/ecl_tests/test_grdecl.py
+++ b/python/tests/ecl_tests/test_grdecl.py
@@ -17,13 +17,13 @@
 
 import os
 from ecl.ecl import EclKW,EclGrid,Ecl3DKW
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 
 
 
 
 
-class GRDECLTest(ExtendedTestCase):
+class GRDECLTest(EclTest):
     def setUp(self):
         self.src_file = self.createTestPath("Statoil/ECLIPSE/Gurbat/include/example_permx.GRDECL")
         self.file_list = []

--- a/python/tests/ecl_tests/test_grid.py
+++ b/python/tests/ecl_tests/test_grid.py
@@ -24,7 +24,8 @@ from ecl.util import IntVector
 from ecl.ecl import EclGrid, EclKW, EclDataType, EclUnitTypeEnum, EclFile
 from ecl.ecl import EclGridGenerator as GridGen
 from ecl.ecl.faults import Layer , FaultCollection
-from ecl.test import ExtendedTestCase , TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 
 # This dict is used to verify that corners are mapped to the correct
 # cell with respect to containment.
@@ -119,7 +120,7 @@ def average(points):
 # This test class should only have test cases which do not require
 # external test data. Tests involving Statoil test data are in the
 # test_grid_statoil module.
-class GridTest(ExtendedTestCase):
+class GridTest(EclTest):
 
     def test_oom_grid(self):
         nx = 2000

--- a/python/tests/ecl_tests/test_indexed_read.py
+++ b/python/tests/ecl_tests/test_indexed_read.py
@@ -3,10 +3,11 @@ import ecl
 
 from ecl import EclPrototype
 from ecl.ecl import EclKW, EclFile, EclDataType, FortIO
-from ecl.test import ExtendedTestCase, TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 from ecl.util import IntVector
 
-class EclIndexedReadTest(ExtendedTestCase):
+class EclIndexedReadTest(EclTest):
     _freadIndexedData   = EclPrototype("void ecl_kw_fread_indexed_data_python(fortio, int, ecl_data_type, int, int_vector, char*)", bind = False) # fortio, offset, type, count, index_map, buffer
     _eclFileIndexedRead = EclPrototype("void ecl_file_indexed_read(ecl_file, char*, int, int_vector, char*)", bind = False) # ecl_file, kw, index, index_map, buffer
 

--- a/python/tests/ecl_tests/test_layer.py
+++ b/python/tests/ecl_tests/test_layer.py
@@ -22,10 +22,11 @@ from ecl.util import IntVector
 from ecl.ecl import EclGrid
 from ecl.geo import CPolyline
 from ecl.ecl.faults import Layer , FaultCollection
-from ecl.test import ExtendedTestCase , TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 
 
-class LayerTest(ExtendedTestCase):
+class LayerTest(EclTest):
     def setUp(self):
         pass
 

--- a/python/tests/ecl_tests/test_npv.py
+++ b/python/tests/ecl_tests/test_npv.py
@@ -28,7 +28,8 @@ from ecl.ecl import EclSum
 from ecl.ecl import EclNPV , NPVPriceVector
 
 from ecl.util import StringList, TimeVector, DoubleVector , CTime
-from ecl.test import ExtendedTestCase , TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 
 
 base = "ECLIPSE"
@@ -45,7 +46,7 @@ def linear2(x):
     return 2*x
 
 
-class NPVTest(ExtendedTestCase):
+class NPVTest(EclTest):
     def setUp(self):
         self.case = self.createTestPath(case)
 

--- a/python/tests/ecl_tests/test_region.py
+++ b/python/tests/ecl_tests/test_region.py
@@ -15,10 +15,10 @@
 #  for more details.
 from ecl.ecl import EclGrid, EclKW, EclRegion, EclDataType
 from ecl.ecl.faults import Layer
-from ecl.test import ExtendedTestCase
 from ecl.util import IntVector
+from tests import EclTest
 
-class RegionTest(ExtendedTestCase):
+class RegionTest(EclTest):
 
     def test_equal(self):
         grid = EclGrid.createRectangular( (10,10,1) , (1,1,1))

--- a/python/tests/ecl_tests/test_region_statoil.py
+++ b/python/tests/ecl_tests/test_region_statoil.py
@@ -16,10 +16,10 @@
 #  for more details.
 from ecl.ecl import EclFile, EclGrid, EclRegion
 from ecl.ecl.faults import Layer
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 
 
-class RegionTest(ExtendedTestCase):
+class RegionTest(EclTest):
     def setUp(self):
         case = self.createTestPath("Statoil/ECLIPSE/Gurbat/ECLIPSE")
         self.grid = EclGrid(case)

--- a/python/tests/ecl_tests/test_removed.py
+++ b/python/tests/ecl_tests/test_removed.py
@@ -1,12 +1,13 @@
 import time
 import datetime
 
-from ecl.test import ExtendedTestCase, TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 from ecl.ecl import EclFile,EclKW,EclDataType,openFortIO, FortIO
 
 
 
-class Removed_2_1_Test(ExtendedTestCase):
+class Removed_2_1_Test(EclTest):
     def test_ecl_file_block(self):
 
         with TestAreaContext("name") as t:

--- a/python/tests/ecl_tests/test_rft.py
+++ b/python/tests/ecl_tests/test_rft.py
@@ -20,10 +20,10 @@ import datetime
 from ecl.util import CTime
 from ecl.ecl import EclRFTFile, EclRFTCell, EclPLTCell
 from ecl.ecl.rft import WellTrajectory
-from ecl.test import ExtendedTestCase
 from ecl.ecl import EclRFT
+from tests import EclTest
 
-class RFTTest(ExtendedTestCase):
+class RFTTest(EclTest):
 
     def test_create(self):
         rft = EclRFT( "WELL" , "RFT" , datetime.date(2015 , 10 , 1 ) , 100 )

--- a/python/tests/ecl_tests/test_rft_cell.py
+++ b/python/tests/ecl_tests/test_rft_cell.py
@@ -17,7 +17,7 @@
 
 
 from ecl.ecl import EclRFTCell, EclPLTCell
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 
 
 # def out_of_range():
@@ -25,7 +25,7 @@ from ecl.test import ExtendedTestCase
 #     rft = rftFile[100]
 
 
-class RFTCellTest(ExtendedTestCase):
+class RFTCellTest(EclTest):
     def setUp(self):
         self.RFT_file = self.createTestPath("Statoil/ECLIPSE/Gurbat/ECLIPSE.RFT")
         self.PLT_file = self.createTestPath("Statoil/ECLIPSE/RFT/TEST1_1A.RFT")

--- a/python/tests/ecl_tests/test_sum.py
+++ b/python/tests/ecl_tests/test_sum.py
@@ -22,7 +22,8 @@ import shutil
 from unittest import skipIf, skipUnless, skipIf
 
 from ecl.ecl import EclSum, EclSumVarType, FortIO, openFortIO, EclKW, EclDataType, EclSumKeyWordVector
-from ecl.test import ExtendedTestCase, TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 from ecl.test.ecl_mock import createEclSum
 
 def fopr(days):
@@ -37,7 +38,7 @@ def fgpt(days):
     else:
         return 100 - days
 
-class SumTest(ExtendedTestCase):
+class SumTest(EclTest):
 
 
     def test_mock(self):

--- a/python/tests/geometry_tests/test_convex_hull.py
+++ b/python/tests/geometry_tests/test_convex_hull.py
@@ -1,8 +1,8 @@
 from ecl.geo.geometry_tools import GeometryTools
-from ecl.test.extended_testcase import ExtendedTestCase
+from tests import EclTest
 
 
-class ConvexHullTest(ExtendedTestCase):
+class ConvexHullTest(EclTest):
 
     def test_ccw(self):
         p1 = (0, 0)

--- a/python/tests/geometry_tests/test_cpolyline.py
+++ b/python/tests/geometry_tests/test_cpolyline.py
@@ -2,10 +2,11 @@ import math
 
 from ecl.geo import CPolyline , Polyline
 from ecl.geo.xyz_io import XYZIo
-from ecl.test import ExtendedTestCase , TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 
 
-class CPolylineTest(ExtendedTestCase):
+class CPolylineTest(EclTest):
     def setUp(self):
         self.polyline1 = self.createTestPath("local/geometry/pol11.xyz")
         self.polyline2 = self.createTestPath("local/geometry/pol8.xyz")

--- a/python/tests/geometry_tests/test_cpolyline_collection.py
+++ b/python/tests/geometry_tests/test_cpolyline_collection.py
@@ -2,10 +2,11 @@ import gc
 
 from ecl.geo import CPolylineCollection , CPolyline
 from ecl.geo.xyz_io import XYZIo
-from ecl.test import ExtendedTestCase , TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 from ecl.util import DoubleVector
 
-class CPolylineCollectionTest(ExtendedTestCase):
+class CPolylineCollectionTest(EclTest):
 
     def test_construction(self):
         pc = CPolylineCollection()

--- a/python/tests/geometry_tests/test_geo_pointset.py
+++ b/python/tests/geometry_tests/test_geo_pointset.py
@@ -1,8 +1,9 @@
 from ecl.geo import GeoPointset, Surface
-from ecl.test import ExtendedTestCase, TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 
 
-class GeoPointsetTest(ExtendedTestCase):
+class GeoPointsetTest(EclTest):
 
     def test_init(self):
         gp = GeoPointset()

--- a/python/tests/geometry_tests/test_geo_region.py
+++ b/python/tests/geometry_tests/test_geo_region.py
@@ -1,8 +1,9 @@
 from ecl.geo import GeoRegion, GeoPointset, CPolyline, Surface
-from ecl.test import ExtendedTestCase, TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 
 
-class GeoRegionTest(ExtendedTestCase):
+class GeoRegionTest(EclTest):
 
     def test_init(self):
         pointset = GeoPointset()

--- a/python/tests/geometry_tests/test_geometry_tools.py
+++ b/python/tests/geometry_tests/test_geometry_tools.py
@@ -2,10 +2,11 @@ import math
 
 from ecl.geo import Polyline, GeometryTools , CPolyline
 from ecl.geo.xyz_io import XYZIo
-from ecl.test import ExtendedTestCase , TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 
 
-class GeometryToolsTest(ExtendedTestCase):
+class GeometryToolsTest(EclTest):
 
     def test_distance(self):
         p1 = (1,1)

--- a/python/tests/geometry_tests/test_intersection.py
+++ b/python/tests/geometry_tests/test_intersection.py
@@ -1,8 +1,8 @@
 from ecl.geo import GeometryTools
-from ecl.test.extended_testcase import ExtendedTestCase
+from tests import EclTest
 
 
-class IntersectionTest(ExtendedTestCase):
+class IntersectionTest(EclTest):
 
     def test_intersection(self):
 

--- a/python/tests/geometry_tests/test_point_in_polygon.py
+++ b/python/tests/geometry_tests/test_point_in_polygon.py
@@ -1,9 +1,9 @@
 from ecl.geo.geometry_tools import GeometryTools
 from ecl.geo.polyline import Polyline
-from ecl.test.extended_testcase import ExtendedTestCase
+from tests import EclTest
 
 
-class PointInPolygonTest(ExtendedTestCase):
+class PointInPolygonTest(EclTest):
 
     def test_point_in_polygon(self):
         p1 = (0.5, 0.5)

--- a/python/tests/geometry_tests/test_polygon_slicing.py
+++ b/python/tests/geometry_tests/test_polygon_slicing.py
@@ -1,9 +1,9 @@
 from math import sqrt
 from ecl.geo.geometry_tools import GeometryTools
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 
 
-class PolygonSlicingTest(ExtendedTestCase):
+class PolygonSlicingTest(EclTest):
 
     def test_slicing_internal_hull(self):
         polygon = [(2,2),(2,1),(1,1),(1,5),(5,5),(5,4),(4,4)]

--- a/python/tests/geometry_tests/test_polyline.py
+++ b/python/tests/geometry_tests/test_polyline.py
@@ -1,10 +1,11 @@
 
 from ecl.geo import Polyline, GeometryTools
 from ecl.geo.xyz_io import XYZIo
-from ecl.test import ExtendedTestCase , TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 
 
-class PolylineTest(ExtendedTestCase):
+class PolylineTest(EclTest):
     def setUp(self):
         self.polyline = self.createTestPath("local/geometry/pol11.xyz")
         self.closed_polyline = self.createTestPath("local/geometry/pol8.xyz")

--- a/python/tests/geometry_tests/test_surface.py
+++ b/python/tests/geometry_tests/test_surface.py
@@ -1,9 +1,10 @@
 import random
 from ecl.geo import Surface
-from ecl.test import ExtendedTestCase , TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 
 
-class SurfaceTest(ExtendedTestCase):
+class SurfaceTest(EclTest):
     def setUp(self):
         self.surface_valid = self.createTestPath("local/geometry/surface/valid_ascii.irap")
         self.surface_short = self.createTestPath("local/geometry/surface/short_ascii.irap")

--- a/python/tests/global_tests/test_import.py
+++ b/python/tests/global_tests/test_import.py
@@ -21,6 +21,6 @@ import sys
 from ecl.test import ImportTestCase
 
 class ImportEcl(ImportTestCase):
-    
+
     def test_import_ecl(self):
         self.assertTrue( self.import_package( "ecl" ))

--- a/python/tests/legacy_tests/test_ecl.py
+++ b/python/tests/legacy_tests/test_ecl.py
@@ -34,8 +34,9 @@ from ert.ecl.faults import FaultBlock , FaultBlockCell
 from ert.ecl.faults import FaultBlockLayer
 
 
-from ecl.test import ExtendedTestCase
+
+from tests import EclTest
 
 
-class ErtLegacyEclTest(ExtendedTestCase):
+class ErtLegacyEclTest(EclTest):
     pass

--- a/python/tests/legacy_tests/test_geo.py
+++ b/python/tests/legacy_tests/test_geo.py
@@ -7,8 +7,8 @@ from ert.geo import XYZIo
 from ert.geo import GeometryTools
 from ert.geo import Surface
 
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 
 
-class ErtLegacyGeoTest(ExtendedTestCase):
+class ErtLegacyGeoTest(EclTest):
     pass

--- a/python/tests/legacy_tests/test_test.py
+++ b/python/tests/legacy_tests/test_test.py
@@ -9,8 +9,8 @@ from ert.test import PathContext
 from ert.test import LintTestCase
 from ert.test import ImportTestCase
 
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 
 
-class ErtLegacyTestTest(ExtendedTestCase):
+class ErtLegacyTestTest(EclTest):
     pass

--- a/python/tests/legacy_tests/test_util.py
+++ b/python/tests/legacy_tests/test_util.py
@@ -23,12 +23,12 @@ from ert.util import Profiler
 from ert.util import ArgPack
 from ert.util import PathFormat
 
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 
 try:
     from res.util import SubstitutionList
 except ImportError:
     pass
 
-class ErtLegacyUtilTest(ExtendedTestCase):
+class ErtLegacyUtilTest(EclTest):
     pass

--- a/python/tests/legacy_tests/test_well.py
+++ b/python/tests/legacy_tests/test_well.py
@@ -6,8 +6,8 @@ from ert.well import WellState
 from ert.well import WellTimeLine
 from ert.well import WellInfo
 
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 
 
-class ErtLegacyWellTest(ExtendedTestCase):
+class ErtLegacyWellTest(EclTest):
     pass

--- a/python/tests/util_tests/test_arg_pack.py
+++ b/python/tests/util_tests/test_arg_pack.py
@@ -1,12 +1,12 @@
 import ecl
 from ecl import EclPrototype
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 from ecl.util import ArgPack, StringList
 
 TEST_LIB = EclPrototype.lib
 
 
-class ArgPackTest(ExtendedTestCase):
+class ArgPackTest(EclTest):
     def test_create(self):
         arg = ArgPack()
         self.assertEqual(len(arg), 0)

--- a/python/tests/util_tests/test_cthread_pool.py
+++ b/python/tests/util_tests/test_cthread_pool.py
@@ -1,13 +1,13 @@
 import ctypes
 import ecl
 from ecl import EclPrototype
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 from ecl.util import CThreadPool, startCThreadPool
 
 TEST_LIB = EclPrototype.lib 
 
 
-class CThreadPoolTest(ExtendedTestCase):
+class CThreadPoolTest(EclTest):
     def test_cfunc(self):
         with self.assertRaises(TypeError):
             func = CThreadPool.lookupCFunction("WRONG-TYPE", "no-this-does-not-exist")

--- a/python/tests/util_tests/test_hash.py
+++ b/python/tests/util_tests/test_hash.py
@@ -1,10 +1,10 @@
 from ctypes import c_void_p
 
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 from ecl.util import Hash, StringHash, DoubleHash, IntegerHash
 
 
-class HashTest(ExtendedTestCase):
+class HashTest(EclTest):
     def test_string_hash(self):
         hash = StringHash()
 

--- a/python/tests/util_tests/test_log.py
+++ b/python/tests/util_tests/test_log.py
@@ -1,8 +1,8 @@
 from ecl.util.enums import MessageLevelEnum
 
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 
-class LogTest(ExtendedTestCase):
+class LogTest(EclTest):
 
     def test_enums(self):
         self.assertEnumIsFullyDefined(MessageLevelEnum, "message_level_type", "lib/include/ert/util/log.h")

--- a/python/tests/util_tests/test_matrix.py
+++ b/python/tests/util_tests/test_matrix.py
@@ -1,8 +1,9 @@
 from ecl.util import Matrix , RandomNumberGenerator
 from ecl.util.enums import RngAlgTypeEnum, RngInitModeEnum
-from ecl.test import ExtendedTestCase, TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 
-class MatrixTest(ExtendedTestCase):
+class MatrixTest(EclTest):
     def test_matrix(self):
         m = Matrix(2, 3)
 

--- a/python/tests/util_tests/test_path_context.py
+++ b/python/tests/util_tests/test_path_context.py
@@ -1,8 +1,9 @@
 import os
-from ecl.test import ExtendedTestCase, PathContext,TestAreaContext
+from ecl.test import PathContext,TestAreaContext
+from tests import EclTest
 
 
-class PathContextTest(ExtendedTestCase):
+class PathContextTest(EclTest):
     
     def test_error(self):
         with TestAreaContext("pathcontext"):

--- a/python/tests/util_tests/test_path_fmt.py
+++ b/python/tests/util_tests/test_path_fmt.py
@@ -1,8 +1,9 @@
 import os
-from ecl.test import ExtendedTestCase, TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 from ecl.util import PathFormat
 
-class PathFmtTest(ExtendedTestCase):
+class PathFmtTest(EclTest):
 
     def test_create(self):
         path_fmt = PathFormat("random/path/%d-%d")

--- a/python/tests/util_tests/test_rng.py
+++ b/python/tests/util_tests/test_rng.py
@@ -1,9 +1,10 @@
 from ecl.util.enums import RngAlgTypeEnum, RngInitModeEnum
 from ecl.util.rng import RandomNumberGenerator
-from ecl.test import ExtendedTestCase,TestAreaContext
+from ecl.test import TestAreaContext
+from tests import EclTest
 
 
-class RngTest(ExtendedTestCase):
+class RngTest(EclTest):
 
     def test_enums(self):
         self.assertEnumIsFullyDefined(RngAlgTypeEnum, "rng_alg_type", "lib/include/ert/util/rng.h")

--- a/python/tests/util_tests/test_spawn.py
+++ b/python/tests/util_tests/test_spawn.py
@@ -4,7 +4,7 @@ import sys
 
 import ecl
 from ecl import EclPrototype
-from ecl.test.extended_testcase import ExtendedTestCase
+from tests import EclTest
 from ecl.test.test_area import TestAreaContext
 
 from cwrap import Prototype
@@ -16,7 +16,7 @@ class _TestSpawnPrototype(Prototype):
         super(_TestSpawnPrototype, self).__init__(_TestSpawnPrototype.lib, prototype, bind=bind)
 
 
-class SpawnTest(ExtendedTestCase):
+class SpawnTest(EclTest):
     _spawn = _TestSpawnPrototype("int util_spawn_blocking(char*, int, void*, char*, char*)", bind = False)
     def createScript(self, name, stdout_string , stderr_string):
         with open(name, "w") as f:

--- a/python/tests/util_tests/test_stat.py
+++ b/python/tests/util_tests/test_stat.py
@@ -1,9 +1,9 @@
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 from ecl.util import DoubleVector, quantile, quantile_sorted, polyfit
 from ecl.util.rng import RandomNumberGenerator
 
 
-class StatTest(ExtendedTestCase):
+class StatTest(EclTest):
     def test_stat_quantiles(self):
         rng = RandomNumberGenerator()
         rng.setState("0123456789ABCDEF")

--- a/python/tests/util_tests/test_ui_return.py
+++ b/python/tests/util_tests/test_ui_return.py
@@ -1,9 +1,9 @@
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 from ecl.util import UIReturn
 from ecl.util.enums import UIReturnStatusEnum
 
 
-class UIReturnTest(ExtendedTestCase):
+class UIReturnTest(EclTest):
     def test_create(self):
         ui_return = UIReturn(UIReturnStatusEnum.UI_RETURN_OK)
         self.assertTrue(ui_return)

--- a/python/tests/util_tests/test_version.py
+++ b/python/tests/util_tests/test_version.py
@@ -16,11 +16,11 @@
 import os.path
 
 import ecl
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 from ecl.util import Version,EclVersion
 
 
-class VersionTest(ExtendedTestCase):
+class VersionTest(EclTest):
     def setUp(self):
         pass
 

--- a/python/tests/util_tests/test_work_area.py
+++ b/python/tests/util_tests/test_work_area.py
@@ -23,10 +23,11 @@ try:
 except ImportError:
     from unittest import skipIf
 
-from ecl.test import ExtendedTestCase , TestAreaContext, TempAreaContext
+from ecl.test import TestAreaContext, TempAreaContext
+from tests import EclTest
 
 
-class WorkAreaTest(ExtendedTestCase):
+class WorkAreaTest(EclTest):
 
     def test_full_path(self):
         with TestAreaContext("TestArea") as test_area:

--- a/python/tests/well_tests/test_ecl_well.py
+++ b/python/tests/well_tests/test_ecl_well.py
@@ -1,11 +1,11 @@
 import datetime
 from ecl.ecl import EclGrid, EclFile, EclFileFlagEnum
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 from ecl.util.ctime import CTime
 from ecl.well import WellInfo, WellConnection, WellTypeEnum, WellConnectionDirectionEnum, WellSegment
 
 
-class EclWellTest(ExtendedTestCase):
+class EclWellTest(EclTest):
     ALL_WELLS = ['E5H', 'G1H', 'M41', 'J41', 'D10H', 'P41', 'L41', 'M42', 'S41', 'S13H', 'Q12HT2', 'O41', 'L11H', 'Q21H',
                  'E6CH', 'D4Y1H', 'D4Y2H', 'I13Y1H', 'Q21AY1H', 'F5AH', 'O14Y4HT2', 'K24Y1H', 'K24Y3H', 'S21H', 'N11H',
                  'L23Y1H', 'D7AY1H', 'S21AHT2', 'H2AH', 'S21AHT3', 'L23Y6H', 'N11AH', 'N11BY1H', 'X23Y2H', 'N22Y3HT3',

--- a/python/tests/well_tests/test_ecl_well2.py
+++ b/python/tests/well_tests/test_ecl_well2.py
@@ -2,13 +2,13 @@ import datetime
 import os.path
 
 from ecl.ecl import EclGrid, EclFile, EclFileFlagEnum
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 from ecl.util.ctime import CTime
 from ecl.well import WellInfo, WellConnection, WellTypeEnum, WellConnectionDirectionEnum, WellSegment
 
 
 
-class EclWellTest2(ExtendedTestCase):
+class EclWellTest2(EclTest):
     grid = None
 
 

--- a/python/tests/well_tests/test_ecl_well3.py
+++ b/python/tests/well_tests/test_ecl_well3.py
@@ -2,12 +2,12 @@ import datetime
 import os.path
 
 from ecl.ecl import EclGrid, EclFile, EclSum
-from ecl.test import ExtendedTestCase
+from tests import EclTest
 from ecl.util.ctime import CTime
 from ecl.well import WellInfo, WellConnection, WellTypeEnum, WellConnectionDirectionEnum, WellSegment
 
 
-class EclWellTest3(ExtendedTestCase):
+class EclWellTest3(EclTest):
     grid = None
 
     def test_rates(self):


### PR DESCRIPTION
**Task**
The test class `ExtendedTestCase` in the `ecl.test` contains a mixture of generic testing functionality, which is also used in libres, ert and ert-statoil, and settings specific to the libecl repository. With this PR these things should be split.

Statoil/libres#197
Statoil/ert#90


  
  