### PR TITLE
Added restart_step to ecl_sum create writer.

### DIFF
--- a/lib/ecl/ecl_sum.c
+++ b/lib/ecl/ecl_sum.c
@@ -317,22 +317,46 @@ ecl_sum_tstep_type * ecl_sum_add_tstep( ecl_sum_type * ecl_sum , int report_step
   return ecl_sum_data_add_new_tstep( ecl_sum->data , report_step , sim_seconds );
 }
 
-
-ecl_sum_type * ecl_sum_alloc_restart_writer( const char * ecl_case , const char * restart_case , bool fmt_output , bool unified , const char * key_join_string , time_t sim_start , bool time_in_days , int nx , int ny , int nz) {
+static ecl_sum_type * ecl_sum_alloc_writer__( const char * ecl_case , const char * restart_case , int restart_step, bool fmt_output , bool unified , const char * key_join_string , time_t sim_start , bool time_in_days , int nx , int ny , int nz) {
 
   ecl_sum_type * ecl_sum = ecl_sum_alloc__( ecl_case , key_join_string );
   if (ecl_sum) {
     ecl_sum_set_unified( ecl_sum , unified );
     ecl_sum_set_fmt_case( ecl_sum , fmt_output );
 
-    ecl_sum->smspec = ecl_smspec_alloc_writer( key_join_string , restart_case, sim_start , time_in_days , nx , ny , nz );
+    if (restart_case)
+      ecl_sum->smspec = ecl_smspec_alloc_restart_writer( key_join_string , restart_case, restart_step, sim_start , time_in_days , nx , ny , nz );
+    else
+      ecl_sum->smspec = ecl_smspec_alloc_writer( key_join_string, sim_start, time_in_days, nx, ny, nz);
+
     ecl_sum->data   = ecl_sum_data_alloc_writer( ecl_sum->smspec );
   }
   return ecl_sum;
 }
 
+
+ecl_sum_type * ecl_sum_alloc_restart_writer2( const char * ecl_case , const char * restart_case , int restart_step, bool fmt_output , bool unified , const char * key_join_string , time_t sim_start , bool time_in_days , int nx , int ny , int nz) {
+  return ecl_sum_alloc_writer__(ecl_case, restart_case, restart_step, fmt_output, unified, key_join_string, sim_start, time_in_days, nx, ny, nz);
+}
+
+
+/*
+  This does not take in the restart_step argument is depcrecated. You should use the
+  ecl_sum_alloc_restart_writer2() function.
+*/
+
+ecl_sum_type * ecl_sum_alloc_restart_writer( const char * ecl_case , const char * restart_case, bool fmt_output , bool unified , const char * key_join_string , time_t sim_start , bool time_in_days , int nx , int ny , int nz) {
+  int restart_step = 0;
+  return ecl_sum_alloc_writer__(ecl_case, restart_case, restart_step, fmt_output, unified, key_join_string, sim_start, time_in_days, nx, ny, nz);
+}
+
+
+
+
+
+
 ecl_sum_type * ecl_sum_alloc_writer( const char * ecl_case , bool fmt_output , bool unified , const char * key_join_string , time_t sim_start , bool time_in_days , int nx , int ny , int nz) {
-  return ecl_sum_alloc_restart_writer(ecl_case, NULL, fmt_output, unified, key_join_string, sim_start, time_in_days, nx, ny, nz);
+  return ecl_sum_alloc_writer__(ecl_case, NULL, 0, fmt_output, unified, key_join_string, sim_start, time_in_days, nx, ny, nz);
 }
 
 
@@ -1142,6 +1166,10 @@ void ecl_sum_export_csv(const ecl_sum_type * ecl_sum , const char * filename  , 
 
 const ecl_sum_type * ecl_sum_get_restart_case(const ecl_sum_type * ecl_sum) {
   return ecl_sum->restart_case;
+}
+
+int ecl_sum_get_restart_step(const ecl_sum_type * ecl_sum) {
+  return ecl_smspec_get_restart_step(ecl_sum->smspec);
 }
 
 

--- a/lib/ecl/ecl_sum_data.c
+++ b/lib/ecl/ecl_sum_data.c
@@ -928,9 +928,15 @@ void ecl_sum_data_add_case(ecl_sum_data_type * self, const ecl_sum_data_type * o
     ecl_sum_tstep_type * other_tstep = ecl_sum_data_iget_ministep( other , tstep_nr );
 
     /*
-      The dataset 'self' is the authorative in the timeinterval where
-      it has data, so if 'other' also has data in the same time interval
-      that is discarded.
+      The dataset 'self' is the authorative in the timeinterval where it has
+      data, so if 'other' also has data in the same time interval that is
+      discarded. In most cases 'other' will represent a history case, and 'self'
+      is a prediction which has been restarted.
+
+      After implementing the time_interval_contains() based check it turned out
+      that the smspec structure also contains a restart_step integer value in
+      the DIMENS vector which could probably be used to achieve the same thing.
+      That field is currently not used.
     */
 
     if (!time_interval_contains( self->sim_time , ecl_sum_tstep_get_sim_time( other_tstep ))) {

--- a/lib/ecl/tests/ecl_sum_writer.c
+++ b/lib/ecl/tests/ecl_sum_writer.c
@@ -184,8 +184,9 @@ void test_long_restart_names() {
    const char * name = "THE_CASE";
    test_work_area_type * work_area = test_work_area_alloc("sum_write_restart_long_name");
    {
+       int restart_step = 77;
        time_t start_time = util_make_date_utc( 1,1,2010 );
-       ecl_sum_type * ecl_sum = ecl_sum_alloc_restart_writer( name , restart_case , false , true , ":" , start_time , true , 3, 3, 3);
+       ecl_sum_type * ecl_sum = ecl_sum_alloc_restart_writer2( name , restart_case , restart_step, false , true , ":" , start_time , true , 3, 3, 3);
        ecl_sum_fwrite( ecl_sum );
        ecl_sum_free(ecl_sum);
 
@@ -199,8 +200,9 @@ void test_long_restart_names() {
          char s[9]; sprintf(s, "WWWWGGG%d", n);
          test_assert_string_equal(s, ecl_kw_iget_char_ptr(restart_kw, n) );
        }
+       ecl_file_close( smspec_file);
        {
-         ecl_smspec_type * smspec = ecl_smspec_alloc_writer( ":" , "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ", start_time, true, 3, 3 ,3);
+         ecl_smspec_type * smspec = ecl_smspec_alloc_restart_writer( ":" , "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ", 10, start_time, true, 3, 3 ,3);
          /*
            Restart case is too long - it is ignored.
          */

--- a/lib/include/ert/ecl/ecl_kw_magic.h
+++ b/lib/include/ert/ecl/ecl_kw_magic.h
@@ -453,15 +453,17 @@ values (2e20) are denoted with '*'.
    keyword in the SMSPEC files. Observe that these magic indices
    differ from the magic indices used to look up grid dimensions from
    the DIMENS keyword in GRID files.  */
-#define DIMENS_SMSPEC_SIZE_INDEX    0
-#define DIMENS_SMSPEC_NX_INDEX      1
-#define DIMENS_SMSPEC_NY_INDEX      2
-#define DIMENS_SMSPEC_NZ_INDEX      3
-#define DIMENS_SIZE                 6   // Do not know what the two last items are?
+#define DIMENS_SMSPEC_SIZE_INDEX           0
+#define DIMENS_SMSPEC_NX_INDEX             1
+#define DIMENS_SMSPEC_NY_INDEX             2
+#define DIMENS_SMSPEC_NZ_INDEX             3
+#define DIMENS_SMSPEC_RESTART_STEP_INDEX   5
+#define DIMENS_SIZE                        6
 
-#define INTEHEAD_SMSPEC_IPROG_INDEX 0
-#define INTEHEAD_SMSPEC_UNIT_INDEX  1
 #define INTEHEAD_SMSPEC_SIZE        2
+#define INTEHEAD_SMSPEC_UNIT_INDEX  0
+#define INTEHEAD_SMSPEC_IPROG_INDEX 1
+
 
 /* Summary data files: */
 #define SEQHDR_KW    "SEQHDR"      // Contains a single 'magic' integer - not used in libecl.

--- a/lib/include/ert/ecl/ecl_smspec.h
+++ b/lib/include/ert/ecl/ecl_smspec.h
@@ -56,7 +56,10 @@ typedef struct ecl_smspec_struct ecl_smspec_type;
   const char        * ecl_smspec_get_var_type_name( ecl_smspec_var_type var_type );
   ecl_smspec_var_type ecl_smspec_identify_var_type(const char * var);
   ecl_smspec_type * ecl_smspec_alloc_empty(bool write_mode , const char * key_join_string);
-  ecl_smspec_type   * ecl_smspec_alloc_writer( const char * key_join_string , const char * restart_case, time_t sim_start , bool time_in_days , int nx , int ny , int nz);
+
+  ecl_smspec_type * ecl_smspec_alloc_restart_writer( const char * key_join_string , const char * restart_case, int restart_step, time_t sim_start , bool time_in_days , int nx , int ny , int nz);
+
+  ecl_smspec_type   * ecl_smspec_alloc_writer( const char * key_join_string ,  time_t sim_start , bool time_in_days , int nx , int ny , int nz);
   void                ecl_smspec_fwrite( const ecl_smspec_type * smspec , const char * ecl_case , bool fmt_file );
 
   ecl_smspec_type *        ecl_smspec_fread_alloc(const char *header_file, const char * key_join_string , bool include_restart);
@@ -130,6 +133,7 @@ typedef struct ecl_smspec_struct ecl_smspec_type;
   stringlist_type          * ecl_smspec_alloc_group_list( const ecl_smspec_type * smspec , const char * pattern);
   stringlist_type          * ecl_smspec_alloc_well_var_list( const ecl_smspec_type * smspec );
   const char               * ecl_smspec_get_simulation_path(const ecl_smspec_type * ecl_smspec);
+  int                        ecl_smspec_get_restart_step(const ecl_smspec_type * ecl_smspec);
   const char               * ecl_smspec_get_restart_case( const ecl_smspec_type * ecl_smspec);
   const char               * ecl_smspec_get_join_string( const ecl_smspec_type * smspec);
   const float_vector_type  * ecl_smspec_get_params_default( const ecl_smspec_type * ecl_smspec );

--- a/lib/include/ert/ecl/ecl_sum.h
+++ b/lib/include/ert/ecl/ecl_sum.h
@@ -202,7 +202,18 @@ typedef struct ecl_sum_struct       ecl_sum_type;
 
   int                   ecl_sum_iget_report_end( const ecl_sum_type * ecl_sum , int report_step );
   int                   ecl_sum_iget_report_start( const ecl_sum_type * ecl_sum , int report_step );
-
+  ecl_sum_type        * ecl_sum_alloc_restart_writer2( const char * ecl_case,
+                                                       const char * restart_case,
+                                                       int restart_step,
+                                                       bool fmt_output,
+                                                       bool unified,
+                                                       const char * key_join_string,
+                                                       time_t sim_start,
+                                                       bool time_in_days,
+                                                       int nx,
+                                                       int ny,
+                                                       int nz);
+ 
   ecl_sum_type * ecl_sum_alloc_restart_writer(const char * ecl_case ,
                                               const char * restart_case ,
                                               bool fmt_output ,

--- a/python/ecl/summary/ecl_sum.py
+++ b/python/ecl/summary/ecl_sum.py
@@ -88,7 +88,8 @@ class EclSum(BaseCClass):
     TYPE_NAME = "ecl_sum"
     _fread_alloc_case              = EclPrototype("void*     ecl_sum_fread_alloc_case__(char*, char*, bool)", bind=False)
     _fread_alloc                   = EclPrototype("void*     ecl_sum_fread_alloc(char*, stringlist, char*, bool)", bind=False)
-    _create_restart_writer         = EclPrototype("ecl_sum_obj  ecl_sum_alloc_restart_writer(char*, char*, bool, bool, char*, time_t, bool, int, int, int)", bind = False)
+    _create_restart_writer         = EclPrototype("ecl_sum_obj  ecl_sum_alloc_restart_writer2(char*, char*, int, bool, bool, char*, time_t, bool, int, int, int)", bind = False)
+    _create_writer                 = EclPrototype("ecl_sum_obj  ecl_sum_alloc_writer(char*, bool, bool, char*, time_t, bool, int, int, int)", bind = False)
     _resample                      = EclPrototype("ecl_sum_obj  ecl_sum_alloc_resample( ecl_sum, char*, time_t_vector)")
     _iiget                         = EclPrototype("double   ecl_sum_iget(ecl_sum, int, int)")
     _free                          = EclPrototype("void     ecl_sum_free(ecl_sum)")
@@ -121,6 +122,7 @@ class EclSum(BaseCClass):
     _get_data_start                = EclPrototype("time_t   ecl_sum_get_data_start(ecl_sum)")
     _get_unit                      = EclPrototype("char*    ecl_sum_get_unit(ecl_sum, char*)")
     _get_restart_case              = EclPrototype("ecl_sum_ref ecl_sum_get_restart_case(ecl_sum)")
+    _get_restart_step              = EclPrototype("int      ecl_sum_get_restart_step(ecl_sum)")
     _get_simcase                   = EclPrototype("char*    ecl_sum_get_case(ecl_sum)")
     _get_unit_system               = EclPrototype("ecl_unit_enum ecl_sum_get_unit_system(ecl_sum)")
     _get_base                      = EclPrototype("char*    ecl_sum_get_base(ecl_sum)")
@@ -217,15 +219,15 @@ class EclSum(BaseCClass):
         The writer is not generally usable.
         @rtype: EclSum
         """
-        return EclSum._create_restart_writer(case, None, fmt_output, unified, key_join_string, CTime(start_time), time_in_days, nx, ny, nz)
+        return EclSum._create_writer(case, fmt_output, unified, key_join_string, CTime(start_time), time_in_days, nx, ny, nz)
 
     @staticmethod
-    def restart_writer(case, restart_case, start_time, nx,ny,nz, fmt_output=False, unified=True, time_in_days=True, key_join_string=":"):
+    def restart_writer(case, restart_case, restart_step, start_time, nx,ny,nz, fmt_output=False, unified=True, time_in_days=True, key_join_string=":"):
         """
         The writer is not generally usable.
         @rtype: EclSum
         """
-        return EclSum._create_restart_writer(case, restart_case, fmt_output, unified, key_join_string, CTime(start_time), time_in_days, nx, ny, nz)
+        return EclSum._create_restart_writer(case, restart_case, restart_step, fmt_output, unified, key_join_string, CTime(start_time), time_in_days, nx, ny, nz)
 
     def add_variable(self, variable, wgname=None, num=0, unit="None", default_value=0):
         return self._add_variable(variable, wgname, num, unit, default_value).setParent(parent=self)
@@ -774,6 +776,14 @@ class EclSum(BaseCClass):
         Will return the case name of the current instance - optionally including path.
         """
         return self._get_simcase()
+
+
+    @property
+    def restart_step(self):
+        """
+        Will return the report step this case has been restarted from, or -1.
+        """
+        return self._get_restart_step()
 
 
     @property

--- a/python/ecl/util/test/ecl_mock/ecl_sum_mock.py
+++ b/python/ecl/util/test/ecl_mock/ecl_sum_mock.py
@@ -15,9 +15,10 @@ def createEclSum( case,
                   num_mini_step = 10,
                   dims = (20,10,5) ,
                   func_table = {},
-                  restart_case = None):
+                  restart_case = None,
+                  restart_step = -1):
 
-    ecl_sum = EclSum.restart_writer(case , restart_case, sim_start , dims[0] , dims[1] , dims[2])
+    ecl_sum = EclSum.restart_writer(case , restart_case, restart_step, sim_start , dims[0] , dims[1] , dims[2])
     var_list = []
     for (kw,wgname,num) in keys:
         var_list.append( ecl_sum.addVariable( kw , wgname = wgname , num = num) )


### PR DESCRIPTION
When restarting you can set the report_step it has been restarted from in the SMSPEC file. That field was previously not set by libecl.

Feature wanted by Resinsight.

[x] : Statoil tests OK.