### PR TITLE
travis.yml: separate commands to split pylint and pandas.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,8 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a  # Useful for debugging any issues with conda
-  - conda install pylint pandas
+  - conda install pylint
+  - conda install pandas
 
 before_script:
   - wget https://raw.githubusercontent.com/Statoil/ert/master/travis/build_total.py


### PR DESCRIPTION
**Task**
Installation of pylint and pandas fails annoyingly many times in clang.


**Approach**
In travis.yml: installation by separate commands. 


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
