### PR TITLE
Python3 tests not allowed to fail.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ env:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: PYTHON_VERSION=3.6
   exclude:
     - os: osx
       compiler: gcc


### PR DESCRIPTION
**Task**
Python3 tests not allowed to fail in python 3. 


**Approach**
Changed in travis.yml. 


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally

