### PR TITLE
Fix spelling of therefore

### DIFF
--- a/docs/code/python/packages/eclipse/index.rst
+++ b/docs/code/python/packages/eclipse/index.rst
@@ -851,9 +851,9 @@ ministep sequence, but there will never be holes in this range. It is
 closely coupled to the simulator timestep and what the user of ECLIPSE
 has chosen to store, so no further meaning should be attached to these
 indices. Ultimately all lookups will be based on :code:`time_index`; in the C
-code it is therefor often denoted :code:`internal_index`.
+code it is therefore often denoted :code:`internal_index`.
 
-ministep 
+ministep
 ,,,,,,,,,
 
 Each simulator timestep corresponds to one ministep, but an arbitrary

--- a/docs/tips.txt
+++ b/docs/tips.txt
@@ -94,7 +94,7 @@ it. In the configuration file both GEN_DATA and GEN_PARAM can be used:
    GEN_PARAM: For parameters which are not changed by the forward
       model, i.e. like porosity and permeability.
 
-   GEN_DATA: Data which is changed by the forward model, and therefor
+   GEN_DATA: Data which is changed by the forward model, and therefore
       must be loaded at the end of each timestep. The arch-typical
       example of a GEN_DATA instance would be seismic data.
 
@@ -436,14 +436,14 @@ The block_fs driver is based on creating block_fs instances
 (block_fs_type is implemented in libutil/src/block_fs.c). The block_fs
 instances are binary files which are open through the duration of the
 program, the block_fs system then has an api for reading and writing
-(key,value) pairs to this file. 
+(key,value) pairs to this file.
 
 The block_fs_driver/block_fs combination is quite complex, but it has
 not had any hickups for about 1.5 years of extensive use in
 Statoil. Observe that if you pull the plug on ERT you might loose some
 of the data which has been stored with the block_fs driver, but partly
 written and malformed data will be detected and discarded at the next
-boot. You are therefor guaranteed (add as many quotes you like to the
+boot. You are therefore guaranteed (add as many quotes you like to the
 guarantee - but this has at least worked 100% up until now) that no
 bogus data will be loaded after an unclean shutdown. When shut down
 cleanly the block_fs will create an index file which can be used for
@@ -551,7 +551,7 @@ SConstruct files:
 
 Unfortunately it has been a major pain in the ass to get SCons to
 behave according to the requirements listed above; for the more
-extensive installation procedures there are therefor simple Python
+extensive installation procedures there are therefore simple Python
 scripts "install.py" which should be invoked after the SCons build is
 complete.
 

--- a/lib/ecl/ecl_grid.c
+++ b/lib/ecl/ecl_grid.c
@@ -411,7 +411,7 @@
   properties and the fracture properties in a cell is implemented as a
   nnc where the fracture cell has global index in the range [nx*ny*nz,
   2*nz*ny*nz). In ert we we have not implemented this double covering
-  in the case of dual porosity models, and therefor NNC involving
+  in the case of dual porosity models so NNC involving
   fracture cells are not considered.
 */
 
@@ -1011,7 +1011,7 @@ static double ecl_cell_max_y( const ecl_cell_type * cell ) {
    have all four corner at the same arbitrary depth; these cells are
    inactive and do not affect flow simulations - however the arbitrary
    location of the cells warps visualisation of normal inactive cells
-   completely. We therefor try to invalidate such cells here. The
+   completely. We therefore try to invalidate such cells here. The
    algorithm used is the same as used for RMS; however RMS will mark
    the cells as inactive - whereas we mark already inactive cells as
    invalid.
@@ -1326,7 +1326,7 @@ static double ecl_cell_get_signed_volume( ecl_cell_type * cell) {
      * Note added: these volume calculations are used to calculate pore
      * volumes in OPM, it turns out that opm is very sensitive to these
      * volumes. Extracting the divison by 6.0 was actually enough to
-     * induce a regression test failure in flow, this has therefor been
+     * induce a regression test failure in flow, this has therefore been
      * reverted.
      */
 
@@ -2793,7 +2793,7 @@ static void ecl_grid_init_nnc_cells( ecl_grid_type * grid1, ecl_grid_type * grid
     The physical connection between the matrix and the fractures in
     cell nr c is modelled as an nnc: cell[c] -> cell[c + nx*ny*nz]. In
     the ert ecl library we only have cells in the range [0,nx*ny*nz),
-    and fracture is a property of a cell, we therefor do not include
+    and fracture is a property of a cell. We therefore do not include
     nnc connections involving fracture cells (i.e. cell_index >=
     nx*ny*nz).
   */

--- a/lib/ecl/ecl_kw.c
+++ b/lib/ecl/ecl_kw.c
@@ -107,7 +107,7 @@ UTIL_IS_INSTANCE_FUNCTION(ecl_kw , ECL_KW_TYPE_ID )
 
     3. The logical type involves converting back and forth between 'T'
        and 'F' and internal logical representation. The format strings
-       are therefor for reading/writing a character.
+       are therefore for reading/writing a character.
 
 */
 
@@ -1289,7 +1289,7 @@ bool ecl_kw_fskip_data(ecl_kw_type *ecl_kw, fortio_type *fortio) {
 /**
    This function will skip the header part of an ecl_kw instance. The
    function will read the file content at the current position, it is
-   therefor essential that the file pointer is positioned at the
+   therefore essential that the file pointer is positioned at the
    beginning of a keyword when this function is called; otherwise it
    will be complete crash and burn.
 */

--- a/lib/ecl/ecl_kw_grdecl.c
+++ b/lib/ecl/ecl_kw_grdecl.c
@@ -42,7 +42,7 @@
       b) There is not type information; presented with a bunch of
          formatted numbers it is in general impossible to determine
          whether the underlying datatype should be integer, float or
-         double. Therefor all the file-reading routines here expect an
+         double. Therefore all the file-reading routines here expect an
          ecl_data_type as input.
 
    2. The files can have comment sections; even in the data block.
@@ -159,7 +159,7 @@ char * ecl_kw_grdecl_alloc_next_header( FILE * stream ) {
   This function will search through a GRDECL file to look for the
   'kw'; input variables and return vales are similar to
   ecl_kw_fseek_kw(). Observe that the GRDECL files are extremely
-  weakly structured, it is therefor veeeery easy to fool this function
+  weakly structured, it is therefore veeeery easy to fool this function
   with a malformed GRDECL file.
 
   In particular the comparison is case sensitive; that is probably not

--- a/lib/ecl/ecl_rft_file.c
+++ b/lib/ecl/ecl_rft_file.c
@@ -415,7 +415,7 @@ void ecl_rft_file_update(const char * rft_file_name, ecl_rft_node_type ** nodes,
       /**
          The sorting here works directly on the internal node storage
          rft_file->data; that might in principle ruin the indexing of
-         the ecl_file object - it is therefor absolutely essential
+         the ecl_file object - it is therefore absolutely essential
          that this ecl_rft_file object does not live beyond this
          function, and also that the ecl_rft_file api functions are
          avoided for the rest of this function.

--- a/lib/ecl/ecl_rft_node.c
+++ b/lib/ecl/ecl_rft_node.c
@@ -75,7 +75,7 @@ struct ecl_rft_node_struct {
   The implementation of cell types based on _either_ RFT data or PLT
   data is based on a misunderstanding and is currently WRONG. One
   section in an RFT file can contain RFT data, PLT data and SEGMENT
-  data. The @data_type string should therefor not be interpreted as a
+  data. The @data_type string should therefore not be interpreted as a
   type string, but rather as a "bit mask":
 
 

--- a/lib/ecl/fault_block_layer.c
+++ b/lib/ecl/fault_block_layer.c
@@ -34,7 +34,7 @@
    The fault_block object is implemented as a separate object type in
    the fault_block.c file; however the fault blocks should be closely
    linked to the layer object in the fault_block_layer structure - it
-   is therefor not possible/legal to create a fault block instance by
+   is therefore not possible/legal to create a fault block instance by
    itself. To support that encapsulation the fault_block.c file is included
    here, and the functions:
 

--- a/lib/ecl/smspec_node.c
+++ b/lib/ecl/smspec_node.c
@@ -197,7 +197,7 @@ char * smspec_alloc_completion_num_key( const char * join_string , const char * 
   To support ECLIPSE behaviour where new wells/groups can be created
   during the simulation it must be possible to create a smspec node
   with an initially unknown well/group name; all gen_key formats which
-  use the wgname value must therefor accept a NULL value for wgname.
+  use the wgname value must therefore accept a NULL value for wgname.
 */
 
 static char * smspec_alloc_wgname_key( const char * join_string , const char * keyword , const char * wgname) {

--- a/lib/include/ert/ecl/EclKW.hpp
+++ b/lib/include/ert/ecl/EclKW.hpp
@@ -107,7 +107,7 @@ inline const char* EclKW_ref< const char* >::at( size_t i ) const {
 /*
   The current implementation of "string" storage in the underlying C
   ecl_kw structure does not lend itself to easily implement
-  operator[]. We have therefor explicitly deleted it here.
+  operator[]. We have therefore explicitly deleted it here.
 */
 
 template<>

--- a/lib/include/ert/util/msvc_stdbool.h
+++ b/lib/include/ert/util/msvc_stdbool.h
@@ -4,12 +4,12 @@
 
   - The ERT code makes use of stdbool in many places.  The msvc C
     compiler does not have a stdbool header, i.e. the #include <stdbool.h>
-    statements fail when compiling. 
+    statements fail when compiling.
 
   - When included in a C++ project the compiler already has a bool
-    defined; it is therefor important not to redefine this symbol if
+    defined; it is therefore important not to redefine this symbol if
     we are compiling C++.
- 
+
 */
 
 #ifndef __cplusplus

--- a/lib/util/thread_pool_posix.c
+++ b/lib/util/thread_pool_posix.c
@@ -163,7 +163,7 @@ static void thread_pool_resize_queue( thread_pool_type * pool, int queue_length 
 /**
    This function updates an element in the queue, the function is
    called by the executing threads, on the same time the main thread
-   might be resizing the thread, we therefor take a read lock during
+   might be resizing the thread, we therefore take a read lock during
    execution of this function. (Write lock is not necessary because we
    will not change the queue pointer itself, only something it points
    to.)

--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -183,7 +183,7 @@ void util_endian_flip_vector(void *data, int element_size , int elements) {
         variables will be by swapping two elements in one operation;
         this is provided by the util_endian_convert32_64() function. In the case
         of binary ECLIPSE files this case is quite common, and
-        therefor worth supporting as a special case.
+        therefore worth supporting as a special case.
       */
       uint64_t *tmp64 = (uint64_t *) data;
 

--- a/lib/util/util_endian.c
+++ b/lib/util/util_endian.c
@@ -119,7 +119,7 @@ void util_endian_flip_vector(void *data, int element_size , int elements) {
         variables will be by swapping two elements in one operation;
         this is provided by the util_endian_convert32_64() function. In the case
         of binary ECLIPSE files this case is quite common, and
-        therefor worth supporting as a special case. 
+        therefore worth supporting as a special case.
       */
       uint64_t *tmp64 = (uint64_t *) data;
 

--- a/lib/util/util_lockf.c
+++ b/lib/util/util_lockf.c
@@ -20,7 +20,7 @@
 
     If the lock is aquired the function will return true, otherwise it
     will return false. The lock is only active as long as the lockfile
-    is open, we therefor have to keep track of the relevant file
+    is open, we therefore have to keep track of the relevant file
     descriptor; it is passed back to the calling scope through a
     reference. Observe that if the locking fails we close the file
     immediately, and return -1 in the file descriptor argument.

--- a/lib/util/util_zlib.c
+++ b/lib/util/util_zlib.c
@@ -93,7 +93,7 @@ Layout on disk when using util_fwrite_compressed:
 Observe that the functions util_fwrite_compressed() and
 util_fread_compressed must be used as a pair, the files can **N O T**
 be interchanged with normal calls to gzip/gunzip. To avoid confusion
-it is therefor strongly advised NOT to give the files a .gz extension.
+it is therefore strongly advised NOT to give the files a .gz extension.
 
 */
 

--- a/lib/util/vector.c
+++ b/lib/util/vector.c
@@ -542,7 +542,7 @@ static int vector_cmp(const void * s1 , const void * s2) {
        int (* user_cmp) (const void *, const void *)
 
    i.e. the same as for qsort. The vector implementation considers
-   (fully) untyped data, it is therefor the users responsability to
+   (fully) untyped data, it is therefore the users responsability to
    ensure that the comparison makes sense. For example:
 
 

--- a/python/doc/devel.txt
+++ b/python/doc/devel.txt
@@ -165,16 +165,16 @@ like:
   typedef struct {
      .....
      .....
-  } abs_type; 
+  } abs_type;
 
 and "methods" like:
 
   abs_type * abs_type_alloc( ) { }
-  void       abs_type_free( abs_type * at ) {} 
-  int        abs_type_get_an_int( const abs_type * at) {}  
+  void       abs_type_free( abs_type * at ) {}
+  int        abs_type_get_an_int( const abs_type * at) {}
   void       abs_type_set_an_int( abs_type * at , int value) {}
 
-it has therefor been relatively easy to map this onto Python classes
+it has therefore been relatively easy to map this onto Python classes
 and give a pythonic feel to the whole thing. As a ground rule each C
 file implements one struct; this struct is wrapped in a Python module
 with the same name and a Python class with CamelCaps naming:

--- a/python/ecl/eclfile/ecl_kw.py
+++ b/python/ecl/eclfile/ecl_kw.py
@@ -273,7 +273,7 @@ class EclKW(BaseCClass):
 
         Observe that since the grdecl files are quite weakly
         structured it is difficult to verify the integrity of the
-        files, malformed input might therefor pass unnoticed before
+        files, malformed input might therefore pass unnoticed before
         things blow up at a later stage.
 
         [1]: It is possible, but not recommended, to pass in None for

--- a/python/ecl/grid/faults/fault_block_collection.py
+++ b/python/ecl/grid/faults/fault_block_collection.py
@@ -37,7 +37,7 @@ class FaultBlockCollection(BaseCClass):
             raise ValueError("Invalid input - failed to create FaultBlockCollection")
 
         # The underlying C implementation uses lazy evaluation and
-        # needs to hold on to the grid reference. We therefor take
+        # needs to hold on to the grid reference. We therefore take
         # references to it here, to protect against premature garbage
         # collection.
         self.grid_ref = grid

--- a/python/ecl/grid/faults/fault_block_layer.py
+++ b/python/ecl/grid/faults/fault_block_layer.py
@@ -50,7 +50,7 @@ class FaultBlockLayer(BaseCClass):
             raise ValueError("Invalid input - failed to create FaultBlockLayer")
 
         # The underlying C implementation uses lazy evaluation and
-        # needs to hold on to the grid reference. We therefor take
+        # needs to hold on to the grid reference. We therefore take
         # references to it here, to protect against premature garbage
         # collection.
         self.grid_ref = grid

--- a/python/ecl/summary/ecl_sum_vector.py
+++ b/python/ecl/summary/ecl_sum_vector.py
@@ -33,7 +33,7 @@ class EclSumVector(object):
         The EclSumVector contains a reference to the parent EclSum
         structure and this is used to implement several of the
         properties and methods of the object; the EclSum vector
-        instances should therefor only be instantiated through the
+        instances should therefore only be instantiated through the
         EclSum.get_vector() method, and not manually with the
         EclSumVector() constructor.
         """


### PR DESCRIPTION
Therefore is commonly misspelled as therefor in the comments. Therefore
is a synonym of "hence", while therefor is an adverb meaning "for it".


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
