### PR TITLE
WIP: Implement summary resample

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,7 +348,7 @@ endif()
 
 add_subdirectory( lib )
 add_subdirectory( applications )
-
+add_subdirectory( bin )
 
 if (ENABLE_PYTHON)
    if (ERT_WINDOWS)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -1,0 +1,3 @@
+if (ENABLE_PYTHON)
+    install(PROGRAMS summary_resample DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+endif()

--- a/bin/summary_resample
+++ b/bin/summary_resample
@@ -22,4 +22,4 @@ delta = end_time - start_time
 time_points.initRange(CTime(start_time), CTime(end_time), CTime(int(delta.total_seconds() / args.num_timestep)))
 
 output_case = input_case.resample(args.output_case, input_case, time_points)
-#output_case.fwrite( )
+output_case.fwrite( )

--- a/bin/summary_resample
+++ b/bin/summary_resample
@@ -21,5 +21,5 @@ delta = end_time - start_time
 
 time_points.initRange(CTime(start_time), CTime(end_time), CTime(int(delta.total_seconds() / args.num_timestep)))
 
-output_case = input_case.resample(args.output_case, time_points)
+output_case = input_case.resample(args.output_case, input_case, time_points)
 #output_case.fwrite( )

--- a/bin/summary_resample
+++ b/bin/summary_resample
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+import sys
+import argparse
+from ecl.ecl import EclSum
+from ecl.util import TimeVector, CTime
+
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("input_case", metavar="input_case", type=str)
+parser.add_argument("output_case", metavar="output_case", type=str)
+parser.add_argument("--num-timestep", type=int, default=50)
+
+args = parser.parse_args()
+
+input_case = EclSum(args.input_case)
+time_points = TimeVector()
+start_time = input_case.get_data_start_time()
+end_time = input_case.get_end_time()
+delta = end_time - start_time
+
+time_points.initRange(CTime(start_time), CTime(end_time), CTime(int(delta.total_seconds() / args.num_timestep)))
+
+output_case = input_case.resample(args.output_case, time_points)
+#output_case.fwrite( )

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: ecl
 Priority: extra
 Maintainer: Arne Morten Kvarving <arne.morten.kvarving@sintef.no>
 Build-Depends: debhelper (>= 8.0.0), cmake, liblapack-dev, libquadmath0,
-               iputils-ping, zlib1g-dev, git, python-dev, python-numpy
+               iputils-ping, zlib1g-dev, git, python-dev, python-numpy, python-cwrap
 Standards-Version: 3.9.2
 Section: libs
 Homepage: http://ert.nr.no
@@ -22,13 +22,6 @@ Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: libecl Eclipse IO library
  libecl is a package for reading and writing the result files from the Eclipse reservoir simulator.
-
-Package: python-cwrap
-Section: python
-Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
-Description: Utilities for wrapping C code from python
- python-cwrap is a package helping to write python bindings for C libraries
 
 Package: python-ecl
 Section: python

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -379,6 +379,7 @@ foreach (name   ecl_alloc_cpgrid
                 ecl_nnc_info_test
                 ecl_nnc_vector
                 ecl_rft_cell
+                ecl_sum_alloc_resampled_test
                 ecl_file_view
                 test_ecl_file_index
                 test_transactions

--- a/lib/ecl/ecl_smspec.c
+++ b/lib/ecl/ecl_smspec.c
@@ -246,7 +246,7 @@ static const char* smspec_required_keywords[] = {
 
 /*****************************************************************/
 
-static ecl_smspec_type * ecl_smspec_alloc_empty(bool write_mode , const char * key_join_string) {
+ecl_smspec_type * ecl_smspec_alloc_empty(bool write_mode , const char * key_join_string) {
   ecl_smspec_type *ecl_smspec;
   ecl_smspec = util_malloc(sizeof *ecl_smspec );
   UTIL_TYPE_ID_INIT(ecl_smspec , ECL_SMSPEC_ID);

--- a/lib/ecl/ecl_sum.c
+++ b/lib/ecl/ecl_sum.c
@@ -714,9 +714,6 @@ ecl_sum_type * ecl_sum_alloc_resample(const char * ecl_case, const ecl_sum_type 
   if ( !time_t_vector_is_sorted(times, false) )
     return NULL;
   
-  bool   fmt_case        = ecl_sum->fmt_case;
-  bool   unified         = ecl_sum->unified;
-  char * key_join_string = ecl_sum->key_join_string;
   const int * grid_dims  = ecl_smspec_get_grid_dims(ecl_sum->smspec);
 
   bool time_in_days = false;
@@ -724,7 +721,7 @@ ecl_sum_type * ecl_sum_alloc_resample(const char * ecl_case, const ecl_sum_type 
   if ( util_string_equal(smspec_node_get_unit(node), "DAYS" ) )
     time_in_days = true;
 
-  ecl_sum_type * ecl_sum_resampled = ecl_sum_alloc_writer( ecl_case , fmt_case , unified , key_join_string , start_time , time_in_days , grid_dims[0] , grid_dims[1] , grid_dims[2] );
+  ecl_sum_type * ecl_sum_resampled = ecl_sum_alloc_writer( ecl_case , ecl_sum->fmt_case , ecl_sum->unified , ecl_sum->key_join_string , start_time , time_in_days , grid_dims[0] , grid_dims[1] , grid_dims[2] );
 
   ecl_sum_vector_type * ecl_sum_vector = ecl_sum_vector_alloc(ecl_sum, true);
 

--- a/lib/ecl/ecl_sum.c
+++ b/lib/ecl/ecl_sum.c
@@ -716,7 +716,7 @@ ecl_sum_type * ecl_sum_alloc_resample(const char * ecl_case, const ecl_sum_type 
   
   bool   fmt_case        = ecl_sum->fmt_case;
   bool   unified         = ecl_sum->unified;
-  char * key_join_string = util_alloc_string_copy(ecl_sum->key_join_string);
+  char * key_join_string = ecl_sum->key_join_string;
   const int * grid_dims  = ecl_smspec_get_grid_dims(ecl_sum->smspec);
 
   bool time_in_days = false;
@@ -748,7 +748,6 @@ ecl_sum_type * ecl_sum_alloc_resample(const char * ecl_case, const ecl_sum_type 
   }
   double_vector_free( data );
   ecl_sum_vector_free( ecl_sum_vector );
-  free(key_join_string);
   return ecl_sum_resampled;
 }
 

--- a/lib/ecl/ecl_sum.c
+++ b/lib/ecl/ecl_sum.c
@@ -274,6 +274,15 @@ smspec_node_type * ecl_sum_add_var( ecl_sum_type * ecl_sum , const char * keywor
   return smspec_node;
 }
 
+smspec_node_type * ecl_sum_add_smspec_node(ecl_sum_type * ecl_sum, const smspec_node_type * node) {
+  return ecl_sum_add_var(ecl_sum,
+                         smspec_node_get_keyword(node),
+                         smspec_node_get_wgname(node),
+                         smspec_node_get_num(node),
+                         smspec_node_get_unit(node),
+                         smspec_node_get_default(node));
+}
+
 
 smspec_node_type * ecl_sum_add_blank_var( ecl_sum_type * ecl_sum , float default_value) {
   smspec_node_type * smspec_node = smspec_node_alloc_new( -1 , default_value );

--- a/lib/ecl/ecl_sum.c
+++ b/lib/ecl/ecl_sum.c
@@ -35,6 +35,8 @@
 
 #include <ert/ecl/ecl_util.h>
 #include <ert/ecl/ecl_sum.h>
+
+#include <ert/ecl/ecl_sum_data.h>
 #include <ert/ecl/ecl_smspec.h>
 #include <ert/ecl/ecl_sum_data.h>
 #include <ert/ecl/smspec_node.h>
@@ -323,6 +325,56 @@ ecl_sum_type * ecl_sum_alloc_restart_writer( const char * ecl_case , const char 
 
 ecl_sum_type * ecl_sum_alloc_writer( const char * ecl_case , bool fmt_output , bool unified , const char * key_join_string , time_t sim_start , bool time_in_days , int nx , int ny , int nz) {
   return ecl_sum_alloc_restart_writer(ecl_case, NULL, fmt_output, unified, key_join_string, sim_start, time_in_days, nx, ny, nz);
+}
+
+
+ecl_sum_type * ecl_sum_alloc_resample(const char * ecl_case, const ecl_sum_type * ecl_sum, const time_t_vector_type * times) {
+
+  time_t start_time = ecl_sum_data_get_data_start(ecl_sum->data);
+
+  if ( time_t_vector_get_first(times) < start_time )
+    return NULL;
+  if ( time_t_vector_get_last(times) > ecl_sum_data_get_sim_end(ecl_sum->data) )
+    return NULL;
+  if ( !time_t_vector_is_sorted(times, false) )
+    return NULL;
+  
+  bool   fmt_case        = ecl_sum->fmt_case;
+  bool   unified         = ecl_sum->unified;
+  char * key_join_string = util_alloc_string_copy(ecl_sum->key_join_string);
+  const int * grid_dims  = ecl_smspec_get_grid_dims(ecl_sum->smspec);
+
+  bool time_in_days = false;
+  const smspec_node_type * node = ecl_smspec_iget_node(ecl_sum->smspec, 0);
+  if ( util_string_equal(smspec_node_get_unit(node), "DAYS" ) )
+    time_in_days = true;
+
+  ecl_sum_type * ecl_sum_resampled = ecl_sum_alloc_writer( ecl_case , fmt_case , unified , key_join_string , start_time , time_in_days , grid_dims[0] , grid_dims[1] , grid_dims[2] );
+
+  ecl_sum_vector_type * ecl_sum_vector = ecl_sum_vector_alloc(ecl_sum, true);
+
+  for (int i = 1; i < ecl_smspec_num_nodes(ecl_sum->smspec); i++) {
+    const smspec_node_type * node = ecl_smspec_iget_node(ecl_sum->smspec, i);
+    smspec_node_type * node_resampled = ecl_sum_add_smspec_node(  ecl_sum_resampled, node );
+  }
+
+  double_vector_type * data = double_vector_alloc( ecl_smspec_num_nodes(ecl_sum->smspec) , 0);  
+
+  for (int report_step = 0; report_step < time_t_vector_size(times); report_step++) {
+    time_t t = time_t_vector_iget(times, report_step);
+    ecl_sum_tstep_type * tstep = ecl_sum_add_tstep( ecl_sum_resampled , report_step , t - start_time);
+    ecl_sum_get_interp_vector( ecl_sum, t, ecl_sum_vector, data);
+
+    for (int i = 1; i < ecl_smspec_num_nodes(ecl_sum_resampled->smspec); i++) {
+      const smspec_node_type * node = ecl_smspec_iget_node(ecl_sum_resampled->smspec, i);
+      ecl_sum_tstep_set_from_node( tstep , node , double_vector_iget(data, i - 1) );
+    }
+
+  }
+  double_vector_free( data );
+  ecl_sum_vector_free( ecl_sum_vector );
+  free(key_join_string);
+  return ecl_sum_resampled;
 }
 
 void ecl_sum_fwrite( const ecl_sum_type * ecl_sum ) {

--- a/lib/ecl/ecl_sum_vector.c
+++ b/lib/ecl/ecl_sum_vector.c
@@ -47,14 +47,37 @@ void ecl_sum_vector_free( ecl_sum_vector_type * ecl_sum_vector ){
 
 UTIL_IS_INSTANCE_FUNCTION( ecl_sum_vector , ECL_SUM_VECTOR_TYPE_ID )
 
+static void ecl_sum_vector_add_node(ecl_sum_vector_type * vector, const smspec_node_type * node, const char * key ) {
+  int params_index = smspec_node_get_params_index( node );
+  bool is_rate_key = smspec_node_is_rate( node);
 
-ecl_sum_vector_type * ecl_sum_vector_alloc(const ecl_sum_type * ecl_sum){
+  int_vector_append(vector->node_index_list, params_index);
+  bool_vector_append(vector->is_rate_list, is_rate_key);
+  stringlist_append_copy( vector->key_list, key );
+}
+
+
+ecl_sum_vector_type * ecl_sum_vector_alloc(const ecl_sum_type * ecl_sum, bool add_keywords) {
     ecl_sum_vector_type * ecl_sum_vector = util_malloc( sizeof * ecl_sum_vector );
     UTIL_TYPE_ID_INIT( ecl_sum_vector , ECL_SUM_VECTOR_TYPE_ID);
     ecl_sum_vector->ecl_sum  = ecl_sum;
     ecl_sum_vector->node_index_list = int_vector_alloc(0,0);
     ecl_sum_vector->is_rate_list  = bool_vector_alloc(0,false);
     ecl_sum_vector->key_list = stringlist_alloc_new( );
+    if (add_keywords) {
+      const ecl_smspec_type * smspec = ecl_sum_get_smspec(ecl_sum);
+      for (int i=0; i < ecl_smspec_num_nodes(smspec); i++) {
+        const smspec_node_type * node = ecl_smspec_iget_node( smspec , i );
+        const char * key = smspec_node_get_gen_key1(node);
+
+        /*
+          The TIME keyword is special case handled to not be included; that is
+          to match the same special casing in the key matching function.
+        */
+        if (!util_string_equal(key, "TIME"))
+          ecl_sum_vector_add_node( ecl_sum_vector, node, key);
+      }
+    }
     return ecl_sum_vector;
 }
 
@@ -79,7 +102,7 @@ static void ecl_sum_vector_add_invalid_key(ecl_sum_vector_type * vector, const c
 */
 
 ecl_sum_vector_type * ecl_sum_vector_alloc_layout_copy(const ecl_sum_vector_type * src_vector, const ecl_sum_type * ecl_sum) {
-  ecl_sum_vector_type * new_vector = ecl_sum_vector_alloc(ecl_sum);
+  ecl_sum_vector_type * new_vector = ecl_sum_vector_alloc(ecl_sum, false);
   for (int i=0; i < stringlist_get_size(src_vector->key_list); i++) {
     const char * key = stringlist_iget(src_vector->key_list, i);
     if (ecl_sum_has_general_var(ecl_sum, key))
@@ -95,12 +118,7 @@ ecl_sum_vector_type * ecl_sum_vector_alloc_layout_copy(const ecl_sum_vector_type
 bool ecl_sum_vector_add_key( ecl_sum_vector_type * ecl_sum_vector, const char * key){
   if (ecl_sum_has_general_var( ecl_sum_vector->ecl_sum , key)) {
     const smspec_node_type * node = ecl_sum_get_general_var_node( ecl_sum_vector->ecl_sum , key );
-    int params_index = smspec_node_get_params_index( node );
-    bool is_rate_key = smspec_node_is_rate( node);
-
-    int_vector_append(ecl_sum_vector->node_index_list, params_index);
-    bool_vector_append(ecl_sum_vector->is_rate_list, is_rate_key);
-    stringlist_append_copy( ecl_sum_vector->key_list, key );
+    ecl_sum_vector_add_node(ecl_sum_vector, node, key);
     return true;
   } else
     return false;
@@ -114,12 +132,7 @@ void ecl_sum_vector_add_keys( ecl_sum_vector_type * ecl_sum_vector, const char *
     for(i = 0; i < num_keywords ;i++){
         const char * key = stringlist_iget(keylist, i);
         const smspec_node_type * node = ecl_sum_get_general_var_node( ecl_sum_vector->ecl_sum , key );
-        int params_index = smspec_node_get_params_index( node );
-        bool is_rate_key = smspec_node_is_rate( node);
-
-        int_vector_append(ecl_sum_vector->node_index_list, params_index);
-        bool_vector_append(ecl_sum_vector->is_rate_list, is_rate_key);
-        stringlist_append_copy( ecl_sum_vector->key_list, key );
+        ecl_sum_vector_add_node(ecl_sum_vector, node, key);
     }
     stringlist_free(keylist);
 }

--- a/lib/ecl/ecl_sum_vector.c
+++ b/lib/ecl/ecl_sum_vector.c
@@ -42,6 +42,7 @@ void ecl_sum_vector_free( ecl_sum_vector_type * ecl_sum_vector ){
     int_vector_free(ecl_sum_vector->node_index_list);
     bool_vector_free(ecl_sum_vector->is_rate_list);
     stringlist_free(ecl_sum_vector->key_list);
+    free(ecl_sum_vector);
 }
 
 

--- a/lib/ecl/tests/ecl_smspec.c
+++ b/lib/ecl/tests/ecl_smspec.c
@@ -20,7 +20,7 @@
 #include <stdbool.h>
 
 #include <ert/util/test_util.h>
-
+#include <ert/ecl/ecl_sum.h>
 #include <ert/ecl/ecl_smspec.h>
 
 void test_sort( ecl_smspec_type * smspec )
@@ -36,6 +36,18 @@ void test_sort( ecl_smspec_type * smspec )
 
     test_assert_int_equal( smspec_node_get_params_index( node1 ) , i - 1 );
   }
+}
+
+
+void test_copy(const ecl_smspec_type * smspec1) {
+  ecl_sum_type * ecl_sum2 = ecl_sum_alloc_writer("CASE", false, true, ":", 0, true, 100, 100, 100);
+  ecl_smspec_type * smspec2 = ecl_sum_get_smspec(ecl_sum2);
+  for (int i=0; i < ecl_smspec_num_nodes(smspec1); i++) {
+    const smspec_node_type * node = ecl_smspec_iget_node(smspec1, i);
+    ecl_sum_add_smspec_node(ecl_sum2, node);
+  }
+  test_assert_true( ecl_smspec_equal(smspec1, smspec2));
+  ecl_sum_free(ecl_sum2);
 }
 
 

--- a/lib/ecl/tests/ecl_sum_alloc_resampled_test.c
+++ b/lib/ecl/tests/ecl_sum_alloc_resampled_test.c
@@ -1,0 +1,95 @@
+
+#include <ert/util/test_util.h>
+
+#include <ert/ecl/ecl_sum.h>
+#include <ert/ecl/smspec_node.h>
+
+ecl_sum_type * test_alloc_ecl_sum() {
+  time_t start_time = util_make_date_utc( 1,1,2010 );
+  ecl_sum_type * ecl_sum = ecl_sum_alloc_writer( "/tmp/CASE" , false , true , ":" , start_time , true , 10 , 10 , 10 );
+  double sim_seconds = 0;
+  
+  int num_dates = 4;
+  int num_ministep = 1;
+  double ministep_length = 86400; // seconds in a day
+
+  smspec_node_type * node1 = ecl_sum_add_var( ecl_sum , "FOPT" , NULL   , 0   , "Barrels" , 99.0 );
+  smspec_node_type * node2 = ecl_sum_add_var( ecl_sum , "BPR"  , NULL   , 567 , "BARS"    , 0.0  );
+  smspec_node_type * node3 = ecl_sum_add_var( ecl_sum , "WWCT" , "OP-1" , 0   , "(1)"     , 0.0  );
+
+  for (int report_step = 0; report_step < num_dates; report_step++) {
+      {
+        ecl_sum_tstep_type * tstep = ecl_sum_add_tstep( ecl_sum , report_step + 1 , sim_seconds );
+        ecl_sum_tstep_set_from_node( tstep , node1 , report_step*2.0 );
+        ecl_sum_tstep_set_from_node( tstep , node2 , report_step*4.0 + 2.0 );
+        ecl_sum_tstep_set_from_node( tstep , node3 , report_step*6.0 + 4.0 );
+      }
+      sim_seconds += ministep_length * 3;
+    
+  }
+  return ecl_sum;
+}
+
+void test_correct_time_vector() {
+
+  ecl_sum_type * ecl_sum = test_alloc_ecl_sum();
+  time_t_vector_type * t = time_t_vector_alloc( 0 , 0 );
+  time_t_vector_append(t, util_make_date_utc( 2,1,2010 ));
+  time_t_vector_append(t, util_make_date_utc( 4,1,2010 ));
+  time_t_vector_append(t, util_make_date_utc( 6,1,2010 ));
+  time_t_vector_append(t, util_make_date_utc( 8,1,2010 ));
+  ecl_sum_type * ecl_sum_resampled = ecl_sum_alloc_resample("kk", ecl_sum, t);
+  test_assert_int_equal(  ecl_sum_get_report_time(ecl_sum_resampled, 2)  , util_make_date_utc( 6,1,2010 ));
+
+  const ecl_smspec_type * smspec_resampled = ecl_sum_get_smspec(ecl_sum_resampled);
+  const smspec_node_type * node1 = ecl_smspec_iget_node(smspec_resampled, 1);
+  const smspec_node_type * node2 = ecl_smspec_iget_node(smspec_resampled, 2);
+  const smspec_node_type * node3 = ecl_smspec_iget_node(smspec_resampled, 3);
+  test_assert_string_equal( "BPR" , smspec_node_get_keyword(node2) );
+  test_assert_string_equal( "BARS" , smspec_node_get_unit(node2) );  
+
+  test_assert_double_equal(3.33333, ecl_sum_get_from_sim_time( ecl_sum_resampled, util_make_date_utc( 6,1,2010 ), node1) );
+  test_assert_double_equal(3.33333, ecl_sum_get_from_sim_time( ecl_sum_resampled, util_make_date_utc( 2,1,2010 ), node2) );
+  test_assert_double_equal(10.0000, ecl_sum_get_from_sim_time( ecl_sum_resampled, util_make_date_utc( 4,1,2010 ), node3) );
+ 
+
+  ecl_sum_free(ecl_sum_resampled);
+  ecl_sum_free(ecl_sum); 
+}
+
+void test_time_before() {
+  ecl_sum_type * ecl_sum = test_alloc_ecl_sum();
+  time_t_vector_type * t = time_t_vector_alloc( 0 , 0 );
+  time_t_vector_append(t, util_make_date_utc( 1,1,2009 ));
+  test_assert_NULL( ecl_sum_alloc_resample("kk", ecl_sum, t) );
+  ecl_sum_free(ecl_sum);
+}
+
+void test_time_after() {
+  ecl_sum_type * ecl_sum = test_alloc_ecl_sum();
+  time_t_vector_type * t = time_t_vector_alloc( 0 , 0 );
+  time_t_vector_append(t, util_make_date_utc( 1,1,2010 ));
+  time_t_vector_append(t, util_make_date_utc( 11,1,2010 ));
+  test_assert_NULL( ecl_sum_alloc_resample("kk", ecl_sum, t) );
+  ecl_sum_free(ecl_sum);
+}
+
+void test_not_sorted() {
+  ecl_sum_type * ecl_sum = test_alloc_ecl_sum();
+  time_t_vector_type * t = time_t_vector_alloc( 0 , 0 );
+  time_t_vector_append(t, util_make_date_utc( 1,1,2010 ));
+  time_t_vector_append(t, util_make_date_utc( 3,1,2010 ));
+  time_t_vector_append(t, util_make_date_utc( 2,1,2010 ));
+  test_assert_NULL( ecl_sum_alloc_resample("kk", ecl_sum, t) );
+  ecl_sum_free(ecl_sum);
+}
+
+
+int main() {
+  test_correct_time_vector();
+  test_time_before();
+  test_time_after();
+  test_not_sorted();
+  return 0;
+}
+

--- a/lib/ecl/tests/ecl_sum_alloc_resampled_test.c
+++ b/lib/ecl/tests/ecl_sum_alloc_resampled_test.c
@@ -10,7 +10,6 @@ ecl_sum_type * test_alloc_ecl_sum() {
   double sim_seconds = 0;
   
   int num_dates = 4;
-  int num_ministep = 1;
   double ministep_length = 86400; // seconds in a day
 
   smspec_node_type * node1 = ecl_sum_add_var( ecl_sum , "FOPT" , NULL   , 0   , "Barrels" , 99.0 );
@@ -54,6 +53,7 @@ void test_correct_time_vector() {
  
 
   ecl_sum_free(ecl_sum_resampled);
+  time_t_vector_free(t);
   ecl_sum_free(ecl_sum); 
 }
 
@@ -62,6 +62,7 @@ void test_time_before() {
   time_t_vector_type * t = time_t_vector_alloc( 0 , 0 );
   time_t_vector_append(t, util_make_date_utc( 1,1,2009 ));
   test_assert_NULL( ecl_sum_alloc_resample("kk", ecl_sum, t) );
+  time_t_vector_free(t);
   ecl_sum_free(ecl_sum);
 }
 
@@ -71,6 +72,7 @@ void test_time_after() {
   time_t_vector_append(t, util_make_date_utc( 1,1,2010 ));
   time_t_vector_append(t, util_make_date_utc( 11,1,2010 ));
   test_assert_NULL( ecl_sum_alloc_resample("kk", ecl_sum, t) );
+  time_t_vector_free(t);
   ecl_sum_free(ecl_sum);
 }
 
@@ -81,6 +83,7 @@ void test_not_sorted() {
   time_t_vector_append(t, util_make_date_utc( 3,1,2010 ));
   time_t_vector_append(t, util_make_date_utc( 2,1,2010 ));
   test_assert_NULL( ecl_sum_alloc_resample("kk", ecl_sum, t) );
+  time_t_vector_free(t);
   ecl_sum_free(ecl_sum);
 }
 

--- a/lib/ecl/tests/ecl_sum_test.c
+++ b/lib/ecl/tests/ecl_sum_test.c
@@ -63,7 +63,7 @@ void test_is_oil_producer( const ecl_sum_type * ecl_sum) {
 
 int main( int argc , char ** argv) {
   const char * case1 = argv[1];
-
+  
   ecl_sum_type * ecl_sum1 = ecl_sum_fread_alloc_case( case1 , ":");
 
   test_assert_true( ecl_sum_is_instance( ecl_sum1 ));

--- a/lib/include/ert/ecl/ecl_smspec.h
+++ b/lib/include/ert/ecl/ecl_smspec.h
@@ -54,6 +54,7 @@ typedef struct ecl_smspec_struct ecl_smspec_type;
   bool                ecl_smspec_needs_wgname( ecl_smspec_var_type var_type );
   const char        * ecl_smspec_get_var_type_name( ecl_smspec_var_type var_type );
   ecl_smspec_var_type ecl_smspec_identify_var_type(const char * var);
+  ecl_smspec_type * ecl_smspec_alloc_empty(bool write_mode , const char * key_join_string);
   ecl_smspec_type   * ecl_smspec_alloc_writer( const char * key_join_string , const char * restart_case, time_t sim_start , bool time_in_days , int nx , int ny , int nz);
   void                ecl_smspec_fwrite( const ecl_smspec_type * smspec , const char * ecl_case , bool fmt_file );
 

--- a/lib/include/ert/ecl/ecl_sum.h
+++ b/lib/include/ert/ecl/ecl_sum.h
@@ -94,6 +94,7 @@ typedef struct ecl_sum_struct       ecl_sum_type;
   ecl_sum_type   * ecl_sum_fread_alloc(const char * , const stringlist_type * data_files, const char * key_join_string, bool include_restart);
   ecl_sum_type   * ecl_sum_fread_alloc_case(const char *  , const char * key_join_string);
   ecl_sum_type   * ecl_sum_fread_alloc_case__(const char *  , const char * key_join_string , bool include_restart);
+  ecl_sum_type   * ecl_sum_alloc_resample(const char * ecl_case, const ecl_sum_type * ecl_sum, const time_t_vector_type * times);
   bool             ecl_sum_case_exists( const char * input_file );
 
   /* Accessor functions : */

--- a/lib/include/ert/ecl/ecl_sum.h
+++ b/lib/include/ert/ecl/ecl_sum.h
@@ -221,6 +221,7 @@ typedef struct ecl_sum_struct       ecl_sum_type;
   void                  ecl_sum_set_case( ecl_sum_type * ecl_sum , const char * ecl_case);
   void                  ecl_sum_fwrite( const ecl_sum_type * ecl_sum );
   void                  ecl_sum_fwrite_smspec( const ecl_sum_type * ecl_sum );
+  smspec_node_type    * ecl_sum_add_smspec_node(ecl_sum_type * ecl_sum, const smspec_node_type * node);
   smspec_node_type    * ecl_sum_add_var(ecl_sum_type * ecl_sum ,
                                         const char * keyword ,
                                         const char * wgname ,

--- a/lib/include/ert/ecl/ecl_sum_vector.h
+++ b/lib/include/ert/ecl/ecl_sum_vector.h
@@ -30,7 +30,7 @@ extern "C" {
 typedef struct ecl_sum_vector_struct ecl_sum_vector_type;
 
   void ecl_sum_vector_free( ecl_sum_vector_type * keylist );
-  ecl_sum_vector_type * ecl_sum_vector_alloc(const ecl_sum_type * ecl_sum);
+  ecl_sum_vector_type * ecl_sum_vector_alloc(const ecl_sum_type * ecl_sum, bool add_keywords);
 
   bool ecl_sum_vector_add_key( ecl_sum_vector_type * keylist, const char * key);
   void ecl_sum_vector_add_keys( ecl_sum_vector_type * keylist, const char * pattern);

--- a/python/ecl/ecl/ecl_sum.py
+++ b/python/ecl/ecl/ecl_sum.py
@@ -1278,6 +1278,10 @@ class EclSum(BaseCClass):
 
 
 
+    def resample(self, new_case, time_points):
+        #return self._resample(new_case, time_points)
+        return None
+
 
 import ecl.ecl.ecl_sum_keyword_vector
 EclSum._dump_csv_line = EclPrototype("void  ecl_sum_fwrite_interp_csv_line(ecl_sum, time_t, ecl_sum_vector, FILE)", bind=False)

--- a/python/ecl/ecl/ecl_sum.py
+++ b/python/ecl/ecl/ecl_sum.py
@@ -89,6 +89,7 @@ class EclSum(BaseCClass):
     _fread_alloc_case              = EclPrototype("void*     ecl_sum_fread_alloc_case__(char*, char*, bool)", bind=False)
     _fread_alloc                   = EclPrototype("void*     ecl_sum_fread_alloc(char*, stringlist, char*, bool)", bind=False)
     _create_restart_writer         = EclPrototype("ecl_sum_obj  ecl_sum_alloc_restart_writer(char*, char*, bool, bool, char*, time_t, bool, int, int, int)", bind = False)
+    _resample                      = EclPrototype("ecl_sum_obj  ecl_sum_alloc_resample(char*, ecl_sum, time_t_vector)", bind = False)
     _iiget                         = EclPrototype("double   ecl_sum_iget(ecl_sum, int, int)")
     _free                          = EclPrototype("void     ecl_sum_free(ecl_sum)")
     _data_length                   = EclPrototype("int      ecl_sum_get_data_length(ecl_sum)")
@@ -1278,9 +1279,8 @@ class EclSum(BaseCClass):
 
 
 
-    def resample(self, new_case, time_points):
-        #return self._resample(new_case, time_points)
-        return None
+    def resample(self, new_case_name, ecl_sum, time_points):
+        return self._resample(new_case_name, ecl_sum, time_points, True)
 
 
 import ecl.ecl.ecl_sum_keyword_vector

--- a/python/ecl/ecl/ecl_sum_keyword_vector.py
+++ b/python/ecl/ecl/ecl_sum_keyword_vector.py
@@ -31,7 +31,7 @@ from ecl import EclPrototype
 
 class EclSumKeyWordVector(BaseCClass):
     TYPE_NAME       = "ecl_sum_vector"
-    _alloc          = EclPrototype("void* ecl_sum_vector_alloc(ecl_sum)", bind=False)
+    _alloc          = EclPrototype("void* ecl_sum_vector_alloc(ecl_sum, bool)", bind=False)
     _alloc_copy     = EclPrototype("ecl_sum_vector_obj ecl_sum_vector_alloc_layout_copy(ecl_sum_vector, ecl_sum)")
     _free           = EclPrototype("void ecl_sum_vector_free(ecl_sum_vector)")
     _add            = EclPrototype("bool ecl_sum_vector_add_key(ecl_sum_vector,  char*)")
@@ -39,8 +39,8 @@ class EclSumKeyWordVector(BaseCClass):
     _get_size       = EclPrototype("int ecl_sum_vector_get_size(ecl_sum_vector)")
     _iget_key       = EclPrototype("char* ecl_sum_vector_iget_key(ecl_sum_vector, int)")
 
-    def __init__(self, ecl_sum):
-        c_pointer = self._alloc(ecl_sum)
+    def __init__(self, ecl_sum, add_keywords = False):
+        c_pointer = self._alloc(ecl_sum, add_keywords)
         super(EclSumKeyWordVector, self).__init__(c_pointer)
 
     def __getitem__(self, index):

--- a/python/tests/CMakeLists.txt
+++ b/python/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_subdirectory(util_tests)
 add_subdirectory(ecl_tests)
 add_subdirectory(well_tests)
 add_subdirectory(global_tests)
+add_subdirectory(bin_tests)
 
 if (INSTALL_ERT_LEGACY)
    add_subdirectory(legacy_tests)

--- a/python/tests/bin_tests/CMakeLists.txt
+++ b/python/tests/bin_tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(TEST_SOURCES
+    __init__.py
+    test_summary_resample.py
+)
+
+add_python_package("python.tests.bin_tests"  ${PYTHON_INSTALL_PREFIX}/tests/bin_tests "${TEST_SOURCES}" False)
+
+addPythonTest(tests.bin_tests.test_summary_resample.SummaryResampleTest)

--- a/python/tests/bin_tests/test_summary_resample.py
+++ b/python/tests/bin_tests/test_summary_resample.py
@@ -49,4 +49,4 @@ class SummaryResampleTest(EclTest):
 
             # Should run OK:
             subprocess.check_call([self.script, "CSV", "OUTPUT"])
-            #output_case = EclSum("OUTPUT")
+            output_case = EclSum("OUTPUT")

--- a/python/tests/bin_tests/test_summary_resample.py
+++ b/python/tests/bin_tests/test_summary_resample.py
@@ -1,0 +1,52 @@
+#  Copyright (C) 2018  Statoil ASA, Norway.
+#
+#  This file is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
+
+import os.path
+import subprocess
+from subprocess import CalledProcessError as CallError
+
+from ecl.ecl import Cell, EclGrid, EclSum
+from tests import EclTest
+from ecl.test.ecl_mock import createEclSum
+from ecl.test import TestAreaContext
+
+
+class SummaryResampleTest(EclTest):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.script = os.path.join(cls.SOURCE_ROOT, "bin/summary_resample")
+        cls.case = createEclSum("CSV", [("FOPT", None, 0), ("FOPR", None, 0)])
+
+    def test_run_default(self):
+        with TestAreaContext(""):
+            self.case.fwrite()
+
+            # Too few arguments
+            with self.assertRaises(CallError):
+                subprocess.check_call([self.script])
+
+            # Too few arguments
+            with self.assertRaises(CallError):
+                subprocess.check_call([self.script, "CSV"])
+
+            # Invalid first arguments
+            with self.assertRaises(CallError):
+                subprocess.check_call([self.script, "DOES_NOT_EXIST", "OUTPUT"])
+
+            # Should run OK:
+            subprocess.check_call([self.script, "CSV", "OUTPUT"])
+            #output_case = EclSum("OUTPUT")

--- a/python/tests/ecl_tests/test_sum.py
+++ b/python/tests/ecl_tests/test_sum.py
@@ -38,6 +38,16 @@ def fgpt(days):
     else:
         return 100 - days
 
+def create_case():
+    length = 100
+    return createEclSum("CSV" , [("FOPT", None , 0) , ("FOPR" , None , 0), ("FGPT" , None , 0)],
+                        sim_length_days = length,
+                        num_report_step = 10,
+                        num_mini_step = 10,
+                        func_table = {"FOPT" : fopt,
+                                      "FOPR" : fopr ,
+                                      "FGPT" : fgpt })
+
 class SumTest(EclTest):
 
 
@@ -70,7 +80,7 @@ class SumTest(EclTest):
         case = createEclSum("CSV" , [("FOPT", None , 0) ,
                                      ("FOPR" , None , 0),
                                      ("AARQ" , None , 10),
-                                     ("RGPT" , None  ,1)])
+                                    ("RGPT" , None  ,1)])
 
         node1 = case.smspec_node( "FOPT" )
         self.assertEqual( node1.varType( ) , EclSumVarType.ECL_SMSPEC_FIELD_VAR )
@@ -351,3 +361,15 @@ class SumTest(EclTest):
             self.assertEqual(d1[0],d2[0])
             self.assertEqual(d1[2],d2[2])
             self.assertEqual(d2[1],"")
+
+
+
+    def test_vector_select_all(self):
+        case = create_case()
+        ecl_sum_vector = EclSumKeyWordVector(case, True)
+        keys = case.keys()
+        self.assertEqual( len(keys), len(ecl_sum_vector))
+        for key in keys:
+            self.assertIn(key, ecl_sum_vector)
+
+


### PR DESCRIPTION
**Task**
To ensure that the different realisations generated by Nexus can be loaded in ERT they must have the same time axis. To facilitate we should create a ecl_sum function:

ecl_sum_type * ecl_sum_alloc_resample(const char * ecl_case, const ecl_sum_type * ecl_sum, const time_t_vector_type * times), 

which should allocate a new summary case resampled to the times in the time_t_vector_type input vector.


**Approach**
Function added to ecl_sum. 


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
