### PR TITLE
Use data_type instead of deprecated EclType

### DIFF
--- a/python/ecl/eclfile/ecl_kw.py
+++ b/python/ecl/eclfile/ecl_kw.py
@@ -352,7 +352,7 @@ class EclKW(BaseCClass):
     def __repr__(self):
         si = len(self)
         nm = self.getName()
-        mm = 'type=%s' % str(self.getEclType())
+        mm = 'type=%s' % str(self.data_type)
         if self.isNumeric():
             mi, ma = self.getMinMax()
             mm = 'min=%.2f, max=%.2f' % (mi,ma)
@@ -968,7 +968,9 @@ class EclKW(BaseCClass):
 
     @property
     def type(self):
-        return self.getEclType()
+        warnings.warn("ecl_kw.type is deprecated, use .data_type",
+            DeprecationWarning)
+        return self._get_type()
 
     @property
     def data_type(self):
@@ -1190,7 +1192,7 @@ class EclKW(BaseCClass):
         if offset >= len(self):
             raise IndexError("Offset:%d invalid - size:%d" % (offset, len(self)))
 
-        if self.getEclType() != other.getEclType():
+        if self.data_type!= other.data_type:
             raise TypeError("The two keywords have different type")
 
         if abs_epsilon is None:

--- a/python/tests/ecl_tests/test_ecl_kw.py
+++ b/python/tests/ecl_tests/test_ecl_kw.py
@@ -72,8 +72,7 @@ class KWTest(EclTest):
 
             self.assertEqual(EclTypeEnum.ECL_INT_TYPE, kw.type)
 
-            self.assertTrue(len(w) > 0)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertTrue(len(w) == 1)
 
     def kw_test(self, data_type, data, fmt):
         name1 = "file1.txt"


### PR DESCRIPTION
**Task**
_Change `get_ecl_type` call to `data_type` - previous call is deprecated. Deprecated the `ecl_kw.type` function_

Fix #211 

**Pre un-WIP checklist**
- [x] Statoil tests pass locally
