### PR TITLE
WIP: Added skeleton for summary_resample script

### DIFF
--- a/bin/summary_resample
+++ b/bin/summary_resample
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+import sys
+import argparse
+from ecl.ecl import EclSum
+from ecl.util import TimeVector, CTime
+
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("input_case", metavar="input_case", type=str)
+parser.add_argument("output_case", metavar="output_case", type=str)
+parser.add_argument("--num-timestep", type=int, default=50)
+
+args = parser.parse_args()
+
+input_case = EclSum(args.input_case)
+time_points = TimeVector()
+start_time = input_case.get_data_start_time()
+end_time = input_case.get_end_time()
+delta = end_time - start_time
+
+time_points.initRange(CTime(start_time), CTime(end_time), CTime(int(delta.total_seconds() / args.num_timestep)))
+
+output_case = input_case.resample(args.output_case, time_points)
+#output_case.fwrite( )

--- a/lib/ecl/ecl_smspec.c
+++ b/lib/ecl/ecl_smspec.c
@@ -246,7 +246,7 @@ static const char* smspec_required_keywords[] = {
 
 /*****************************************************************/
 
-static ecl_smspec_type * ecl_smspec_alloc_empty(bool write_mode , const char * key_join_string) {
+ecl_smspec_type * ecl_smspec_alloc_empty(bool write_mode , const char * key_join_string) {
   ecl_smspec_type *ecl_smspec;
   ecl_smspec = util_malloc(sizeof *ecl_smspec );
   UTIL_TYPE_ID_INIT(ecl_smspec , ECL_SMSPEC_ID);

--- a/lib/ecl/ecl_sum.c
+++ b/lib/ecl/ecl_sum.c
@@ -274,6 +274,15 @@ smspec_node_type * ecl_sum_add_var( ecl_sum_type * ecl_sum , const char * keywor
   return smspec_node;
 }
 
+smspec_node_type * ecl_sum_add_smspec_node(ecl_sum_type * ecl_sum, const smspec_node_type * node) {
+  return ecl_sum_add_var(ecl_sum,
+                         smspec_node_get_keyword(node),
+                         smspec_node_get_wgname(node),
+                         smspec_node_get_num(node),
+                         smspec_node_get_unit(node),
+                         smspec_node_get_default(node));
+}
+
 
 smspec_node_type * ecl_sum_add_blank_var( ecl_sum_type * ecl_sum , float default_value) {
   smspec_node_type * smspec_node = smspec_node_alloc_new( -1 , default_value );

--- a/lib/ecl/ecl_sum_vector.c
+++ b/lib/ecl/ecl_sum_vector.c
@@ -47,14 +47,37 @@ void ecl_sum_vector_free( ecl_sum_vector_type * ecl_sum_vector ){
 
 UTIL_IS_INSTANCE_FUNCTION( ecl_sum_vector , ECL_SUM_VECTOR_TYPE_ID )
 
+static void ecl_sum_vector_add_node(ecl_sum_vector_type * vector, const smspec_node_type * node, const char * key ) {
+  int params_index = smspec_node_get_params_index( node );
+  bool is_rate_key = smspec_node_is_rate( node);
 
-ecl_sum_vector_type * ecl_sum_vector_alloc(const ecl_sum_type * ecl_sum){
+  int_vector_append(vector->node_index_list, params_index);
+  bool_vector_append(vector->is_rate_list, is_rate_key);
+  stringlist_append_copy( vector->key_list, key );
+}
+
+
+ecl_sum_vector_type * ecl_sum_vector_alloc(const ecl_sum_type * ecl_sum, bool add_keywords) {
     ecl_sum_vector_type * ecl_sum_vector = util_malloc( sizeof * ecl_sum_vector );
     UTIL_TYPE_ID_INIT( ecl_sum_vector , ECL_SUM_VECTOR_TYPE_ID);
     ecl_sum_vector->ecl_sum  = ecl_sum;
     ecl_sum_vector->node_index_list = int_vector_alloc(0,0);
     ecl_sum_vector->is_rate_list  = bool_vector_alloc(0,false);
     ecl_sum_vector->key_list = stringlist_alloc_new( );
+    if (add_keywords) {
+      const ecl_smspec_type * smspec = ecl_sum_get_smspec(ecl_sum);
+      for (int i=0; i < ecl_smspec_num_nodes(smspec); i++) {
+        const smspec_node_type * node = ecl_smspec_iget_node( smspec , i );
+        const char * key = smspec_node_get_gen_key1(node);
+
+        /*
+          The TIME keyword is special case handled to not be included; that is
+          to match the same special casing in the key matching function.
+        */
+        if (!util_string_equal(key, "TIME"))
+          ecl_sum_vector_add_node( ecl_sum_vector, node, key);
+      }
+    }
     return ecl_sum_vector;
 }
 
@@ -79,7 +102,7 @@ static void ecl_sum_vector_add_invalid_key(ecl_sum_vector_type * vector, const c
 */
 
 ecl_sum_vector_type * ecl_sum_vector_alloc_layout_copy(const ecl_sum_vector_type * src_vector, const ecl_sum_type * ecl_sum) {
-  ecl_sum_vector_type * new_vector = ecl_sum_vector_alloc(ecl_sum);
+  ecl_sum_vector_type * new_vector = ecl_sum_vector_alloc(ecl_sum, false);
   for (int i=0; i < stringlist_get_size(src_vector->key_list); i++) {
     const char * key = stringlist_iget(src_vector->key_list, i);
     if (ecl_sum_has_general_var(ecl_sum, key))
@@ -95,12 +118,7 @@ ecl_sum_vector_type * ecl_sum_vector_alloc_layout_copy(const ecl_sum_vector_type
 bool ecl_sum_vector_add_key( ecl_sum_vector_type * ecl_sum_vector, const char * key){
   if (ecl_sum_has_general_var( ecl_sum_vector->ecl_sum , key)) {
     const smspec_node_type * node = ecl_sum_get_general_var_node( ecl_sum_vector->ecl_sum , key );
-    int params_index = smspec_node_get_params_index( node );
-    bool is_rate_key = smspec_node_is_rate( node);
-
-    int_vector_append(ecl_sum_vector->node_index_list, params_index);
-    bool_vector_append(ecl_sum_vector->is_rate_list, is_rate_key);
-    stringlist_append_copy( ecl_sum_vector->key_list, key );
+    ecl_sum_vector_add_node(ecl_sum_vector, node, key);
     return true;
   } else
     return false;
@@ -114,12 +132,7 @@ void ecl_sum_vector_add_keys( ecl_sum_vector_type * ecl_sum_vector, const char *
     for(i = 0; i < num_keywords ;i++){
         const char * key = stringlist_iget(keylist, i);
         const smspec_node_type * node = ecl_sum_get_general_var_node( ecl_sum_vector->ecl_sum , key );
-        int params_index = smspec_node_get_params_index( node );
-        bool is_rate_key = smspec_node_is_rate( node);
-
-        int_vector_append(ecl_sum_vector->node_index_list, params_index);
-        bool_vector_append(ecl_sum_vector->is_rate_list, is_rate_key);
-        stringlist_append_copy( ecl_sum_vector->key_list, key );
+        ecl_sum_vector_add_node(ecl_sum_vector, node, key);
     }
     stringlist_free(keylist);
 }

--- a/lib/ecl/tests/ecl_smspec.c
+++ b/lib/ecl/tests/ecl_smspec.c
@@ -20,7 +20,7 @@
 #include <stdbool.h>
 
 #include <ert/util/test_util.h>
-
+#include <ert/ecl/ecl_sum.h>
 #include <ert/ecl/ecl_smspec.h>
 
 void test_sort( ecl_smspec_type * smspec )
@@ -36,6 +36,18 @@ void test_sort( ecl_smspec_type * smspec )
 
     test_assert_int_equal( smspec_node_get_params_index( node1 ) , i - 1 );
   }
+}
+
+
+void test_copy(const ecl_smspec_type * smspec1) {
+  ecl_sum_type * ecl_sum2 = ecl_sum_alloc_writer("CASE", false, true, ":", 0, true, 100, 100, 100);
+  ecl_smspec_type * smspec2 = ecl_sum_get_smspec(ecl_sum2);
+  for (int i=0; i < ecl_smspec_num_nodes(smspec1); i++) {
+    const smspec_node_type * node = ecl_smspec_iget_node(smspec1, i);
+    ecl_sum_add_smspec_node(ecl_sum2, node);
+  }
+  test_assert_true( ecl_smspec_equal(smspec1, smspec2));
+  ecl_sum_free(ecl_sum2);
 }
 
 

--- a/lib/include/ert/ecl/ecl_smspec.h
+++ b/lib/include/ert/ecl/ecl_smspec.h
@@ -54,6 +54,7 @@ typedef struct ecl_smspec_struct ecl_smspec_type;
   bool                ecl_smspec_needs_wgname( ecl_smspec_var_type var_type );
   const char        * ecl_smspec_get_var_type_name( ecl_smspec_var_type var_type );
   ecl_smspec_var_type ecl_smspec_identify_var_type(const char * var);
+  ecl_smspec_type * ecl_smspec_alloc_empty(bool write_mode , const char * key_join_string);
   ecl_smspec_type   * ecl_smspec_alloc_writer( const char * key_join_string , const char * restart_case, time_t sim_start , bool time_in_days , int nx , int ny , int nz);
   void                ecl_smspec_fwrite( const ecl_smspec_type * smspec , const char * ecl_case , bool fmt_file );
 

--- a/lib/include/ert/ecl/ecl_sum.h
+++ b/lib/include/ert/ecl/ecl_sum.h
@@ -221,6 +221,7 @@ typedef struct ecl_sum_struct       ecl_sum_type;
   void                  ecl_sum_set_case( ecl_sum_type * ecl_sum , const char * ecl_case);
   void                  ecl_sum_fwrite( const ecl_sum_type * ecl_sum );
   void                  ecl_sum_fwrite_smspec( const ecl_sum_type * ecl_sum );
+  smspec_node_type    * ecl_sum_add_smspec_node(ecl_sum_type * ecl_sum, const smspec_node_type * node);
   smspec_node_type    * ecl_sum_add_var(ecl_sum_type * ecl_sum ,
                                         const char * keyword ,
                                         const char * wgname ,

--- a/lib/include/ert/ecl/ecl_sum_vector.h
+++ b/lib/include/ert/ecl/ecl_sum_vector.h
@@ -30,7 +30,7 @@ extern "C" {
 typedef struct ecl_sum_vector_struct ecl_sum_vector_type;
 
   void ecl_sum_vector_free( ecl_sum_vector_type * keylist );
-  ecl_sum_vector_type * ecl_sum_vector_alloc(const ecl_sum_type * ecl_sum);
+  ecl_sum_vector_type * ecl_sum_vector_alloc(const ecl_sum_type * ecl_sum, bool add_keywords);
 
   bool ecl_sum_vector_add_key( ecl_sum_vector_type * keylist, const char * key);
   void ecl_sum_vector_add_keys( ecl_sum_vector_type * keylist, const char * pattern);

--- a/python/ecl/ecl/ecl_sum.py
+++ b/python/ecl/ecl/ecl_sum.py
@@ -1278,6 +1278,10 @@ class EclSum(BaseCClass):
 
 
 
+    def resample(self, new_case, time_points):
+        #return self._resample(new_case, time_points)
+        return None
+
 
 import ecl.ecl.ecl_sum_keyword_vector
 EclSum._dump_csv_line = EclPrototype("void  ecl_sum_fwrite_interp_csv_line(ecl_sum, time_t, ecl_sum_vector, FILE)", bind=False)

--- a/python/ecl/ecl/ecl_sum_keyword_vector.py
+++ b/python/ecl/ecl/ecl_sum_keyword_vector.py
@@ -31,7 +31,7 @@ from ecl import EclPrototype
 
 class EclSumKeyWordVector(BaseCClass):
     TYPE_NAME       = "ecl_sum_vector"
-    _alloc          = EclPrototype("void* ecl_sum_vector_alloc(ecl_sum)", bind=False)
+    _alloc          = EclPrototype("void* ecl_sum_vector_alloc(ecl_sum, bool)", bind=False)
     _alloc_copy     = EclPrototype("ecl_sum_vector_obj ecl_sum_vector_alloc_layout_copy(ecl_sum_vector, ecl_sum)")
     _free           = EclPrototype("void ecl_sum_vector_free(ecl_sum_vector)")
     _add            = EclPrototype("bool ecl_sum_vector_add_key(ecl_sum_vector,  char*)")
@@ -39,8 +39,8 @@ class EclSumKeyWordVector(BaseCClass):
     _get_size       = EclPrototype("int ecl_sum_vector_get_size(ecl_sum_vector)")
     _iget_key       = EclPrototype("char* ecl_sum_vector_iget_key(ecl_sum_vector, int)")
 
-    def __init__(self, ecl_sum):
-        c_pointer = self._alloc(ecl_sum)
+    def __init__(self, ecl_sum, add_keywords = False):
+        c_pointer = self._alloc(ecl_sum, add_keywords)
         super(EclSumKeyWordVector, self).__init__(c_pointer)
 
     def __getitem__(self, index):

--- a/python/tests/CMakeLists.txt
+++ b/python/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_subdirectory(util_tests)
 add_subdirectory(ecl_tests)
 add_subdirectory(well_tests)
 add_subdirectory(global_tests)
+add_subdirectory(bin_tests)
 
 if (INSTALL_ERT_LEGACY)
    add_subdirectory(legacy_tests)

--- a/python/tests/bin_tests/CMakeLists.txt
+++ b/python/tests/bin_tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(TEST_SOURCES
+    __init__.py
+    test_summary_resample.py
+)
+
+add_python_package("python.tests.bin_tests"  ${PYTHON_INSTALL_PREFIX}/tests/bin_tests "${TEST_SOURCES}" False)
+
+addPythonTest(tests.bin_tests.test_summary_resample.SummaryResampleTest)

--- a/python/tests/bin_tests/test_summary_resample.py
+++ b/python/tests/bin_tests/test_summary_resample.py
@@ -1,0 +1,52 @@
+#  Copyright (C) 2018  Statoil ASA, Norway.
+#
+#  This file is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
+
+import os.path
+import subprocess
+from subprocess import CalledProcessError as CallError
+
+from ecl.ecl import Cell, EclGrid, EclSum
+from tests import EclTest
+from ecl.test.ecl_mock import createEclSum
+from ecl.test import TestAreaContext
+
+
+class SummaryResampleTest(EclTest):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.script = os.path.join(cls.SOURCE_ROOT, "bin/summary_resample")
+        cls.case = createEclSum("CSV", [("FOPT", None, 0), ("FOPR", None, 0)])
+
+    def test_run_default(self):
+        with TestAreaContext(""):
+            self.case.fwrite()
+
+            # Too few arguments
+            with self.assertRaises(CallError):
+                subprocess.check_call([self.script])
+
+            # Too few arguments
+            with self.assertRaises(CallError):
+                subprocess.check_call([self.script, "CSV"])
+
+            # Invalid first arguments
+            with self.assertRaises(CallError):
+                subprocess.check_call([self.script, "DOES_NOT_EXIST", "OUTPUT"])
+
+            # Should run OK:
+            subprocess.check_call([self.script, "CSV", "OUTPUT"])
+            #output_case = EclSum("OUTPUT")

--- a/python/tests/ecl_tests/test_sum.py
+++ b/python/tests/ecl_tests/test_sum.py
@@ -38,6 +38,16 @@ def fgpt(days):
     else:
         return 100 - days
 
+def create_case():
+    length = 100
+    return createEclSum("CSV" , [("FOPT", None , 0) , ("FOPR" , None , 0), ("FGPT" , None , 0)],
+                        sim_length_days = length,
+                        num_report_step = 10,
+                        num_mini_step = 10,
+                        func_table = {"FOPT" : fopt,
+                                      "FOPR" : fopr ,
+                                      "FGPT" : fgpt })
+
 class SumTest(EclTest):
 
 
@@ -70,7 +80,7 @@ class SumTest(EclTest):
         case = createEclSum("CSV" , [("FOPT", None , 0) ,
                                      ("FOPR" , None , 0),
                                      ("AARQ" , None , 10),
-                                     ("RGPT" , None  ,1)])
+                                    ("RGPT" , None  ,1)])
 
         node1 = case.smspec_node( "FOPT" )
         self.assertEqual( node1.varType( ) , EclSumVarType.ECL_SMSPEC_FIELD_VAR )
@@ -351,3 +361,15 @@ class SumTest(EclTest):
             self.assertEqual(d1[0],d2[0])
             self.assertEqual(d1[2],d2[2])
             self.assertEqual(d2[1],"")
+
+
+
+    def test_vector_select_all(self):
+        case = create_case()
+        ecl_sum_vector = EclSumKeyWordVector(case, True)
+        keys = case.keys()
+        self.assertEqual( len(keys), len(ecl_sum_vector))
+        for key in keys:
+            self.assertIn(key, ecl_sum_vector)
+
+


### PR DESCRIPTION
**Task**
We need to be able to control the time-points used for loading the summary cases into ert. This is a skeleton script which can output an ecl_summary on-disk - with new time axis.

This is continued in #285

**Pre un-WIP checklist**
- [x] Statoil tests pass locally

  