### PR TITLE
bump packaging versions to 2018.04-rc1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-ecl (2017.09-test1-1~xenial) xenial; urgency=low
+ecl (2018.04-rc1-1~xenial) xenial; urgency=low
 
   * New release
 

--- a/redhat/ecl.spec
+++ b/redhat/ecl.spec
@@ -5,7 +5,7 @@
 %define tag rc1
 
 Name:           ecl
-Version:        2017.10
+Version:        2018.04
 Release:        0
 Summary:        ECL library
 License:        GPL-3+


### PR DESCRIPTION
**Task**
Bump packaging versions for 2018.04 release candidate 1


**Approach**
Keyboard utilized to operate vim in order to change version numbers.


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally

Bag and tag as release/2018.04/rc1 please