### PR TITLE
Summary restart load fix

### DIFF
--- a/lib/ecl/ecl_smspec.c
+++ b/lib/ecl/ecl_smspec.c
@@ -1017,9 +1017,13 @@ static void ecl_smspec_load_restart( ecl_smspec_type * ecl_smspec , const ecl_fi
       util_alloc_file_components( ecl_smspec->header_file , &path , NULL , NULL );
       smspec_header = ecl_util_alloc_exfilename( path , restart_base , ECL_SUMMARY_HEADER_FILE , ecl_smspec->formatted , 0);
       if (!util_same_file(smspec_header , ecl_smspec->header_file))    /* Restart from the current case is ignored. */ {
-        char * tmp_path = util_alloc_filename( path , restart_base , NULL );
-        ecl_smspec->restart_case = util_alloc_abs_path(tmp_path);
-        free( tmp_path );
+        if (util_is_abs_path(restart_base))
+          ecl_smspec->restart_case = util_alloc_string_copy( restart_base );
+        else {
+          char * tmp_path = util_alloc_filename( path , restart_base , NULL );
+          ecl_smspec->restart_case = util_alloc_abs_path(tmp_path);
+          free( tmp_path );
+        }
       }
 
       util_safe_free( path );

--- a/lib/ecl/ecl_smspec.c
+++ b/lib/ecl/ecl_smspec.c
@@ -373,14 +373,14 @@ static void ecl_smspec_fortio_fwrite( const ecl_smspec_type * smspec , fortio_ty
            ecl_kw_iset_string8( restart_kw , i , "");
 
     if (smspec->restart_case != NULL) {
-       int restart_case_len = strlen(smspec->restart_case);                           
-     
+       int restart_case_len = strlen(smspec->restart_case);
+
        int offset = 0;
        for (int i = 0; i < SUMMARY_RESTART_SIZE ; i++) {
           if (offset < restart_case_len)
               ecl_kw_iset_string8( restart_kw , i , &smspec->restart_case[ offset ]);
           offset += ECL_STRING8_LENGTH;
-       } 
+       }
     }
 
     ecl_kw_fwrite( restart_kw , fortio );
@@ -503,12 +503,14 @@ void ecl_smspec_fwrite( const ecl_smspec_type * smspec , const char * ecl_case ,
 
 ecl_smspec_type * ecl_smspec_alloc_writer( const char * key_join_string , const char * restart_case, time_t sim_start , bool time_in_days , int nx , int ny , int nz) {
   ecl_smspec_type * ecl_smspec = ecl_smspec_alloc_empty( true , key_join_string );
-  
-  if (restart_case != NULL) {
-     if (strlen(restart_case) <= (SUMMARY_RESTART_SIZE * ECL_STRING8_LENGTH))
-        ecl_smspec->restart_case = util_alloc_string_copy( restart_case );
-     else 
-        return NULL;
+
+  /*
+    Only a total of 9 * 8 characters is set aside for the restart keyword, if
+    the supplied restart case is longer than that we silently ignore it.
+  */
+  if (restart_case) {
+    if (strlen(restart_case) <= (SUMMARY_RESTART_SIZE * ECL_STRING8_LENGTH))
+      ecl_smspec->restart_case = util_alloc_string_copy( restart_case );
   }
   ecl_smspec->grid_dims[0] = nx;
   ecl_smspec->grid_dims[1] = ny;

--- a/lib/ecl/ecl_sum.c
+++ b/lib/ecl/ecl_sum.c
@@ -1126,6 +1126,10 @@ void ecl_sum_export_csv(const ecl_sum_type * ecl_sum , const char * filename  , 
 }
 
 
+const char * ecl_sum_get_restart_case(const ecl_sum_type * ecl_sum) {
+  return ecl_smspec_get_restart_case(ecl_sum->smspec);
+}
+
 
 const char * ecl_sum_get_case(const ecl_sum_type * ecl_sum) {
   return ecl_sum->ecl_case;

--- a/lib/ecl/tests/ecl_sum_writer.c
+++ b/lib/ecl/tests/ecl_sum_writer.c
@@ -61,7 +61,7 @@ double write_summary( const char * name , time_t start_time , int nx , int ny , 
 
 int write_restart_summary(const char * name, const char * restart_name , int start_report_step, double sim_seconds, time_t start_time , int nx , int ny , int nz , int num_dates, int num_ministep, double ministep_length) {
   ecl_sum_type * ecl_sum = ecl_sum_alloc_restart_writer( name , restart_name, false , true , ":" , start_time , true , nx , ny , nz );
- 
+
 
   smspec_node_type * node1 = ecl_sum_add_var( ecl_sum , "FOPT" , NULL   , 0   , "Barrels" , 99.0 );
   smspec_node_type * node2 = ecl_sum_add_var( ecl_sum , "BPR"  , NULL   , 567 , "BARS"    , 0.0  );
@@ -70,8 +70,6 @@ int write_restart_summary(const char * name, const char * restart_name , int sta
   int num_report_steps = start_report_step + num_dates;
   for (int report_step = start_report_step; report_step < num_report_steps; report_step++) {
     for (int step = 0; step < num_ministep; step++) {
-      
-
       {
         ecl_sum_tstep_type * tstep = ecl_sum_add_tstep( ecl_sum , report_step + 1 , sim_seconds );
         ecl_sum_tstep_set_from_node( tstep , node1 , sim_seconds);
@@ -147,7 +145,7 @@ void test_ecl_sum_alloc_restart_writer() {
       int num_ministep = 10;
       double ministep_length = 36000; // Seconds
 
-      int sim_seconds = write_summary( name1 , start_time , nx , ny , nz , num_dates , num_ministep , ministep_length);  
+      int sim_seconds = write_summary( name1 , start_time , nx , ny , nz , num_dates , num_ministep , ministep_length);
       sim_seconds = write_restart_summary( name2 , name1 , num_dates, sim_seconds, start_time , nx , ny , nz , num_dates , num_ministep , ministep_length);
 
       ecl_sum_type * case1 = ecl_sum_fread_alloc_case( name1 , ":" );
@@ -157,20 +155,20 @@ void test_ecl_sum_alloc_restart_writer() {
       test_assert_true( ecl_sum_has_key( case2 , "FOPT" ));
 
       ecl_file_type * restart_file = ecl_file_open( "CASE2.SMSPEC" , 0 );
-      ecl_file_view_type * view_file = ecl_file_get_global_view( restart_file );    
+      ecl_file_view_type * view_file = ecl_file_get_global_view( restart_file );
       test_assert_true( ecl_file_view_has_kw(view_file, RESTART_KW));
       ecl_kw_type * kw = ecl_file_view_iget_kw(view_file, 0);
       test_assert_int_equal(8, ecl_kw_get_size(kw));
       test_assert_string_equal( "CASE1   ", ecl_kw_iget_ptr( kw , 0 ) );
       test_assert_string_equal( "        ", ecl_kw_iget_ptr( kw , 1 ) );
 
-      for (int time_index=0; time_index < ecl_sum_get_data_length( case1 ); time_index++) 
+      for (int time_index=0; time_index < ecl_sum_get_data_length( case1 ); time_index++)
          test_assert_double_equal(  ecl_sum_get_general_var( case1 , time_index , "FOPT"), ecl_sum_get_general_var( case2 , time_index , "FOPT"));
 
       ecl_sum_free(case2);
       ecl_sum_free(case1);
       ecl_file_close(restart_file);
-       
+
    }
    test_work_area_free( work_area );
 }
@@ -190,9 +188,9 @@ void test_long_restart_names() {
        ecl_sum_type * ecl_sum = ecl_sum_alloc_restart_writer( name , restart_case , false , true , ":" , start_time , true , 3, 3, 3);
        ecl_sum_fwrite( ecl_sum );
        ecl_sum_free(ecl_sum);
-             
+
        ecl_file_type * smspec_file = ecl_file_open( "THE_CASE.SMSPEC" , 0 );
-       ecl_file_view_type * view_file = ecl_file_get_global_view( smspec_file );    
+       ecl_file_view_type * view_file = ecl_file_get_global_view( smspec_file );
        test_assert_true( ecl_file_view_has_kw(view_file, RESTART_KW));
        ecl_kw_type * kw = ecl_file_view_iget_kw(view_file, 0);
        test_assert_int_equal(8, ecl_kw_get_size(kw));
@@ -201,12 +199,18 @@ void test_long_restart_names() {
          char s[9]; sprintf(s, "WWWWGGG%d", n);
          test_assert_string_equal(s, ecl_kw_iget_char_ptr(kw, n) );
        }
-       
-       test_assert_NULL( ecl_smspec_alloc_writer( ":" , "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ", start_time, true, 3, 3 ,3) );
+       {
+         ecl_smspec_type * smspec = ecl_smspec_alloc_writer( ":" , "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ", start_time, true, 3, 3 ,3);
+         /*
+           Restart case is too long - it is ignored.
+         */
+         test_assert_NULL( ecl_smspec_get_restart_case( smspec));
+         ecl_smspec_free( smspec);
+       }
    }
 
    test_work_area_free( work_area );
-  
+
 }
 
 int main( int argc , char ** argv) {

--- a/lib/include/ert/ecl/ecl_sum.h
+++ b/lib/include/ert/ecl/ecl_sum.h
@@ -171,6 +171,7 @@ typedef struct ecl_sum_struct       ecl_sum_type;
   const char * ecl_sum_get_base(const ecl_sum_type * ecl_sum );
   const char * ecl_sum_get_path(const ecl_sum_type * ecl_sum );
   const char * ecl_sum_get_abs_path(const ecl_sum_type * ecl_sum );
+  const char * ecl_sum_get_restart_case(const ecl_sum_type * ecl_sum);
   const char * ecl_sum_get_case(const ecl_sum_type * );
   bool         ecl_sum_same_case( const ecl_sum_type * ecl_sum , const char * input_file );
 

--- a/python/ecl/summary/ecl_sum.py
+++ b/python/ecl/summary/ecl_sum.py
@@ -120,6 +120,7 @@ class EclSum(BaseCClass):
     _get_first_day                 = EclPrototype("double   ecl_sum_get_first_day(ecl_sum)")
     _get_data_start                = EclPrototype("time_t   ecl_sum_get_data_start(ecl_sum)")
     _get_unit                      = EclPrototype("char*    ecl_sum_get_unit(ecl_sum, char*)")
+    _get_restart_case              = EclPrototype("char*    ecl_sum_get_restart_case(ecl_sum)")
     _get_simcase                   = EclPrototype("char*    ecl_sum_get_case(ecl_sum)")
     _get_base                      = EclPrototype("char*    ecl_sum_get_base(ecl_sum)")
     _get_path                      = EclPrototype("char*    ecl_sum_get_path(ecl_sum)")
@@ -765,6 +766,11 @@ class EclSum(BaseCClass):
         Will return the case name of the current instance - optionally including path.
         """
         return self._get_simcase()
+
+
+    @property
+    def restart_case(self):
+        return self._get_restart_case()
 
 
     @property

--- a/python/ecl/util/test/ecl_mock/ecl_sum_mock.py
+++ b/python/ecl/util/test/ecl_mock/ecl_sum_mock.py
@@ -6,8 +6,8 @@ def mock_func(ecl_sum , key , days):
     return days * 10
 
 
-def createEclSum( case , keys , start = datetime.date(2010 , 1, 1) , sim_length_days = 5 * 365 , num_report_step = 5, num_mini_step = 10, dims = (20,10,5) , func_table = {}):
-    ecl_sum = EclSum.writer(case , start , dims[0] , dims[1] , dims[2])
+def createEclSum( case , keys , start = datetime.date(2010 , 1, 1) , sim_length_days = 5 * 365 , num_report_step = 5, num_mini_step = 10, dims = (20,10,5) , func_table = {}, restart_case = None):
+    ecl_sum = EclSum.restart_writer(case , restart_case, start , dims[0] , dims[1] , dims[2])
     var_list = []
     for (kw,wgname,num) in keys:
         var_list.append( ecl_sum.addVariable( kw , wgname = wgname , num = num) )

--- a/python/ecl/util/test/ecl_mock/ecl_sum_mock.py
+++ b/python/ecl/util/test/ecl_mock/ecl_sum_mock.py
@@ -6,17 +6,33 @@ def mock_func(ecl_sum , key , days):
     return days * 10
 
 
-def createEclSum( case , keys , start = datetime.date(2010 , 1, 1) , sim_length_days = 5 * 365 , num_report_step = 5, num_mini_step = 10, dims = (20,10,5) , func_table = {}, restart_case = None):
-    ecl_sum = EclSum.restart_writer(case , restart_case, start , dims[0] , dims[1] , dims[2])
+def createEclSum( case,
+                  keys,
+                  sim_start = datetime.date(2010 , 1, 1),
+                  data_start = None,
+                  sim_length_days = 5 * 365,
+                  num_report_step = 5,
+                  num_mini_step = 10,
+                  dims = (20,10,5) ,
+                  func_table = {},
+                  restart_case = None):
+
+    ecl_sum = EclSum.restart_writer(case , restart_case, sim_start , dims[0] , dims[1] , dims[2])
     var_list = []
     for (kw,wgname,num) in keys:
         var_list.append( ecl_sum.addVariable( kw , wgname = wgname , num = num) )
+
+    if data_start is None:
+        time_offset = 0
+    else:
+        dt = data_start - sim_start
+        time_offset = dt.total_seconds() / 86400.0
 
     report_step_length = sim_length_days / num_report_step
     mini_step_length = report_step_length / num_mini_step
     for report_step in range(num_report_step):
         for mini_step in range(num_mini_step):
-            days = report_step * report_step_length + mini_step * mini_step_length
+            days = time_offset + report_step * report_step_length + mini_step * mini_step_length
             t_step = ecl_sum.addTStep( report_step + 1 , sim_days = days )
 
             for var in var_list:

--- a/python/tests/ecl_tests/test_sum.py
+++ b/python/tests/ecl_tests/test_sum.py
@@ -154,14 +154,7 @@ class SumTest(EclTest):
 
     def test_solve(self):
         length = 100
-        case = createEclSum("CSV" , [("FOPT", None , 0) , ("FOPR" , None , 0), ("FGPT" , None , 0)],
-                            sim_length_days = length,
-                            num_report_step = 10,
-                            num_mini_step = 10,
-                            func_table = {"FOPT" : fopt,
-                                          "FOPR" : fopr ,
-                                          "FGPT" : fgpt })
-
+        case = create_case()
         self.assert_solve( case )
 
     def assert_solve(self, case):
@@ -212,15 +205,7 @@ class SumTest(EclTest):
         scalar = 0.78
         addend = 2.718281828459045
 
-        # setup
-        length = 100
-        case = createEclSum("CSV" , [("FOPT", None , 0) , ("FOPR" , None , 0), ("FGPT" , None , 0)],
-                            sim_length_days = length,
-                            num_report_step = 10,
-                            num_mini_step = 10,
-                            func_table = {"FOPT" : fopt,
-                                          "FOPR" : fopr ,
-                                          "FGPT" : fgpt })
+        case = create_case()
         with self.assertRaises( KeyError ):
             case.scaleVector( "MISSING:KEY" , scalar)
             case.shiftVector( "MISSING:KEY" , addend)
@@ -245,15 +230,7 @@ class SumTest(EclTest):
 
 
     def test_different_names(self):
-        length = 100
-        case = createEclSum("CSV" , [("FOPT", None , 0) , ("FOPR" , None , 0), ("FGPT" , None , 0)],
-                            sim_length_days = length,
-                            num_report_step = 10,
-                            num_mini_step = 10,
-                            func_table = {"FOPT" : fopt,
-                                          "FOPR" : fopr ,
-                                          "FGPT" : fgpt })
-
+        case = create_case()
         with TestAreaContext("sum_different"):
             case.fwrite( )
             shutil.move("CSV.SMSPEC" , "CSVX.SMSPEC")
@@ -267,14 +244,7 @@ class SumTest(EclTest):
             self.assert_solve( case2 )
 
     def test_invalid(self):
-        case = createEclSum("CSV" , [("FOPT", None , 0) , ("FOPR" , None , 0), ("FGPT" , None , 0)],
-                            sim_length_days = 100,
-                            num_report_step = 10,
-                            num_mini_step = 10,
-                            func_table = {"FOPT" : fopt,
-                                          "FOPR" : fopr ,
-                                          "FGPT" : fgpt })
-
+        case = create_case()
         with TestAreaContext("sum_invalid"):
             case.fwrite( )
             with open("CASE.txt", "w") as f:
@@ -301,14 +271,7 @@ class SumTest(EclTest):
 
 
     def test_kw_vector(self):
-        case1 = createEclSum("CSV" , [("FOPT", None , 0) , ("FOPR" , None , 0), ("FGPT" , None , 0)],
-                             sim_length_days = 100,
-                             num_report_step = 10,
-                             num_mini_step = 10,
-                             func_table = {"FOPT" : fopt,
-                                           "FOPR" : fopr ,
-                                           "FGPT" : fgpt })
-
+        case1 = create_case()
         case2 = createEclSum("CSV" , [("FOPR", None , 0) , ("FOPT" , None , 0), ("FWPT" , None , 0)],
                              sim_length_days = 100,
                              num_report_step = 10,

--- a/python/tests/ecl_tests/test_sum.py
+++ b/python/tests/ecl_tests/test_sum.py
@@ -405,9 +405,29 @@ class SumTest(EclTest):
            create_prediction(history, pred_path)
 
            pred = EclSum(os.path.join(pred_path, "PREDICTION"))
-           length = pred.sim_length
-           pred_times = pred.alloc_time_vector(False)
-           hist_times = history.alloc_time_vector(False)
+           # The restart case has a maximum length of 72 characters, depending
+           # on the path used for $TMP and so on we do not really know here if
+           # the restart_case has been set or not.
+           if pred.restart_case:
+               self.assertEqual(pred.restart_case, os.path.join(os.getcwd(), history.case))
 
-           for index in range(len(hist_times)):
-               self.assertEqual(hist_times[index], pred_times[index])
+               length = pred.sim_length
+               pred_times = pred.alloc_time_vector(False)
+               hist_times = history.alloc_time_vector(False)
+
+               for index in range(len(hist_times)):
+                   self.assertEqual(hist_times[index], pred_times[index])
+
+
+
+
+    def test_restart_too_long_history_path(self):
+        with TestAreaContext("restart_test_too_fucking_long_path_for_the_eclipse_restart_keyword_1234567890123456789012345678901234567890"):
+            history =  create_case(case = "HISTORY")
+            history.fwrite()
+
+            pred_path = "prediction"
+            create_prediction(history, pred_path)
+
+            pred = EclSum(os.path.join(pred_path, "PREDICTION"))
+            self.assertIsNone(pred.restart_case)

--- a/python/tests/ecl_tests/test_sum.py
+++ b/python/tests/ecl_tests/test_sum.py
@@ -14,11 +14,13 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
+import os.path
 import os
 import inspect
 import datetime
 import csv
 import shutil
+from contextlib import contextmanager
 from unittest import skipIf, skipUnless, skipIf
 
 from ecl import EclDataType
@@ -27,6 +29,25 @@ from ecl.summary import EclSum, EclSumVarType, EclSumKeyWordVector
 from ecl.util.test import TestAreaContext
 from tests import EclTest
 from ecl.util.test.ecl_mock import createEclSum
+
+
+@contextmanager
+def pushd(path):
+    if not os.path.isdir(path):
+        os.mkdir(path)
+    cwd = os.getcwd()
+    os.chdir(path)
+
+    yield
+
+    os.chdir(cwd)
+
+def create_prediction(history, pred_path):
+    restart_case = os.path.join( os.getcwd(), history.base)
+    with pushd(pred_path):
+        prediction = create_case( case = "PREDICTION", restart_case = restart_case, data_start = history.end_date)
+        prediction.fwrite()
+
 
 def fopr(days):
     return days
@@ -40,15 +61,17 @@ def fgpt(days):
     else:
         return 100 - days
 
-def create_case():
+def create_case(case = "CSV", restart_case = None, data_start = None):
     length = 100
-    return createEclSum("CSV" , [("FOPT", None , 0) , ("FOPR" , None , 0), ("FGPT" , None , 0)],
+    return createEclSum(case , [("FOPT", None , 0) , ("FOPR" , None , 0), ("FGPT" , None , 0)],
                         sim_length_days = length,
                         num_report_step = 10,
                         num_mini_step = 10,
+                        data_start = data_start,
                         func_table = {"FOPT" : fopt,
                                       "FOPR" : fopr ,
-                                      "FGPT" : fgpt })
+                                      "FGPT" : fgpt },
+                        restart_case = restart_case)
 
 class SumTest(EclTest):
 
@@ -356,3 +379,35 @@ class SumTest(EclTest):
         time_vector_resample = case2.alloc_time_vector(False)
         first_diff = time_vector_resample.first_neq( time_vector)
         self.assertEqual( time_vector_resample, time_vector)
+
+
+
+    # The purpose of this test is to reproduce a slightly contrived error situation.
+    #
+    # 1. A history simulation is created and stored somewhere in the
+    #    filesystem.
+    #
+    # 2. We create a prediction, which has 'RESTART' reference to
+    #    the history case.
+    #
+    # 3. The prediction case is loaded from disk, with a cwd different from the
+    #    location of the predition case.
+    #
+    # This configuration would previously lead to a bug in the path used to
+    # resolve the history case, and the history would silently be ignored.
+
+    def test_restart_abs_path(self):
+        with TestAreaContext("restart_test"):
+           history =  create_case(case = "HISTORY")
+           history.fwrite()
+
+           pred_path = "prediction"
+           create_prediction(history, pred_path)
+
+           pred = EclSum(os.path.join(pred_path, "PREDICTION"))
+           length = pred.sim_length
+           pred_times = pred.alloc_time_vector(False)
+           hist_times = history.alloc_time_vector(False)
+
+           for index in range(len(hist_times)):
+               self.assertEqual(hist_times[index], pred_times[index])


### PR DESCRIPTION
**Task**
Bug when loading a restarted summary case when the restarted source was given as an absolute path.

The first commit is the fix.

The two middle commits are test refactoring, the last commit is a test of the fix.

NB: This fix unearthed another bug/problem which comes in the Statoil testdata. That problem is fixed here: #319.