### PR TITLE
Internalize restart case as full ecl_sum instance.

### DIFF
--- a/lib/ecl/ecl_sum.c
+++ b/lib/ecl/ecl_sum.c
@@ -97,6 +97,7 @@ struct ecl_sum_struct {
   UTIL_TYPE_ID_DECLARATION;
   ecl_smspec_type   * smspec;     /* Internalized version of the SMSPEC file. */
   ecl_sum_data_type * data;       /* The data - can be NULL. */
+  ecl_sum_type      * restart_case;
 
 
   bool                fmt_case;
@@ -167,6 +168,7 @@ static ecl_sum_type * ecl_sum_alloc__( const char * input_arg , const char * key
 
   ecl_sum->smspec = NULL;
   ecl_sum->data   = NULL;
+  ecl_sum->restart_case = NULL;
 
   return ecl_sum;
 }
@@ -182,10 +184,10 @@ static bool ecl_sum_fread_data( ecl_sum_type * ecl_sum , const stringlist_type *
 
 
 static void ecl_sum_fread_history( ecl_sum_type * ecl_sum ) {
-  ecl_sum_type * history = ecl_sum_fread_alloc_case__( ecl_smspec_get_restart_case( ecl_sum->smspec ) , ":" , true);
-  if (history) {
-    ecl_sum_data_add_case(ecl_sum->data , history->data );
-    ecl_sum_free( history );
+  ecl_sum_type * restart_case = ecl_sum_fread_alloc_case__( ecl_smspec_get_restart_case( ecl_sum->smspec ) , ":" , true);
+  if (restart_case) {
+    ecl_sum->restart_case = restart_case;
+    ecl_sum_data_add_case(ecl_sum->data , restart_case->data );
   }
 }
 
@@ -360,10 +362,13 @@ void ecl_sum_free_data( ecl_sum_type * ecl_sum ) {
 
 
 void ecl_sum_free( ecl_sum_type * ecl_sum ) {
-  if (ecl_sum->data != NULL)
+  if (ecl_sum->restart_case)
+    ecl_sum_free(ecl_sum->restart_case);
+
+  if (ecl_sum->data)
     ecl_sum_free_data( ecl_sum );
 
-  if (ecl_sum->smspec != NULL)
+  if (ecl_sum->smspec)
     ecl_smspec_free( ecl_sum->smspec );
 
   util_safe_free( ecl_sum->path );
@@ -1135,8 +1140,8 @@ void ecl_sum_export_csv(const ecl_sum_type * ecl_sum , const char * filename  , 
 }
 
 
-const char * ecl_sum_get_restart_case(const ecl_sum_type * ecl_sum) {
-  return ecl_smspec_get_restart_case(ecl_sum->smspec);
+const ecl_sum_type * ecl_sum_get_restart_case(const ecl_sum_type * ecl_sum) {
+  return ecl_sum->restart_case;
 }
 
 

--- a/lib/include/ert/ecl/ecl_sum.h
+++ b/lib/include/ert/ecl/ecl_sum.h
@@ -171,7 +171,7 @@ typedef struct ecl_sum_struct       ecl_sum_type;
   const char * ecl_sum_get_base(const ecl_sum_type * ecl_sum );
   const char * ecl_sum_get_path(const ecl_sum_type * ecl_sum );
   const char * ecl_sum_get_abs_path(const ecl_sum_type * ecl_sum );
-  const char * ecl_sum_get_restart_case(const ecl_sum_type * ecl_sum);
+  const ecl_sum_type * ecl_sum_get_restart_case(const ecl_sum_type * ecl_sum);
   const char * ecl_sum_get_case(const ecl_sum_type * );
   bool         ecl_sum_same_case( const ecl_sum_type * ecl_sum , const char * input_file );
 

--- a/python/ecl/summary/ecl_sum.py
+++ b/python/ecl/summary/ecl_sum.py
@@ -120,7 +120,7 @@ class EclSum(BaseCClass):
     _get_first_day                 = EclPrototype("double   ecl_sum_get_first_day(ecl_sum)")
     _get_data_start                = EclPrototype("time_t   ecl_sum_get_data_start(ecl_sum)")
     _get_unit                      = EclPrototype("char*    ecl_sum_get_unit(ecl_sum, char*)")
-    _get_restart_case              = EclPrototype("char*    ecl_sum_get_restart_case(ecl_sum)")
+    _get_restart_case              = EclPrototype("ecl_sum_ref ecl_sum_get_restart_case(ecl_sum)")
     _get_simcase                   = EclPrototype("char*    ecl_sum_get_case(ecl_sum)")
     _get_base                      = EclPrototype("char*    ecl_sum_get_base(ecl_sum)")
     _get_path                      = EclPrototype("char*    ecl_sum_get_path(ecl_sum)")
@@ -770,7 +770,10 @@ class EclSum(BaseCClass):
 
     @property
     def restart_case(self):
-        return self._get_restart_case()
+        restart_case = self._get_restart_case()
+        if restart_case:
+            restart_case.setParent(parent=self)
+        return restart_case
 
 
     @property

--- a/python/tests/ecl_tests/test_sum.py
+++ b/python/tests/ecl_tests/test_sum.py
@@ -411,7 +411,8 @@ class SumTest(EclTest):
            # on the path used for $TMP and so on we do not really know here if
            # the restart_case has been set or not.
            if pred.restart_case:
-               self.assertEqual(pred.restart_case, os.path.join(os.getcwd(), history.case))
+               self.assertTrue(isinstance(pred.restart_case, EclSum))
+               self.assertEqual(pred.restart_case.case, os.path.join(os.getcwd(), history.case))
 
                length = pred.sim_length
                pred_times = pred.alloc_time_vector(False)


### PR DESCRIPTION
Instead of just storing the name of the case we have restarted from - we store the full `ecl_sum` instance.

Feature requested from Resinsight.