### PR TITLE
Don't Declare readlinkat() Unless Needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,13 @@ try_compile( HAVE_PID_T   ${CMAKE_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/Tests/
 try_compile( HAVE_MODE_T  ${CMAKE_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/Tests/test_mode_t.c )
 try_compile( ERT_HAVE_ISFINITE ${CMAKE_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/Tests/test_isfinite.c)
 
+if (ERT_HAVE_READLINKAT)
+  try_compile( ERT_HAVE_READLINKAT_DECLARATION
+    ${CMAKE_BINARY_DIR}
+    ${PROJECT_SOURCE_DIR}/cmake/Tests/test_have_readlinkat_decl.c
+    )
+endif()
+
 set( BUILD_CXX ON )
 try_compile( HAVE_CXX_SHARED_PTR ${CMAKE_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/Tests/test_shared_ptr.cpp )
 if (NOT HAVE_CXX_SHARED_PTR)

--- a/cmake/Tests/test_have_readlinkat_decl.c
+++ b/cmake/Tests/test_have_readlinkat_decl.c
@@ -1,0 +1,17 @@
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <stdlib.h>
+
+#define NCHAR 63
+
+int main(int argc, char *argv[])
+{
+    char linkname[NCHAR + 1] = { 0 };
+    ssize_t r;
+
+    r = (argc < 2) ? -1
+        : readlinkat(1, argv[1], linkname, NCHAR);
+
+    return (r > 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/lib/ert_api_config.h.in
+++ b/lib/ert_api_config.h.in
@@ -7,6 +7,7 @@
 #cmakedefine ERT_HAVE_OPENDIR
 #cmakedefine ERT_HAVE_SYMLINK
 #cmakedefine ERT_HAVE_READLINKAT
+#cmakedefine ERT_HAVE_READLINKAT_DECLARATION
 #cmakedefine ERT_HAVE_GLOB
 #cmakedefine ERT_HAVE_GETUID
 #cmakedefine ERT_HAVE_REGEXP

--- a/lib/util/util_symlink.cpp
+++ b/lib/util/util_symlink.cpp
@@ -91,12 +91,14 @@ char * util_alloc_link_target(const char * link) {
 
 #ifdef ERT_HAVE_READLINKAT
 
+#if !defined(ERT_HAVE_READLINKAT_DECLARATION)
 /*
   The manual page says that the readlinkat() function should be in the
   unistd.h header file, but not on RedHat5. On RedHat6 it is.
 
 */
 extern ssize_t readlinkat (int __fd, __const char *__restrict __path, char *__restrict __buf, size_t __len);
+#endif  /* !defined(ERT_HAVE_READLINKAT_DECLARATION) */
 
 char * util_alloc_atlink_target(const char * path , const char * link) {
   if (util_is_abs_path( link ))


### PR DESCRIPTION
This commit makes the declaration of Posix function `readlinkat()` in `util_symlink.cpp` contingent on no declaration already being in scope (typically from `<unistd.h>`).  Implementations are allowed to
decorate system functions with additional--non-standard--properties (e.g., an exception specification) and there is usually no way of honouring such decorations in portable code.

Therefore this commit adds a simple compile check for `readlinkat()` from `<unistd.h>` and only declares the function if that compilation check fails.

**Task**
_Restore build of libecl on Ubuntu 16.04 LTS with GCC 5.4 and its associate C library implementation_


**Approach**
_Probe system during configuration (`cmake path/to/libecl`) for an existing declaration of Posix function `readlinkat()`&mdash;add local declaration if no such declaration exists._


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
