### PR TITLE
Removed buffer functions from vector_template

### DIFF
--- a/lib/ecl/ecl_coarse_cell.c
+++ b/lib/ecl/ecl_coarse_cell.c
@@ -17,6 +17,8 @@
 */
 
 #include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include <ert/util/util.h>
 #include <ert/util/type_macros.h>

--- a/lib/util/vector_template.c
+++ b/lib/util/vector_template.c
@@ -98,7 +98,6 @@
 
 #include <ert/util/type_macros.h>
 #include <ert/util/util.h>
-#include <ert/util/buffer.h>
 #include <ert/util/@TYPE@_vector.h>
 
 #ifdef __cplusplus
@@ -1469,31 +1468,6 @@ void @TYPE@_vector_fread( @TYPE@_vector_type * vector , FILE * stream ) {
 }
 
 
-
-void @TYPE@_vector_buffer_fwrite(const @TYPE@_vector_type * vector , buffer_type * buffer) {
-  buffer_fwrite_int( buffer , vector->size );
-  buffer_fwrite( buffer , &vector->default_value , sizeof vector->default_value , 1 );
-  buffer_fwrite( buffer , vector->data , sizeof * vector->data , vector->size );
-}
-
-
-void @TYPE@_vector_buffer_fread(@TYPE@_vector_type * vector , buffer_type * buffer) {
-  @TYPE@     default_value;
-  int size = buffer_fread_int( buffer );
-  buffer_fread( buffer , &default_value , sizeof default_value , 1 );
-
-  @TYPE@_vector_set_default( vector , default_value );
-  @TYPE@_vector_realloc_data__( vector , size );
-  buffer_fread( buffer , vector->data , sizeof * vector->data , size );
-  vector->size = size;
-}
-
-
-@TYPE@_vector_type * @TYPE@_vector_buffer_fread_alloc( buffer_type * buffer ) {
-  @TYPE@_vector_type * vector = @TYPE@_vector_alloc( 0 , 0);
-  @TYPE@_vector_buffer_fread( vector , buffer );
-  return vector;
-}
 
 
 /*****************************************************************/

--- a/lib/util/vector_template.c
+++ b/lib/util/vector_template.c
@@ -95,6 +95,8 @@
 
 #include <string.h>
 #include <stdbool.h>
+#include <stdlib.h>
+#include <math.h>
 
 #include <ert/util/type_macros.h>
 #include <ert/util/util.h>

--- a/lib/vector_template.h.in
+++ b/lib/vector_template.h.in
@@ -24,7 +24,6 @@ extern "C" {
 #include <stdio.h>
 #include <stdbool.h>
 
-#include <ert/util/buffer.h>
 #include <ert/util/type_macros.h>
 #include <ert/util/perm_vector.h>
 
@@ -109,10 +108,7 @@ typedef @TYPE@ (@TYPE@_ftype) (@TYPE@);
   perm_vector_type *   @TYPE@_vector_alloc_rsort_perm(const @TYPE@_vector_type * vector);
   void                 @TYPE@_vector_fprintf(const @TYPE@_vector_type * vector , FILE * stream , const char * name , const char * fmt);
   void                 @TYPE@_vector_fwrite(const @TYPE@_vector_type * vector , FILE * stream);
-  void                 @TYPE@_vector_buffer_fread(@TYPE@_vector_type * vector , buffer_type * buffer);
   @TYPE@_vector_type * @TYPE@_vector_fread_alloc( FILE * stream );
-  @TYPE@_vector_type * @TYPE@_vector_buffer_fread_alloc( buffer_type * buffer );
-  void                 @TYPE@_vector_buffer_fwrite(const @TYPE@_vector_type * vector , buffer_type * buffer);
   void                 @TYPE@_vector_fread( @TYPE@_vector_type * vector , FILE * stream );
   void                 @TYPE@_vector_fwrite_data( const @TYPE@_vector_type * vector , FILE * stream );
   void                 @TYPE@_vector_fread_data( @TYPE@_vector_type * vector , int size, FILE * stream);


### PR DESCRIPTION
**Task**
Removed functions reading and writing a typed vector to a buffer. When this has been merged the whole `buffer` implementation can be moved to libres.


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally

Statoil/libres#259