### PR TITLE
Added import local to ert/__init__

### DIFF
--- a/python/ert/__init__.py
+++ b/python/ert/__init__.py
@@ -1,0 +1,4 @@
+try:
+    from .local import *
+except ImportError:
+    pass


### PR DESCRIPTION
Added a small stub:
```
try:
   from .local import *
except ImportError:
   pass
```

the purpose of this is to be able to install/enable site local warning/messages/...


