### PR TITLE
Ecl grid export cells

### DIFF
--- a/lib/ecl/ecl_grid.c
+++ b/lib/ecl/ecl_grid.c
@@ -4751,6 +4751,17 @@ void ecl_grid_get_cell_corner_xyz1(const ecl_grid_type * grid , int global_index
 }
 
 
+void ecl_grid_export_cell_corners1(const ecl_grid_type * grid, int global_index, double *x, double *y, double *z) {
+  const ecl_cell_type * cell = ecl_grid_get_cell(grid, global_index);
+  for (int i=0; i<8; i++) {
+    const point_type point = cell->corner_list[i];
+    x[i] = point.x;
+    y[i] = point.y;
+    z[i] = point.z;
+  }
+}
+
+
 void ecl_grid_get_cell_corner_xyz3(const ecl_grid_type * grid , int i , int j , int k, int corner_nr , double * xpos , double * ypos , double * zpos ) {
   const int global_index = ecl_grid_get_global_index__(grid , i , j , k );
   ecl_grid_get_cell_corner_xyz1( grid , global_index , corner_nr , xpos , ypos , zpos);

--- a/lib/ecl/tests/ecl_grid_corner.c
+++ b/lib/ecl/tests/ecl_grid_corner.c
@@ -40,6 +40,9 @@ void test_invalid( ecl_grid_type * grid) {
 
 void test_OK( const ecl_grid_type * grid) {
   double x,y,z;
+  double x8[8];
+  double y8[8];
+  double z8[8];
 
   ecl_grid_get_corner_xyz( grid , 0,0,0,&x,&y,&z);
   test_assert_double_equal( x,0 );
@@ -55,6 +58,14 @@ void test_OK( const ecl_grid_type * grid) {
   test_assert_double_equal( x,10 );
   test_assert_double_equal( y,10 );
   test_assert_double_equal( z,10 );
+
+  ecl_grid_export_cell_corners1(grid, 456, x8, y8, z8);
+  for (int i=0; i < 8; i++) {
+    ecl_grid_get_cell_corner_xyz1(grid, 456, i, &x,&y,&z);
+    test_assert_double_equal(x,x8[i]);
+    test_assert_double_equal(y,y8[i]);
+    test_assert_double_equal(z,z8[i]);
+  }
 }
 
 

--- a/lib/ecl/tests/ecl_grid_corner.c
+++ b/lib/ecl/tests/ecl_grid_corner.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2014  Statoil ASA, Norway. 
-    
-   The file 'ecl_grid_corner.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2014  Statoil ASA, Norway.
+
+   The file 'ecl_grid_corner.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 #include <stdlib.h>
 #include <stdbool.h>
@@ -40,7 +40,7 @@ void test_invalid( ecl_grid_type * grid) {
 
 void test_OK( const ecl_grid_type * grid) {
   double x,y,z;
-  
+
   ecl_grid_get_corner_xyz( grid , 0,0,0,&x,&y,&z);
   test_assert_double_equal( x,0 );
   test_assert_double_equal( y,0 );
@@ -65,7 +65,7 @@ int main( int argc , char ** argv) {
 
   test_invalid( grid );
   test_OK(grid);
-  
+
   ecl_grid_free( grid );
   exit(0);
 }

--- a/lib/include/ert/ecl/ecl_grid.h
+++ b/lib/include/ert/ecl/ecl_grid.h
@@ -254,6 +254,7 @@ extern "C" {
   void ecl_grid_reset_actnum( ecl_grid_type * grid , const int * actnum );
   void ecl_grid_compressed_kw_copy( const ecl_grid_type * grid , ecl_kw_type * target_kw , const ecl_kw_type * src_kw);
   void ecl_grid_global_kw_copy( const ecl_grid_type * grid , ecl_kw_type * target_kw , const ecl_kw_type * src_kw);
+  void ecl_grid_export_cell_corners1(const ecl_grid_type * grid, int global_index, double *x, double *y, double *z);
 
   UTIL_IS_INSTANCE_HEADER( ecl_grid );
   UTIL_SAFE_CAST_HEADER( ecl_grid );


### PR DESCRIPTION
**Task**
Small utility function for fast export of all coordinates of a cell.

