### PR TITLE
WIP: travis.yml: added setting for LD_LIBRARY_PATH.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ dist: trusty
 env:
   global:
     - ERT_SHOW_BACKTRACE=1
+    - LD_LIBRARY_PATH="$(pwd)/install/lib64"
   matrix:
     - PYTHON_VERSION=2.7 TEST_SUITE="-LE SLOW"  # Run all tests not labeled as slow
     - PYTHON_VERSION=2.7 TEST_SUITE="-L SLOW_1" # Run all tests labeled as SLOW in group 1
@@ -46,6 +47,7 @@ addons:
 
 
 install:
+  - echo $LD_LIBRARY_PATH
   - if [[ "$CC" == "gcc" ]]; then export CXX="g++-4.8"; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       export CONDA_OS=MacOSX;


### PR DESCRIPTION
**Task**
Travis will not process in python 3.


**Approach**
In travis.yml: LD_LIBRARYT_PATH is set as a global variable. 


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
