### PR TITLE
Fixed circular dependency in CThreadPool

### DIFF
--- a/python/ecl/util/cthread_pool.py
+++ b/python/ecl/util/cthread_pool.py
@@ -1,23 +1,25 @@
-#  Copyright (C) 2015  Statoil ASA, Norway. 
-#   
-#  The file 'cthread_pool.py' is part of ERT - Ensemble based Reservoir Tool. 
-#   
-#  ERT is free software: you can redistribute it and/or modify 
-#  it under the terms of the GNU General Public License as published by 
-#  the Free Software Foundation, either version 3 of the License, or 
-#  (at your option) any later version. 
-#   
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-#  FITNESS FOR A PARTICULAR PURPOSE.   
-#   
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-#  for more details. 
+#  Copyright (C) 2015  Statoil ASA, Norway.
+#
+#  The file 'cthread_pool.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
 
 import ctypes
 
 from cwrap import BaseCClass
 from ecl import EclPrototype
+
+import weakref
 
 
 class CThreadPool(BaseCClass):
@@ -35,9 +37,10 @@ class CThreadPool(BaseCClass):
 
     def addTaskFunction(self, name, lib, c_function_name):
         function = CThreadPool.lookupCFunction(lib, c_function_name)
+        self_ref = weakref.ref(self)  # avoid circular dependencies
 
         def wrappedFunction(arg):
-            return self.addTask(function, arg)
+            return self_ref().addTask(function, arg)
 
         setattr(self, name, wrappedFunction)
 


### PR DESCRIPTION
**Task**
The `addTaskFunction` method caused a circular dependency (`self` held `wrappedFunction`and viceversa

**Approach**
Use a weakref on `self`


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
