### PR TITLE
Smspec node not mutable

### DIFF
--- a/lib/ecl/ecl_sum.cpp
+++ b/lib/ecl/ecl_sum.cpp
@@ -277,14 +277,19 @@ void ecl_sum_set_fmt_case( ecl_sum_type * ecl_sum , bool fmt_case ) {
 }
 
 
-void ecl_sum_init_var( ecl_sum_type * ecl_sum , smspec_node_type * smspec_node , const char * keyword , const char * wgname , int num , const char * unit) {
-  ecl_smspec_init_var( ecl_sum->smspec , smspec_node , keyword , wgname , num, unit );
-}
 
 
 smspec_node_type * ecl_sum_add_var( ecl_sum_type * ecl_sum , const char * keyword , const char * wgname , int num , const char * unit , float default_value) {
-  smspec_node_type * smspec_node = ecl_sum_add_blank_var( ecl_sum , default_value );
-  ecl_sum_init_var( ecl_sum , smspec_node , keyword , wgname , num , unit );
+  smspec_node_type * smspec_node = smspec_node_alloc( ecl_smspec_identify_var_type(keyword),
+                                                      wgname,
+                                                      keyword,
+                                                      unit,
+                                                      ecl_sum->key_join_string,
+                                                      ecl_smspec_get_grid_dims(ecl_sum->smspec),
+                                                      num,
+                                                      -1,
+                                                      default_value);
+  ecl_smspec_add_node(ecl_sum->smspec, smspec_node);
   return smspec_node;
 }
 
@@ -298,11 +303,6 @@ smspec_node_type * ecl_sum_add_smspec_node(ecl_sum_type * ecl_sum, const smspec_
 }
 
 
-smspec_node_type * ecl_sum_add_blank_var( ecl_sum_type * ecl_sum , float default_value) {
-  smspec_node_type * smspec_node = smspec_node_alloc_new( -1 , default_value );
-  ecl_smspec_add_node( ecl_sum->smspec , smspec_node );
-  return smspec_node;
-}
 
 
 
@@ -776,9 +776,6 @@ ecl_sum_type * ecl_sum_alloc_resample(const ecl_sum_type * ecl_sum, const char *
   for (int i = 0; i < ecl_smspec_num_nodes(ecl_sum->smspec); i++) {
     const smspec_node_type * node = ecl_smspec_iget_node(ecl_sum->smspec, i);
     if (util_string_equal(smspec_node_get_gen_key1(node), "TIME"))
-      continue;
-
-    if (!smspec_node_is_valid(node))
       continue;
 
     ecl_sum_add_smspec_node(  ecl_sum_resampled, node );
@@ -1381,9 +1378,6 @@ const ecl_smspec_type * ecl_sum_get_smspec( const ecl_sum_type * ecl_sum ) {
   return ecl_sum->smspec;
 }
 
-void ecl_sum_update_wgname( ecl_sum_type * ecl_sum , smspec_node_type * node , const char * wgname ) {
-  ecl_smspec_update_wgname( ecl_sum->smspec ,node , wgname );
-}
 
 /*****************************************************************/
 

--- a/lib/ecl/ecl_sum_vector.cpp
+++ b/lib/ecl/ecl_sum_vector.cpp
@@ -69,9 +69,6 @@ ecl_sum_vector_type * ecl_sum_vector_alloc(const ecl_sum_type * ecl_sum, bool ad
       const ecl_smspec_type * smspec = ecl_sum_get_smspec(ecl_sum);
       for (int i=0; i < ecl_smspec_num_nodes(smspec); i++) {
         const smspec_node_type * node = ecl_smspec_iget_node( smspec , i );
-        if (!smspec_node_is_valid(node))
-          continue;
-
         const char * key = smspec_node_get_gen_key1(node);
         /*
           The TIME keyword is special case handled to not be included; that is

--- a/lib/ecl/tests/ecl_smspec_node.c
+++ b/lib/ecl/tests/ecl_smspec_node.c
@@ -57,10 +57,6 @@ void test_cmp_types() {
   test_assert_true( smspec_node_cmp( misc_node1, misc_node2) < 0 );
   test_assert_true( smspec_node_cmp( misc_node2, misc_node1) > 0 );
 
-  smspec_node_type * net1 = smspec_node_alloc(ECL_SMSPEC_NETWORK_VAR, "Net", "FOPT", "UNIT", ":", dims, 10 , 0, 0);
-  smspec_node_type * net2 = smspec_node_alloc(ECL_SMSPEC_NETWORK_VAR, "Net", "FOPT", "UNIT", ":", dims, 10 , 0, 0);
-  test_assert_true( smspec_node_cmp( net1, net2) == 0 );
-
   smspec_node_free( segment_node );
   smspec_node_free( aquifer_node );
   smspec_node_free( block_node );
@@ -70,8 +66,6 @@ void test_cmp_types() {
   smspec_node_free( field_node );
   smspec_node_free( misc_node1 );
   smspec_node_free( misc_node2 );
-  smspec_node_free( net1 );
-  smspec_node_free( net2 );
 }
 
 void test_cmp_well() {
@@ -82,6 +76,7 @@ void test_cmp_well() {
   smspec_node_type * well_node2_2 = smspec_node_alloc( ECL_SMSPEC_WELL_VAR , "W2" , "WWWT" , "UNIT" , ":" , dims , 10 , 0 , 0 );
   smspec_node_type * well_node_dummy = smspec_node_alloc( ECL_SMSPEC_WELL_VAR , DUMMY_WELL , "WOPR" , "UNIT" , ":" , dims , 10 , 0 , 0 );
 
+  test_assert_NULL( well_node_dummy);
   test_assert_int_equal( smspec_node_cmp( well_node1_1 , well_node1_1 ), 0);
   test_assert_int_equal( smspec_node_cmp( well_node2_2 , well_node2_2 ), 0);
 
@@ -92,15 +87,10 @@ void test_cmp_well() {
   test_assert_true( smspec_node_cmp( well_node1_2, well_node1_1) > 0 );
   test_assert_true( smspec_node_cmp( well_node1_2, well_node2_1) < 0 );
 
-  test_assert_true( smspec_node_cmp( well_node1_1, well_node_dummy) < 0 );
-  test_assert_false( smspec_node_is_valid( well_node_dummy ));
-  test_assert_true( smspec_node_is_valid( well_node1_1 ));
-
   smspec_node_free( well_node1_1 );
   smspec_node_free( well_node2_1 );
   smspec_node_free( well_node1_2 );
   smspec_node_free( well_node2_2 );
-  smspec_node_free( well_node_dummy );
 }
 
 

--- a/lib/include/ert/ecl/ecl_smspec.h
+++ b/lib/include/ert/ecl/ecl_smspec.h
@@ -137,7 +137,6 @@ typedef struct ecl_smspec_struct ecl_smspec_type;
   const char               * ecl_smspec_get_restart_case( const ecl_smspec_type * ecl_smspec);
   const char               * ecl_smspec_get_join_string( const ecl_smspec_type * smspec);
   const float_vector_type  * ecl_smspec_get_params_default( const ecl_smspec_type * ecl_smspec );
-  void                       ecl_smspec_update_wgname( ecl_smspec_type * smspec , smspec_node_type * node , const char * wgname );
 
   const int                * ecl_smspec_get_grid_dims( const ecl_smspec_type * smspec );
   int                        ecl_smspec_get_params_size( const ecl_smspec_type * smspec );

--- a/lib/include/ert/ecl/ecl_sum.h
+++ b/lib/include/ert/ecl/ecl_sum.h
@@ -243,16 +243,7 @@ typedef struct ecl_sum_struct       ecl_sum_type;
                                         int num ,
                                         const char * unit ,
                                         float default_value);
-  smspec_node_type    * ecl_sum_add_blank_var(ecl_sum_type * ecl_sum ,
-                                              float default_value);
-  void                  ecl_sum_init_var(ecl_sum_type * ecl_sum ,
-                                         smspec_node_type * smspec_node ,
-                                         const char * keyword ,
-                                         const char * wgname ,
-                                         int num ,
-                                         const char * unit);
   ecl_sum_tstep_type  * ecl_sum_add_tstep( ecl_sum_type * ecl_sum , int report_step , double sim_seconds);
-  void                  ecl_sum_update_wgname( ecl_sum_type * ecl_sum , smspec_node_type * node , const char * wgname );
 
   bool                  ecl_sum_is_oil_producer( const ecl_sum_type * ecl_sum , const char * well);
   char                * ecl_sum_alloc_well_key( const ecl_sum_type * ecl_sum , const char * keyword , const char * wgname);

--- a/lib/include/ert/ecl/smspec_node.h
+++ b/lib/include/ert/ecl/smspec_node.h
@@ -118,14 +118,12 @@ typedef enum {ECL_SMSPEC_INVALID_VAR            =  0 ,
   ecl_smspec_var_type smspec_node_get_var_type( const smspec_node_type * smspec_node);
   int                 smspec_node_get_num( const smspec_node_type * smspec_node);
   const char        * smspec_node_get_wgname( const smspec_node_type * smspec_node);
-  void                smspec_node_update_wgname( smspec_node_type * index , const char * wgname , const char * key_join_string);
   const char        * smspec_node_get_keyword( const smspec_node_type * smspec_node);
   const char        * smspec_node_get_unit( const smspec_node_type * smspec_node);
   void                smspec_node_set_unit( smspec_node_type * smspec_node , const char * unit );
   bool                smspec_node_is_rate( const smspec_node_type * smspec_node );
   bool                smspec_node_is_total( const smspec_node_type * smspec_node );
   bool                smspec_node_is_historical( const smspec_node_type * smspec_node );
-  bool                smspec_node_is_valid( const smspec_node_type * smspec_node );
   bool                smspec_node_need_nums( const smspec_node_type * smspec_node );
   void                smspec_node_fprintf( const smspec_node_type * smspec_node , FILE * stream);
 


### PR DESCRIPTION
Currently it is possible to add smspec_node to the summary object which is not properly initiialized; and then initialize it properly later. This flexibility comes with a significant cost in complexity and no real advantages - removing it.

Statoil/libres#315