### PR TITLE
Will look for the INTEHEAD keyword an extract unit system.

### DIFF
--- a/lib/ecl/ecl_smspec.c
+++ b/lib/ecl/ecl_smspec.c
@@ -365,137 +365,143 @@ static ecl_data_type get_wgnames_type(const ecl_smspec_type * smspec) {
   return max_len <= ECL_STRING8_LENGTH ? ECL_CHAR : ECL_STRING(max_len);
 }
 
-// DIMENS
-// KEYWORDS
-// WGNAMES
-// NUMS    - optional
-// UNITS
-// STARTDAT
+static void ecl_smspec_fwrite_INTEHEAD(const ecl_smspec_type * smspec, fortio_type * fortio) {
+  ecl_kw_type * intehead = ecl_kw_alloc( INTEHEAD_KW, INTEHEAD_SMSPEC_SIZE, ECL_INT);
+  ecl_kw_iset_int(intehead, INTEHEAD_SMSPEC_UNIT_INDEX, smspec->unit_system);
+  /*
+    The simulator type is just hardcoded to ECLIPSE100.
+  */
+  ecl_kw_iset_int(intehead, INTEHEAD_SMSPEC_IPROG_INDEX, INTEHEAD_ECLIPSE100_VALUE);
+  ecl_kw_fwrite(intehead, fortio);
+  ecl_kw_free(intehead);
+}
+
+
+static void ecl_smspec_fwrite_RESTART(const ecl_smspec_type * smspec, fortio_type * fortio) {
+  ecl_kw_type * restart_kw = ecl_kw_alloc( RESTART_KW , SUMMARY_RESTART_SIZE , ECL_CHAR );
+  for (int i=0; i < SUMMARY_RESTART_SIZE; i++)
+    ecl_kw_iset_string8( restart_kw , i , "");
+
+  if (smspec->restart_case != NULL) {
+    int restart_case_len = strlen(smspec->restart_case);
+
+    int offset = 0;
+    for (int i = 0; i < SUMMARY_RESTART_SIZE ; i++) {
+      if (offset < restart_case_len)
+        ecl_kw_iset_string8( restart_kw , i , &smspec->restart_case[ offset ]);
+      offset += ECL_STRING8_LENGTH;
+    }
+  }
+
+  ecl_kw_fwrite( restart_kw , fortio );
+  ecl_kw_free( restart_kw );
+}
+
+
+
+static void ecl_smspec_fwrite_DIMENS(const ecl_smspec_type * smspec, fortio_type * fortio) {
+  ecl_kw_type * dimens_kw = ecl_kw_alloc( DIMENS_KW , DIMENS_SIZE , ECL_INT );
+  int num_nodes = ecl_smspec_num_nodes( smspec );
+  ecl_kw_iset_int( dimens_kw , DIMENS_SMSPEC_SIZE_INDEX , num_nodes );
+  ecl_kw_iset_int( dimens_kw , DIMENS_SMSPEC_NX_INDEX   , smspec->grid_dims[0] );
+  ecl_kw_iset_int( dimens_kw , DIMENS_SMSPEC_NY_INDEX   , smspec->grid_dims[1] );
+  ecl_kw_iset_int( dimens_kw , DIMENS_SMSPEC_NZ_INDEX   , smspec->grid_dims[2] );
+
+  /* Do not know what these two last items are for. */
+  ecl_kw_iset_int( dimens_kw , 4  , 0 );
+  ecl_kw_iset_int( dimens_kw , 5 , -1 );
+
+  ecl_kw_fwrite( dimens_kw , fortio );
+  ecl_kw_free( dimens_kw );
+}
+
+
+static void ecl_smspec_fwrite_STARTDAT(const ecl_smspec_type * smspec, fortio_type * fortio) {
+  ecl_kw_type * startdat_kw = ecl_kw_alloc( STARTDAT_KW , STARTDAT_SIZE , ECL_INT );
+  int day,month,year;
+  ecl_util_set_date_values( smspec->sim_start_time , &day, &month , &year);
+
+  ecl_kw_iset_int( startdat_kw , STARTDAT_DAY_INDEX   , day );
+  ecl_kw_iset_int( startdat_kw , STARTDAT_MONTH_INDEX , month );
+  ecl_kw_iset_int( startdat_kw , STARTDAT_YEAR_INDEX  , year );
+
+  ecl_kw_fwrite( startdat_kw , fortio );
+  ecl_kw_free( startdat_kw );
+}
 
 
 static void ecl_smspec_fortio_fwrite( const ecl_smspec_type * smspec , fortio_type * fortio) {
-  int num_nodes           = ecl_smspec_num_nodes( smspec );
-  {
-    ecl_kw_type * restart_kw = ecl_kw_alloc( RESTART_KW , SUMMARY_RESTART_SIZE , ECL_CHAR );
-    for (int i=0; i < SUMMARY_RESTART_SIZE; i++)
-           ecl_kw_iset_string8( restart_kw , i , "");
+  ecl_smspec_fwrite_INTEHEAD(smspec, fortio);
+  ecl_smspec_fwrite_RESTART(smspec, fortio);
+  ecl_smspec_fwrite_DIMENS(smspec, fortio);
 
-    if (smspec->restart_case != NULL) {
-       int restart_case_len = strlen(smspec->restart_case);
+  int num_nodes = ecl_smspec_num_nodes( smspec );
+  ecl_kw_type * keywords_kw = ecl_kw_alloc( KEYWORDS_KW , num_nodes , ECL_CHAR );
+  ecl_kw_type * units_kw    = ecl_kw_alloc( UNITS_KW    , num_nodes , ECL_CHAR );
+  ecl_kw_type * nums_kw     = NULL;
 
-       int offset = 0;
-       for (int i = 0; i < SUMMARY_RESTART_SIZE ; i++) {
-          if (offset < restart_case_len)
-              ecl_kw_iset_string8( restart_kw , i , &smspec->restart_case[ offset ]);
-          offset += ECL_STRING8_LENGTH;
-       }
-    }
+  // If the names_type is an ECL_STRING we expect this to be an INTERSECT
+  // summary, otherwise an ECLIPSE summary.
+  ecl_data_type names_type  = get_wgnames_type(smspec);
+  ecl_kw_type * wgnames_kw = ecl_kw_alloc( ecl_type_is_char(names_type) ? WGNAMES_KW : NAMES_KW,
+                                           num_nodes,
+                                           names_type );
 
-    ecl_kw_fwrite( restart_kw , fortio );
-    ecl_kw_free( restart_kw );
-  }
-  {
-    ecl_kw_type * dimens_kw = ecl_kw_alloc( DIMENS_KW , DIMENS_SIZE , ECL_INT );
-    ecl_kw_iset_int( dimens_kw , DIMENS_SMSPEC_SIZE_INDEX , num_nodes );
-    ecl_kw_iset_int( dimens_kw , DIMENS_SMSPEC_NX_INDEX   , smspec->grid_dims[0] );
-    ecl_kw_iset_int( dimens_kw , DIMENS_SMSPEC_NY_INDEX   , smspec->grid_dims[1] );
-    ecl_kw_iset_int( dimens_kw , DIMENS_SMSPEC_NZ_INDEX   , smspec->grid_dims[2] );
+  if (smspec->need_nums)
+    nums_kw = ecl_kw_alloc( NUMS_KW , num_nodes , ECL_INT);
 
-    /* Do not know what these two last items are for. */
-    ecl_kw_iset_int( dimens_kw , 4  , 0 );
-    ecl_kw_iset_int( dimens_kw , 5 , -1 );
+  for (int i=0; i < ecl_smspec_num_nodes( smspec ); i++) {
+    const smspec_node_type * smspec_node = ecl_smspec_iget_node( smspec , i );
+    /*
+      It is possible to add variables with deferred initialisation
+      with the ecl_sum_add_blank_var() function. Before these
+      variables can be actually used for anything interesting they
+      must be initialized with the ecl_sum_init_var() function.
 
-    ecl_kw_fwrite( dimens_kw , fortio );
-    ecl_kw_free( dimens_kw );
-  }
+      If a call to save the smspec file comes before all the
+      variable have been initialized things will potentially go
+      belly up. This is solved with the following uber-hack:
 
+      o One of the well related keywords is chosen; in
+        particular 'WWCT' in this case.
 
-  {
-    ecl_kw_type * keywords_kw = ecl_kw_alloc( KEYWORDS_KW , num_nodes , ECL_CHAR );
-    ecl_kw_type * units_kw    = ecl_kw_alloc( UNITS_KW    , num_nodes , ECL_CHAR );
-    ecl_kw_type * nums_kw     = NULL;
+      o The wgname value is set to DUMMY_WELL
 
-    // If the names_type is an ECL_STRING we expect this to be an INTERSECT
-    // summary, otherwise an ECLIPSE summary.
-    ecl_data_type names_type  = get_wgnames_type(smspec);
-    ecl_kw_type * wgnames_kw = ecl_kw_alloc(
-                ecl_type_is_char(names_type) ? WGNAMES_KW : NAMES_KW,
-                num_nodes,
-                names_type
-            );
-
-    if (smspec->need_nums)
-      nums_kw = ecl_kw_alloc( NUMS_KW , num_nodes , ECL_INT);
-    {
-      int i;
-      for (i=0; i < ecl_smspec_num_nodes( smspec ); i++) {
-        const smspec_node_type * smspec_node = ecl_smspec_iget_node( smspec , i );
-        /*
-          It is possible to add variables with deferred initialisation
-          with the ecl_sum_add_blank_var() function. Before these
-          variables can be actually used for anything interesting they
-          must be initialized with the ecl_sum_init_var() function.
-
-          If a call to save the smspec file comes before all the
-          variable have been initialized things will potentially go
-          belly up. This is solved with the following uber-hack:
-
-            o One of the well related keywords is chosen; in
-              particular 'WWCT' in this case.
-
-            o The wgname value is set to DUMMY_WELL
-
-          The use of DUMMY_WELL ensures that this field will be
-          ignored when/if this smspec file is read in at a later
-          stage.
-        */
-        if (smspec_node_get_var_type( smspec_node ) == ECL_SMSPEC_INVALID_VAR) {
-          ecl_kw_iset_string8( keywords_kw , i , "WWCT" );
-          ecl_kw_iset_string8( units_kw , i , "????????");
-          ecl_kw_iset_string_ptr( wgnames_kw , i , DUMMY_WELL);
-        } else {
-          ecl_kw_iset_string8( keywords_kw , i , smspec_node_get_keyword( smspec_node ));
-          ecl_kw_iset_string8( units_kw , i , smspec_node_get_unit( smspec_node ));
-          {
-            const char * wgname = DUMMY_WELL;
-            if (smspec_node_get_wgname( smspec_node ))
-              wgname = smspec_node_get_wgname( smspec_node );
-            ecl_kw_iset_string_ptr( wgnames_kw , i , wgname);
-          }
-        }
-
-        if (nums_kw != NULL)
-          ecl_kw_iset_int( nums_kw , i , smspec_node_get_num( smspec_node ));
+      The use of DUMMY_WELL ensures that this field will be
+      ignored when/if this smspec file is read in at a later
+      stage.
+    */
+    if (smspec_node_get_var_type( smspec_node ) == ECL_SMSPEC_INVALID_VAR) {
+      ecl_kw_iset_string8( keywords_kw , i , "WWCT" );
+      ecl_kw_iset_string8( units_kw , i , "????????");
+      ecl_kw_iset_string_ptr( wgnames_kw , i , DUMMY_WELL);
+    } else {
+      ecl_kw_iset_string8( keywords_kw , i , smspec_node_get_keyword( smspec_node ));
+      ecl_kw_iset_string8( units_kw , i , smspec_node_get_unit( smspec_node ));
+      {
+        const char * wgname = DUMMY_WELL;
+        if (smspec_node_get_wgname( smspec_node ))
+          wgname = smspec_node_get_wgname( smspec_node );
+        ecl_kw_iset_string_ptr( wgnames_kw , i , wgname);
       }
     }
 
-
-    ecl_kw_fwrite( keywords_kw , fortio );
-    ecl_kw_fwrite( wgnames_kw , fortio );
     if (nums_kw != NULL)
-      ecl_kw_fwrite( nums_kw , fortio );
-    ecl_kw_fwrite( units_kw , fortio );
-
-
-    ecl_kw_free( keywords_kw );
-    ecl_kw_free( wgnames_kw );
-    ecl_kw_free( units_kw );
-    if (nums_kw != NULL)
-      ecl_kw_free( nums_kw );
+      ecl_kw_iset_int( nums_kw , i , smspec_node_get_num( smspec_node ));
   }
+  ecl_kw_fwrite( keywords_kw , fortio );
+  ecl_kw_fwrite( wgnames_kw , fortio );
+  if (nums_kw != NULL)
+    ecl_kw_fwrite( nums_kw , fortio );
+  ecl_kw_fwrite( units_kw , fortio );
 
-  {
-    ecl_kw_type * startdat_kw = ecl_kw_alloc( STARTDAT_KW , STARTDAT_SIZE , ECL_INT );
-    int day,month,year;
-    ecl_util_set_date_values( smspec->sim_start_time , &day, &month , &year);
+  ecl_kw_free( keywords_kw );
+  ecl_kw_free( wgnames_kw );
+  ecl_kw_free( units_kw );
+  if (nums_kw != NULL)
+    ecl_kw_free( nums_kw );
 
-    ecl_kw_iset_int( startdat_kw , STARTDAT_DAY_INDEX   , day );
-    ecl_kw_iset_int( startdat_kw , STARTDAT_MONTH_INDEX , month );
-    ecl_kw_iset_int( startdat_kw , STARTDAT_YEAR_INDEX  , year );
-
-    ecl_kw_fwrite( startdat_kw , fortio );
-    ecl_kw_free( startdat_kw );
-  }
+  ecl_smspec_fwrite_STARTDAT(smspec, fortio);
 }
 
 

--- a/lib/ecl/ecl_sum.c
+++ b/lib/ecl/ecl_sum.c
@@ -1386,3 +1386,8 @@ time_t_vector_type * ecl_sum_alloc_time_solution( const ecl_sum_type * ecl_sum ,
   }
   return solution;
 }
+
+
+ert_ecl_unit_enum ecl_sum_get_unit_system(const ecl_sum_type * ecl_sum) {
+  return ecl_smspec_get_unit_system(ecl_sum->smspec);
+}

--- a/lib/ecl/tests/ecl_sum_writer.c
+++ b/lib/ecl/tests/ecl_sum_writer.c
@@ -157,10 +157,10 @@ void test_ecl_sum_alloc_restart_writer() {
       ecl_file_type * restart_file = ecl_file_open( "CASE2.SMSPEC" , 0 );
       ecl_file_view_type * view_file = ecl_file_get_global_view( restart_file );
       test_assert_true( ecl_file_view_has_kw(view_file, RESTART_KW));
-      ecl_kw_type * kw = ecl_file_view_iget_kw(view_file, 0);
-      test_assert_int_equal(8, ecl_kw_get_size(kw));
-      test_assert_string_equal( "CASE1   ", ecl_kw_iget_ptr( kw , 0 ) );
-      test_assert_string_equal( "        ", ecl_kw_iget_ptr( kw , 1 ) );
+      ecl_kw_type * restart_kw = ecl_file_view_iget_named_kw(view_file, "RESTART", 0);
+      test_assert_int_equal(8, ecl_kw_get_size(restart_kw));
+      test_assert_string_equal( "CASE1   ", ecl_kw_iget_ptr( restart_kw , 0 ) );
+      test_assert_string_equal( "        ", ecl_kw_iget_ptr( restart_kw , 1 ) );
 
       for (int time_index=0; time_index < ecl_sum_get_data_length( case1 ); time_index++)
          test_assert_double_equal(  ecl_sum_get_general_var( case1 , time_index , "FOPT"), ecl_sum_get_general_var( case2 , time_index , "FOPT"));
@@ -192,12 +192,12 @@ void test_long_restart_names() {
        ecl_file_type * smspec_file = ecl_file_open( "THE_CASE.SMSPEC" , 0 );
        ecl_file_view_type * view_file = ecl_file_get_global_view( smspec_file );
        test_assert_true( ecl_file_view_has_kw(view_file, RESTART_KW));
-       ecl_kw_type * kw = ecl_file_view_iget_kw(view_file, 0);
-       test_assert_int_equal(8, ecl_kw_get_size(kw));
+       ecl_kw_type * restart_kw = ecl_file_view_iget_named_kw(view_file, "RESTART", 0);
+       test_assert_int_equal(8, ecl_kw_get_size(restart_kw));
 
        for (int n = 0; n < 8; n++) {
          char s[9]; sprintf(s, "WWWWGGG%d", n);
-         test_assert_string_equal(s, ecl_kw_iget_char_ptr(kw, n) );
+         test_assert_string_equal(s, ecl_kw_iget_char_ptr(restart_kw, n) );
        }
        {
          ecl_smspec_type * smspec = ecl_smspec_alloc_writer( ":" , "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ", start_time, true, 3, 3 ,3);

--- a/lib/include/ert/ecl/ecl_kw_magic.h
+++ b/lib/include/ert/ecl/ecl_kw_magic.h
@@ -459,7 +459,9 @@ values (2e20) are denoted with '*'.
 #define DIMENS_SMSPEC_NZ_INDEX      3
 #define DIMENS_SIZE                 6   // Do not know what the two last items are?
 
+#define INTEHEAD_SMSPEC_IPROG_INDEX 0
 #define INTEHEAD_SMSPEC_UNIT_INDEX  1
+#define INTEHEAD_SMSPEC_SIZE        2
 
 /* Summary data files: */
 #define SEQHDR_KW    "SEQHDR"      // Contains a single 'magic' integer - not used in libecl.

--- a/lib/include/ert/ecl/ecl_kw_magic.h
+++ b/lib/include/ert/ecl/ecl_kw_magic.h
@@ -453,13 +453,13 @@ values (2e20) are denoted with '*'.
    keyword in the SMSPEC files. Observe that these magic indices
    differ from the magic indices used to look up grid dimensions from
    the DIMENS keyword in GRID files.  */
-#define DIMENS_SMSPEC_SIZE_INDEX      0
-#define DIMENS_SMSPEC_NX_INDEX 1
-#define DIMENS_SMSPEC_NY_INDEX 2
-#define DIMENS_SMSPEC_NZ_INDEX 3
+#define DIMENS_SMSPEC_SIZE_INDEX    0
+#define DIMENS_SMSPEC_NX_INDEX      1
+#define DIMENS_SMSPEC_NY_INDEX      2
+#define DIMENS_SMSPEC_NZ_INDEX      3
+#define DIMENS_SIZE                 6   // Do not know what the two last items are?
 
-#define DIMENS_SIZE            6   // Do not know what the two last items are?
-
+#define INTEHEAD_SMSPEC_UNIT_INDEX  1
 
 /* Summary data files: */
 #define SEQHDR_KW    "SEQHDR"      // Contains a single 'magic' integer - not used in libecl.

--- a/lib/include/ert/ecl/ecl_smspec.h
+++ b/lib/include/ert/ecl/ecl_smspec.h
@@ -29,6 +29,7 @@ extern "C" {
 #include <ert/util/float_vector.h>
 #include <ert/util/stringlist.h>
 
+#include <ert/ecl/ecl_util.h>
 #include <ert/ecl/smspec_node.h>
 
 typedef struct ecl_smspec_struct ecl_smspec_type;
@@ -145,6 +146,7 @@ typedef struct ecl_smspec_struct ecl_smspec_type;
   bool                       ecl_smspec_equal( const ecl_smspec_type * self , const ecl_smspec_type * other);
 
   void                       ecl_smspec_sort( ecl_smspec_type * smspec );
+  ert_ecl_unit_enum          ecl_smspec_get_unit_system(const ecl_smspec_type * smspec);
 
 #ifdef __cplusplus
 }

--- a/lib/include/ert/ecl/ecl_util.h
+++ b/lib/include/ert/ecl/ecl_util.h
@@ -96,7 +96,6 @@ typedef enum {
 #define ECL_PHASE_ENUM_DEFS {.value = 1 , .name = "ECL_OIL_PHASE"}, {.value = 2 , .name = "ECL_GAS_PHASE"} , {.value = 4 , .name = "ECL_WATER_PHASE"}
 #define ECL_PHASE_ENUM_SIZE 3
 
-
 typedef enum {
   ECL_METRIC_UNITS = 1,
   ECL_FIELD_UNITS  = 2,

--- a/python/ecl/summary/ecl_sum.py
+++ b/python/ecl/summary/ecl_sum.py
@@ -39,7 +39,7 @@ from ecl.summary import EclSumTStep
 from ecl.summary import EclSumVarType
 from ecl.summary.ecl_sum_vector import EclSumVector
 from ecl.summary.ecl_smspec_node import EclSMSPECNode
-from ecl import EclPrototype
+from ecl import EclPrototype, EclUnitTypeEnum
 #, EclSumKeyWordVector
 
 
@@ -122,6 +122,7 @@ class EclSum(BaseCClass):
     _get_unit                      = EclPrototype("char*    ecl_sum_get_unit(ecl_sum, char*)")
     _get_restart_case              = EclPrototype("char*    ecl_sum_get_restart_case(ecl_sum)")
     _get_simcase                   = EclPrototype("char*    ecl_sum_get_case(ecl_sum)")
+    _get_unit_system               = EclPrototype("ecl_unit_enum ecl_sum_get_unit_system(ecl_sum)")
     _get_base                      = EclPrototype("char*    ecl_sum_get_base(ecl_sum)")
     _get_path                      = EclPrototype("char*    ecl_sum_get_path(ecl_sum)")
     _get_abs_path                  = EclPrototype("char*    ecl_sum_get_abs_path(ecl_sum)")
@@ -759,6 +760,13 @@ class EclSum(BaseCClass):
         node = self.smspec_node(key)
         return node.unit
 
+
+    @property
+    def unit_system(self):
+        """
+        Will return the unit system in use for this case.
+        """
+        return self._get_unit_system()
 
     @property
     def case(self):

--- a/python/tests/ecl_tests/test_sum.py
+++ b/python/tests/ecl_tests/test_sum.py
@@ -27,7 +27,7 @@ from unittest import skipIf, skipUnless, skipIf
 
 from ecl import EclUnitTypeEnum
 from ecl import EclDataType
-from ecl.eclfile import FortIO, openFortIO, EclKW
+from ecl.eclfile import FortIO, openFortIO, EclKW, EclFile
 from ecl.summary import EclSum, EclSumVarType, EclSumKeyWordVector
 from ecl.util.test import TestAreaContext
 from tests import EclTest
@@ -457,3 +457,28 @@ class SumTest(EclTest):
     def test_units(self):
         case = create_case()
         self.assertEqual(case.unit_system, EclUnitTypeEnum.ECL_METRIC_UNITS)
+
+
+        # We do not really have support for writing anything else than the
+        # default MERIC unit system. To be able to test the read functionality
+        # we therefor monkey-patch the summary files in place.
+        with TestAreaContext("unit_test"):
+            case = create_case("UNITS")
+            case.fwrite()
+            case2 = EclSum("UNITS")
+
+            kw_list = []
+            f = EclFile("UNITS.SMSPEC")
+            for kw in f:
+                if kw.name == "INTEHEAD":
+                    kw[1] = 3
+                kw_list.append(kw.copy())
+
+            f.close()
+            with openFortIO("UNITS.SMSPEC", mode = FortIO.WRITE_MODE) as f:
+                for kw in kw_list:
+                    kw.fwrite(f)
+
+
+            case = EclSum("UNITS")
+            self.assertEqual(case.unit_system, EclUnitTypeEnum.ECL_LAB_UNITS)

--- a/python/tests/ecl_tests/test_sum.py
+++ b/python/tests/ecl_tests/test_sum.py
@@ -25,6 +25,7 @@ import stat
 from contextlib import contextmanager
 from unittest import skipIf, skipUnless, skipIf
 
+from ecl import EclUnitTypeEnum
 from ecl import EclDataType
 from ecl.eclfile import FortIO, openFortIO, EclKW
 from ecl.summary import EclSum, EclSumVarType, EclSumKeyWordVector
@@ -451,3 +452,8 @@ class SumTest(EclTest):
             pred = EclSum("PREDICTION")
 
             os.chmod("history", stat.S_IRWXU)
+
+
+    def test_units(self):
+        case = create_case()
+        self.assertEqual(case.unit_system, EclUnitTypeEnum.ECL_METRIC_UNITS)

--- a/python/tests/ecl_tests/test_sum_statoil.py
+++ b/python/tests/ecl_tests/test_sum_statoil.py
@@ -21,6 +21,7 @@ from unittest import skipIf, skipUnless, skipIf
 
 from ecl.eclfile import EclFile
 from ecl.summary import EclSum
+from ecl import EclUnitTypeEnum
 
 from ecl.util.util import StringList, TimeVector, DoubleVector, CTime
 
@@ -525,3 +526,7 @@ class SumTest(EclTest):
         for key in keys:
             for time_index,t in enumerate(time_points):
                 self.assertFloatEqual(resampled.iget( key, time_index), self.ecl_sum.get_interp_direct( key, t))
+
+
+    def test_summary_units(self):
+        self.assertEqual(self.ecl_sum.unit_system, EclUnitTypeEnum.ECL_METRIC_UNITS)


### PR DESCRIPTION
Internalize an ID for the unit system used when loading summary files.

Feature requested by web portal.

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
