### PR TITLE
Using buffer for input & output

### DIFF
--- a/lib/ecl/ecl_file_kw.c
+++ b/lib/ecl/ecl_file_kw.c
@@ -363,11 +363,11 @@ void ecl_file_kw_fwrite( const ecl_file_kw_type * file_kw , FILE * stream ) {
   util_fwrite_int( file_kw->kw_size , stream );
   util_fwrite_offset( file_kw->file_offset , stream );
   util_fwrite_int( ecl_type_get_type( file_kw->data_type ) , stream );
-  util_fwrite_size_t( ecl_type_get_sizeof_ctype_fortio( file_kw->data_type ) , stream );
+  util_fwrite_size_t( ecl_type_get_sizeof_iotype( file_kw->data_type ) , stream );
 }
 
 ecl_file_kw_type ** ecl_file_kw_fread_alloc_multiple( FILE * stream , int num) {
-  
+
   size_t file_kw_size = ECL_STRING8_LENGTH + 2 * sizeof(int) + sizeof(offset_type) + sizeof(size_t);
   size_t buffer_size = num * file_kw_size;
   char * buffer = util_malloc( buffer_size * sizeof * buffer );

--- a/lib/ecl/ecl_file_view.c
+++ b/lib/ecl/ecl_file_view.c
@@ -169,7 +169,7 @@ ecl_kw_type * ecl_file_view_iget_kw( const ecl_file_view_type * ecl_file_view , 
   return ecl_file_view_get_kw(ecl_file_view, file_kw);
 }
 
-void ecl_file_view_index_fload_kw(const ecl_file_view_type * ecl_file_view, const char* kw, int index, const int_vector_type * index_map, char* buffer) {
+void ecl_file_view_index_fload_kw(const ecl_file_view_type * ecl_file_view, const char* kw, int index, const int_vector_type * index_map, char* io_buffer) {
     ecl_file_kw_type * file_kw = ecl_file_view_iget_named_file_kw( ecl_file_view , kw , index);
 
     if (fortio_assert_stream_open( ecl_file_view->fortio )) {
@@ -177,7 +177,7 @@ void ecl_file_view_index_fload_kw(const ecl_file_view_type * ecl_file_view, cons
         ecl_data_type data_type = ecl_file_kw_get_data_type(file_kw);
         int element_count = ecl_file_kw_get_size(file_kw);
 
-        ecl_kw_fread_indexed_data(ecl_file_view->fortio, offset + ECL_KW_HEADER_FORTIO_SIZE, data_type, element_count, index_map, buffer);
+        ecl_kw_fread_indexed_data(ecl_file_view->fortio, offset + ECL_KW_HEADER_FORTIO_SIZE, data_type, element_count, index_map, io_buffer);
     }
 }
 

--- a/lib/ecl/ecl_type.c
+++ b/lib/ecl/ecl_type.c
@@ -37,7 +37,7 @@
 static char * alloc_string_name(const ecl_data_type ecl_type) {
   return util_alloc_sprintf(
           "C%03d",
-          ecl_type_get_sizeof_ctype_fortio(ecl_type)
+          ecl_type_get_sizeof_iotype(ecl_type)
           );
 }
 
@@ -64,11 +64,11 @@ ecl_data_type ecl_type_create(const ecl_type_enum type, const size_t element_siz
                                 ecl_type_create_from_type(type)
                             );
 
-  if(ecl_type_get_sizeof_ctype_fortio(ecl_type) != element_size)
+  if(ecl_type_get_sizeof_iotype(ecl_type) != element_size)
       util_abort(
               "%s: element_size mismatch for type %d, was: %d, expected: %d\n",
               __func__, type,
-              element_size, ecl_type_get_sizeof_ctype_fortio(ecl_type)
+              element_size, ecl_type_get_sizeof_iotype(ecl_type)
               );
 
   return ecl_type;
@@ -146,16 +146,24 @@ ecl_data_type ecl_type_create_from_name( const char * type_name ) {
 }
 
 
-int ecl_type_get_sizeof_ctype_fortio(const ecl_data_type ecl_type) {
-  if(ecl_type_is_char(ecl_type) || ecl_type_is_string(ecl_type))
-      return ecl_type.element_size - 1;
-  else
-      return ecl_type_get_sizeof_ctype(ecl_type);
-}
-
 int ecl_type_get_sizeof_ctype(const ecl_data_type ecl_type) {
   return ecl_type.element_size;
 }
+
+
+int ecl_type_get_sizeof_iotype(const ecl_data_type ecl_type) {
+  if (ecl_type_is_bool(ecl_type))
+    return sizeof(int);
+
+  if (ecl_type_is_char(ecl_type))
+    return ecl_type.element_size -1;
+
+  if (ecl_type_is_string(ecl_type))
+    return ecl_type.element_size - 1;
+
+  return ecl_type.element_size;
+}
+
 
 bool ecl_type_is_numeric(const ecl_data_type ecl_type) {
   return (ecl_type_is_int(ecl_type) ||

--- a/lib/ecl/ecl_type_python.c
+++ b/lib/ecl/ecl_type_python.c
@@ -40,9 +40,11 @@ const char * ecl_type_alloc_name_python(const ecl_data_type * ecl_type) {
     return ecl_type_alloc_name(*ecl_type);
 }
 
-int ecl_type_get_sizeof_ctype_fortio_python(const ecl_data_type * ecl_type) {
-    return ecl_type_get_sizeof_ctype_fortio(*ecl_type);
+
+int ecl_type_get_sizeof_iotype_python(const ecl_data_type * ecl_type) {
+  return ecl_type_get_sizeof_iotype(*ecl_type);
 }
+
 
 int ecl_type_get_sizeof_ctype_python(const ecl_data_type * ecl_type) {
     return ecl_type_get_sizeof_ctype(*ecl_type);

--- a/lib/ecl/tests/ecl_kw_init.c
+++ b/lib/ecl/tests/ecl_kw_init.c
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
+#include <ert/util/bool_vector.h>
 #include <ert/util/test_util.h>
 #include <ert/util/util.h>
 
@@ -57,9 +58,29 @@ void test_float() {
 }
 
 
+void test_bool() {
+  size_t N = 100;
+  bool * data = util_malloc(N * sizeof * data);
+  ecl_kw_type * kw = ecl_kw_alloc("BOOL", N , ECL_BOOL);
+  for (int i=0; i < N/2; i++) {
+    ecl_kw_iset_bool(kw, 2*i, true);
+    ecl_kw_iset_bool(kw, 2*i + 1, false);
+
+    data[2*i] = true;
+    data[2*i + 1] = false;
+  }
+
+  const bool * internal_data = ecl_kw_get_bool_ptr(kw);
+
+  test_assert_int_equal( memcmp(internal_data, data, N * sizeof * data), 0);
+  ecl_kw_free(kw);
+  free(data);
+}
+
 int main( int argc , char ** argv) {
   test_int();
   test_double();
   test_float();
+  test_bool();
   exit(0);
 }

--- a/lib/include/ert/ecl/ecl_kw.h
+++ b/lib/include/ert/ecl/ecl_kw.h
@@ -72,7 +72,6 @@ extern "C" {
   void           ecl_kw_fwrite_data(const ecl_kw_type *_ecl_kw , fortio_type *fortio);
   bool           ecl_kw_fread_realloc_data(ecl_kw_type *ecl_kw, fortio_type *fortio);
   ecl_data_type  ecl_kw_get_data_type(const ecl_kw_type *);
-  size_t         ecl_kw_get_sizeof_ctype(const ecl_kw_type *);
   const char   * ecl_kw_get_header8(const ecl_kw_type *);
   const char   * ecl_kw_get_header(const ecl_kw_type * ecl_kw );
   ecl_kw_type  * ecl_kw_alloc_empty(void);

--- a/lib/include/ert/ecl/ecl_type.h
+++ b/lib/include/ert/ecl/ecl_type.h
@@ -81,7 +81,7 @@ struct ecl_type_struct {
 #define ECL_INT ecl_data_type{ ECL_INT_TYPE, sizeof(int)}
 #define ECL_FLOAT ecl_data_type{ ECL_FLOAT_TYPE, sizeof(float)}
 #define ECL_DOUBLE ecl_data_type{ ECL_DOUBLE_TYPE, sizeof(double)}
-#define ECL_BOOL ecl_data_type{ ECL_BOOL_TYPE, sizeof(int)}
+#define ECL_BOOL ecl_data_type{ ECL_BOOL_TYPE, sizeof(bool)}
 #define ECL_CHAR ecl_data_type{ ECL_CHAR_TYPE, ECL_STRING8_LENGTH + 1}
 #define ECL_MESS ecl_data_type{ ECL_MESS_TYPE, 0}
 #define ECL_STRING(size) ecl_data_type{ECL_STRING_TYPE, (size) + 1}
@@ -94,7 +94,7 @@ struct ecl_type_struct {
 #define ECL_INT (ecl_data_type) {.type = ECL_INT_TYPE, .element_size = sizeof(int)}
 #define ECL_FLOAT (ecl_data_type) {.type = ECL_FLOAT_TYPE, .element_size = sizeof(float)}
 #define ECL_DOUBLE (ecl_data_type) {.type = ECL_DOUBLE_TYPE, .element_size = sizeof(double)}
-#define ECL_BOOL (ecl_data_type) {.type = ECL_BOOL_TYPE, .element_size = sizeof(int)}
+#define ECL_BOOL (ecl_data_type) {.type = ECL_BOOL_TYPE, .element_size = sizeof(bool)}
 #define ECL_MESS (ecl_data_type) {.type = ECL_MESS_TYPE, .element_size = 0}
 #define ECL_STRING(size) (ecl_data_type) {.type = ECL_STRING_TYPE, .element_size = (size) + 1}
 
@@ -114,7 +114,7 @@ ecl_type_enum      ecl_type_get_type(const ecl_data_type);
 char *             ecl_type_alloc_name(const ecl_data_type);
 
 int                ecl_type_get_sizeof_ctype(const ecl_data_type);
-int                ecl_type_get_sizeof_ctype_fortio(const ecl_data_type);
+int                ecl_type_get_sizeof_iotype(const ecl_data_type);
 
 bool               ecl_type_is_equal(const ecl_data_type, const ecl_data_type);
 

--- a/python/ecl/ecl_type.py
+++ b/python/ecl/ecl_type.py
@@ -46,7 +46,7 @@ class EclDataType(BaseCClass):
     _alloc_from_name  = EclPrototype("void* ecl_type_alloc_from_name_python(char*)", bind=False)
     _free             = EclPrototype("void ecl_type_free_python(ecl_data_type)")
     _get_type         = EclPrototype("ecl_type_enum ecl_type_get_type_python(ecl_data_type)")
-    _get_element_size = EclPrototype("size_t ecl_type_get_sizeof_ctype_fortio_python(ecl_data_type)")
+    _get_element_size = EclPrototype("size_t ecl_type_get_sizeof_iotype_python(ecl_data_type)")
     _is_int           = EclPrototype("bool ecl_type_is_int_python(ecl_data_type)")
     _is_char          = EclPrototype("bool ecl_type_is_char_python(ecl_data_type)")
     _is_float         = EclPrototype("bool ecl_type_is_float_python(ecl_data_type)")

--- a/python/tests/ecl_tests/test_ecl_kw.py
+++ b/python/tests/ecl_tests/test_ecl_kw.py
@@ -79,10 +79,8 @@ class KWTest(EclTest):
         name1 = "file1.txt"
         name2 = "file2.txt"
         kw = EclKW("TEST", len(data), data_type)
-        i = 0
-        for d in data:
+        for (i,d) in enumerate(data):
             kw[i] = d
-            i += 1
 
         file1 = cwrap.open(name1, "w")
         kw.fprintf_data(file1, fmt)


### PR DESCRIPTION
The main motivation for this PR was to facilitate `operator[]` for boolean data; a side effect was a quite substantial refactoring of reading and writing of unformatted data.

Statoil tests: [x] 