### PR TITLE
Add unit string to EclSummary testing

### DIFF
--- a/python/ecl/util/test/ecl_mock/ecl_sum_mock.py
+++ b/python/ecl/util/test/ecl_mock/ecl_sum_mock.py
@@ -20,8 +20,8 @@ def createEclSum( case,
 
     ecl_sum = EclSum.restart_writer(case , restart_case, restart_step, sim_start , dims[0] , dims[1] , dims[2])
     var_list = []
-    for (kw,wgname,num) in keys:
-        var_list.append( ecl_sum.addVariable( kw , wgname = wgname , num = num) )
+    for (kw,wgname,num,unit) in keys:
+        var_list.append( ecl_sum.addVariable( kw , wgname = wgname , num = num, unit =unit) )
 
     # This is a bug! This should not be integer division, but tests are written
     # around that assumption.

--- a/python/tests/bin_tests/test_summary_resample.py
+++ b/python/tests/bin_tests/test_summary_resample.py
@@ -39,7 +39,7 @@ def fgpt(days):
 
 def create_case(num_mini_step = 10, case = "CSV"):
     length = 100
-    return createEclSum(case, [("FOPT", None , 0) , ("FOPR" , None , 0), ("FGPT" , None , 0)],
+    return createEclSum(case, [("FOPT", None , 0, "SM3") , ("FOPR" , None , 0, "SM3/DAY"), ("FGPT" , None , 0, "SM3")],
                         sim_length_days = length,
                         num_report_step = 10,
                         num_mini_step = num_mini_step,

--- a/python/tests/ecl_tests/test_sum.py
+++ b/python/tests/ecl_tests/test_sum.py
@@ -67,7 +67,7 @@ def fgpt(days):
 
 def create_case(case = "CSV", restart_case = None, restart_step = -1, data_start = None):
     length = 100
-    return createEclSum(case , [("FOPT", None , 0) , ("FOPR" , None , 0), ("FGPT" , None , 0)],
+    return createEclSum(case , [("FOPT", None , 0, "SM3") , ("FOPR" , None , 0, "SM3/DAY"), ("FGPT" , None , 0, "SM3")],
                         sim_length_days = length,
                         num_report_step = 10,
                         num_mini_step = 10,
@@ -82,12 +82,12 @@ class SumTest(EclTest):
 
 
     def test_mock(self):
-        case = createEclSum("CSV" , [("FOPT", None , 0) , ("FOPR" , None , 0)])
+        case = createEclSum("CSV" , [("FOPT", None , 0, "SM3") , ("FOPR" , None , 0, "SM3/DAY")])
         self.assertTrue("FOPT" in case)
         self.assertFalse("WWCT:OPX" in case)
 
     def test_TIME_special_case(self):
-        case = createEclSum("CSV" , [("FOPT", None , 0) , ("FOPR" , None , 0)])
+        case = createEclSum("CSV" , [("FOPT", None , 0, "SM3") , ("FOPR" , None , 0, "SM3/DAY")])
         keys = case.keys()
         self.assertEqual( len(keys) , 2 )
         self.assertIn( "FOPT" , keys )
@@ -107,10 +107,10 @@ class SumTest(EclTest):
         self.assertEqual( EclSum.varType( "WNEWTON") , EclSumVarType.ECL_SMSPEC_MISC_VAR )
         self.assertEqual( EclSum.varType( "AARQ:4") , EclSumVarType.ECL_SMSPEC_AQUIFER_VAR )
 
-        case = createEclSum("CSV" , [("FOPT", None , 0) ,
-                                     ("FOPR" , None , 0),
-                                     ("AARQ" , None , 10),
-                                    ("RGPT" , None  ,1)])
+        case = createEclSum("CSV" , [("FOPT", None , 0, "SM3") ,
+                                     ("FOPR" , None , 0, "SM3/DAY"),
+                                     ("AARQ" , None , 10, "???"),
+                                    ("RGPT" , None  ,1, "SM3")])
 
         node1 = case.smspec_node( "FOPT" )
         self.assertEqual( node1.varType( ) , EclSumVarType.ECL_SMSPEC_FIELD_VAR )
@@ -133,7 +133,7 @@ class SumTest(EclTest):
             a = node1 < 1
 
     def test_csv_export(self):
-        case = createEclSum("CSV" , [("FOPT", None , 0) , ("FOPR" , None , 0)])
+        case = createEclSum("CSV" , [("FOPT", None , 0, "SM3") , ("FOPR" , None , 0, "SM3/DAY")])
         sep = ";"
         with TestAreaContext("ecl/csv"):
             case.exportCSV( "file.csv" , sep = sep)
@@ -147,7 +147,7 @@ class SumTest(EclTest):
                 self.assertEqual( len(row) , 4 )
                 break
 
-
+            self.assertEqual(case.unit("FOPT"), "SM3")
 
         with TestAreaContext("ecl/csv"):
             case.exportCSV( "file.csv" , keys = ["FOPT"] , sep = sep)
@@ -270,6 +270,7 @@ class SumTest(EclTest):
 
             case2 = EclSum.load( "CSVX.SMSPEC" , "CSV.UNSMRY" )
             self.assert_solve( case2 )
+            self.assertEqual(case.unit("FOPR"), "SM3/DAY")
 
     def test_invalid(self):
         case = create_case()
@@ -300,7 +301,7 @@ class SumTest(EclTest):
 
     def test_kw_vector(self):
         case1 = create_case()
-        case2 = createEclSum("CSV" , [("FOPR", None , 0) , ("FOPT" , None , 0), ("FWPT" , None , 0)],
+        case2 = createEclSum("CSV" , [("FOPR", None , 0, "SM3/DAY") , ("FOPT" , None , 0, "SM3"), ("FWPT" , None , 0, "SM3")],
                              sim_length_days = 100,
                              num_report_step = 10,
                              num_mini_step = 10,


### PR DESCRIPTION
Add a unit string to the summary variables created with the `ecl_sum_mock` implementation.