### PR TITLE
Require Pandas 0.17 instead of 0.20

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -4,7 +4,7 @@ set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/M
 include(init_python)
 init_python( 2.7 )
 
-find_python_package(pandas 0.20 ${PYTHON_INSTALL_PREFIX})
+find_python_package(pandas 0.17 ${PYTHON_INSTALL_PREFIX})
 if (NOT DEFINED PY_pandas)
    message(WARNING "Pandas module not found Python wrappers not enabled. Install with: \"pip install pandas\"")
    set( ENABLE_PYTHON OFF PARENT_SCOPE )


### PR DESCRIPTION
We don't actually need Pandas 0.20, so degrade it to 0.17.

I'm not sure that we want a _build requirement_ on Pandas at all, but that can possibly be removed later.