### PR TITLE
Removed ping utility.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,10 +296,6 @@ if (ERT_WINDOWS)
     endif()
 endif()
 
-find_program(PING_PATH NAMES ping)
-if (PING_PATH)
-    set(ERT_HAVE_PING ON)
-endif()
 
 find_package(Git)
 if(GIT_FOUND)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -194,9 +194,6 @@ target_compile_definitions(ecl PRIVATE
 
 target_compile_options(ecl PUBLIC ${pthreadarg})
 
-if (PING_PATH)
-    target_compile_definitions(ecl PRIVATE -DPING_CMD=${PING_PATH})
-endif()
 
 if (ERT_USE_OPENMP)
     target_compile_options(ecl PUBLIC ${OpenMP_C_FLAGS})

--- a/lib/include/ert/util/util.h
+++ b/lib/include/ert/util/util.h
@@ -515,9 +515,6 @@ void    util_abort_set_executable( const char * argv0 );
 #ifdef ERT_HAVE_SPAWN
   pid_t      util_spawn(const char *executable, int argc, const char **argv, const char *stdout_file, const char *stderr_file);
   int        util_spawn_blocking(const char *executable, int argc, const char **argv, const char *stdout_file, const char *stderr_file);
-#ifdef ERT_HAVE_PING
-  bool       util_ping( const char * hostname);
-#endif
 #endif
 
 

--- a/lib/util/util_spawn.c
+++ b/lib/util/util_spawn.c
@@ -124,30 +124,6 @@ int util_spawn_blocking(const char *executable, int argc, const char **argv, con
 
 
 
-/**
-   The ping program must(?) be setuid root, so implementing a simple
-   version based on sockets() proved to be nontrivial.
-
-   The PING_CMD is passed as -D from the build system.
-*/
-
-#ifdef ERT_HAVE_PING
-#define xstr(s) #s
-#define str(s) xstr(s)
-bool util_ping(const char *hostname) {
-  int wait_status;
-  const char* args[ 4 ] = { "-c", "3", "-q", hostname };
-  wait_status = util_spawn_blocking(str(PING_CMD), 4, args, "/dev/null" , "/dev/null");
-
-  if (WIFEXITED( wait_status )) {
-      int ping_status = WEXITSTATUS( wait_status );
-      return ping_status == 0;
-  } else {
-      return false;
-  }
-}
-#endif
-
 
 
 


### PR DESCRIPTION
**Task**
Strip down libecl - removed `util_ping` function.

Statoil/libres#234

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
