### PR TITLE
WIP: EOL_CHAR made public.

### DIFF
--- a/lib/include/ert/util/util.h
+++ b/lib/include/ert/util/util.h
@@ -184,6 +184,8 @@ typedef enum {left_pad   = 0,
   int          util_stat(const char * filename , stat_type * stat_info);
   int          util_fstat(int fileno, stat_type * stat_info);
 
+  bool         EOL_CHAR(char c);
+
 
 
 #ifdef ERT_HAVE_OPENDIR

--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -264,7 +264,7 @@ void util_endian_flip_vector_old(void *data, int element_size , int elements) {
 /*****************************************************************/
 
 
-static bool EOL_CHAR(char c) {
+bool EOL_CHAR(char c) {
   if (c == '\r' || c == '\n')
     return true;
   else


### PR DESCRIPTION
**Task**
util_alloc_stdin_line has been moved to the ert rep. It accesses the static function EOL_CHAR, so EOL_CHAR need to be made public. 


**Approach**
...


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
