### PR TITLE
Refactor ecl_sum_data

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -108,6 +108,7 @@ add_library(ecl util/rng.cpp
                 ecl/ecl_grav_calc.cpp
                 ecl/ecl_smspec.cpp
                 ecl/ecl_sum_data.cpp
+                ecl/ecl_sum_file_data.cpp
                 ecl/ecl_util.cpp
                 ecl/ecl_kw.cpp
                 ecl/ecl_sum.cpp
@@ -372,6 +373,10 @@ foreach (name   ecl_alloc_cpgrid
         target_link_libraries(${name} ecl)
         add_test(NAME ${name} COMMAND ${name})
 endforeach ()
+
+add_executable(ecl_sum_data_intermediate ecl/tests/ecl_sum_data_intermediate_test.cpp)
+target_link_libraries(ecl_sum_data_intermediate ecl)
+add_test(NAME ecl_sum_data_intermediate COMMAND ecl_sum_data_intermediate)
 
 add_executable(ecl_grid_cell_contains ecl/tests/ecl_grid_cell_contains.c)
 target_link_libraries(ecl_grid_cell_contains ecl)

--- a/lib/ecl/ecl_smspec.cpp
+++ b/lib/ecl/ecl_smspec.cpp
@@ -296,6 +296,14 @@ ecl_smspec_type * ecl_smspec_alloc_empty(bool write_mode , const char * key_join
 }
 
 
+int * ecl_smspec_alloc_self_mapping( const ecl_smspec_type * self ) {
+  int params_size = ecl_smspec_get_params_size( self );
+  int * mapping = (int*)util_malloc( params_size * sizeof * mapping );
+  for (int i = 0; i < ecl_smspec_get_params_size( self ); i++)
+    mapping[i] = i;
+  return mapping;
+}
+
 int * ecl_smspec_alloc_mapping( const ecl_smspec_type * self, const ecl_smspec_type * other) {
   int params_size = ecl_smspec_get_params_size( self );
   int * mapping = (int*)util_malloc( params_size * sizeof * mapping );

--- a/lib/ecl/ecl_sum.cpp
+++ b/lib/ecl/ecl_sum.cpp
@@ -290,6 +290,7 @@ smspec_node_type * ecl_sum_add_var( ecl_sum_type * ecl_sum , const char * keywor
                                                       -1,
                                                       default_value);
   ecl_smspec_add_node(ecl_sum->smspec, smspec_node);
+  ecl_sum_data_reset_self_map( ecl_sum->data );
   return smspec_node;
 }
 
@@ -755,7 +756,7 @@ const char * ecl_sum_get_general_var_unit( const ecl_sum_type * ecl_sum , const 
 ecl_sum_type * ecl_sum_alloc_resample(const ecl_sum_type * ecl_sum, const char * ecl_case, const time_t_vector_type * times) {
   time_t start_time = ecl_sum_get_data_start(ecl_sum);
 
-  if ( time_t_vector_get_first(times) < start_time )
+  if ( time_t_vector_get_first(times) < start_time ) 
     return NULL;
   if ( time_t_vector_get_last(times) > ecl_sum_get_end_time(ecl_sum) )
     return NULL;
@@ -770,7 +771,6 @@ ecl_sum_type * ecl_sum_alloc_resample(const ecl_sum_type * ecl_sum, const char *
     time_in_days = true;
 
   ecl_sum_type * ecl_sum_resampled = ecl_sum_alloc_writer( ecl_case , ecl_sum->fmt_case , ecl_sum->unified , ecl_sum->key_join_string , start_time , time_in_days , grid_dims[0] , grid_dims[1] , grid_dims[2] );
-
 
 
   for (int i = 0; i < ecl_smspec_num_nodes(ecl_sum->smspec); i++) {

--- a/lib/ecl/ecl_sum_data.cpp
+++ b/lib/ecl/ecl_sum_data.cpp
@@ -199,7 +199,7 @@
    method to access the time dimension of the data, i.e. all the
    functions like ecl_sum_get_general_var() expect the time direction
    to be given as a ministep; however it is also possible to get the
-   data by giving an invector_typeternal (not that internal ...) index. In
+   data by giving an internal (not that internal ...) index. In
    ecl_sum_data.c the latter functions have _iget():
 
 
@@ -860,8 +860,6 @@ double ecl_sum_data_iget( const ecl_sum_data_type * data , int time_index , int 
   ecl::ecl_sum_file_data_type * file_data = data->data_list[list_index];
   int * param_map = data->param_map[list_index];
   return file_data->iget( time_index - data->data_list_first_index[list_index] , param_map[params_index] );
-
-  return 0;
 }
 
 

--- a/lib/ecl/ecl_sum_data.cpp
+++ b/lib/ecl/ecl_sum_data.cpp
@@ -18,15 +18,20 @@
 
 #include <string.h>
 #include <math.h>
+#include <vector>
+#include <stdexcept>
+#include <string>
 
 #include <ert/util/util.hpp>
 #include <ert/util/vector.hpp>
 #include <ert/util/time_t_vector.hpp>
 #include <ert/util/int_vector.hpp>
 #include <ert/util/stringlist.hpp>
+#include <ert/util/test_util.hpp>
 
 #include <ert/ecl/ecl_util.hpp>
 #include <ert/ecl/ecl_smspec.hpp>
+#include "ert/ecl/ecl_sum_file_data.hpp"
 #include <ert/ecl/ecl_sum_data.hpp>
 #include <ert/ecl/ecl_sum_tstep.hpp>
 #include <ert/ecl/smspec_node.hpp>
@@ -194,7 +199,7 @@
    method to access the time dimension of the data, i.e. all the
    functions like ecl_sum_get_general_var() expect the time direction
    to be given as a ministep; however it is also possible to get the
-   data by giving an internal (not that internal ...) index. In
+   data by giving an invector_typeternal (not that internal ...) index. In
    ecl_sum_data.c the latter functions have _iget():
 
 
@@ -205,12 +210,8 @@
 
 
 
-#define INVALID_MINISTEP_NR -1
-#define INVALID_TIME_T 0
-
 struct ecl_sum_data_struct {
   ecl_smspec_type        * smspec;                 /* A shared reference - only used for providing good error messages. */
-  vector_type            * data;                   /* Vector of ecl_sum_tstep_type instances. */
   double                   days_start;
   double                   sim_length;
   int_vector_type        * report_first_index ;    /* Indexed by report_step - giving first internal_index in report_step.   */
@@ -221,6 +222,13 @@ struct ecl_sum_data_struct {
   time_t                   start_time;             /* In the case of restarts the start might disagree with the value reported
                                                       in the smspec file. */
   time_t                   end_time;
+  std::vector<ecl::ecl_sum_file_data_type*> data_list;              // List of ecl_sum_file_data instances
+
+  size_t                   data_list_size;         //number of ecl_sum_file_data objects contained
+  std::vector<size_t>      data_list_first_index;
+  std::vector<size_t>      data_list_last_index;     
+
+  std::vector<int *>       param_map; //maps each underlying ecl_sum_file_data_type into current file_data
 };
 
 
@@ -229,11 +237,18 @@ struct ecl_sum_data_struct {
 
 /*****************************************************************/
 
- void ecl_sum_data_free( ecl_sum_data_type * data ) {
-  vector_free( data->data );
+ void ecl_sum_data_free( ecl_sum_data_type * data ) { 
+  if (!data)
+    throw std::invalid_argument(__func__ + std::string(": invalid delete") );
+  if (data->data_list.size() > 0)
+    delete data->data_list.back();
+
+  for (size_t index = 0; index < data->param_map.size(); index++)
+    free(data->param_map[index]);
+
   int_vector_free( data->report_first_index );
   int_vector_free( data->report_last_index  );
-  free(data);
+  delete data;
 }
 
 /*
@@ -258,15 +273,53 @@ static void ecl_sum_data_clear_index( ecl_sum_data_type * data ) {
 
 
 ecl_sum_data_type * ecl_sum_data_alloc(ecl_smspec_type * smspec) {
-  ecl_sum_data_type * data = (ecl_sum_data_type*)util_malloc( sizeof * data );
-  data->data        = vector_alloc_new();
-  data->smspec      = smspec;
-
+  ecl_sum_data_type * data =  new ecl_sum_data_type;
   data->report_first_index    = int_vector_alloc( 0 , INVALID_MINISTEP_NR );
   data->report_last_index     = int_vector_alloc( 0 , INVALID_MINISTEP_NR );
-
+  data->data_list   = {};
+  data->smspec      = smspec;
+  data->data_list_size    = 0;
+  data->data_list_first_index = {};
+  data->data_list_last_index = {};
+  data->param_map = { ecl_smspec_alloc_self_mapping( data->smspec ) };
   ecl_sum_data_clear_index( data );
   return data;
+}
+
+
+void ecl_sum_data_reset_self_map( ecl_sum_data_type * data ) {
+  if (data->param_map.size() > 0) {
+    for (size_t i = 0; i < data->param_map.size(); i++)
+      free( data->param_map[i] );
+  }
+  data->param_map = { ecl_smspec_alloc_self_mapping( data->smspec ) };;
+}
+
+static void ecl_sum_data_append_file_data( ecl_sum_data_type * sum_data, ecl::ecl_sum_file_data_type * file_data) {
+
+  sum_data->data_list.push_back( file_data );
+  sum_data->data_list_first_index.push_back(0);
+  sum_data->data_list_last_index.push_back( file_data->get_length() - 1 );
+
+  sum_data->start_time = file_data->get_data_start();
+  sum_data->end_time   = file_data->get_sim_end();
+}
+
+
+static int ecl_sum_data_get_list_index_from_ministep_index( const ecl_sum_data_type * data, size_t ministep_index ) {
+  size_t index = 0;
+  int data_list_index = -1;
+  while (index < data->data_list.size()) {
+    if (ministep_index >= data->data_list_first_index[index] && ministep_index <= data->data_list_last_index[index]) {
+      data_list_index = index;
+      break;
+    }
+    index++;
+  }
+  if (data_list_index < 0)
+    throw std::invalid_argument(__func__ + std::string(": arg ministep index too high: ") + std::to_string(ministep_index) 
+                                         + std::string(" >= ") + std::to_string( ecl_sum_data_get_length(data)));
+  return data_list_index;
 }
 
 
@@ -293,7 +346,8 @@ ecl_sum_data_type * ecl_sum_data_alloc(ecl_smspec_type * smspec) {
 
 
 static ecl_sum_tstep_type * ecl_sum_data_iget_ministep( const ecl_sum_data_type * data , int internal_index ) {
-  return (ecl_sum_tstep_type*)vector_iget( data->data , internal_index );
+  int list_index = ecl_sum_data_get_list_index_from_ministep_index( data, internal_index );
+  return data->data_list[list_index]->iget_ministep( internal_index - data->data_list_first_index[list_index] );
 }
 
 
@@ -310,6 +364,8 @@ void ecl_sum_data_report2internal_range(const ecl_sum_data_type * data , int rep
 
 ecl_sum_data_type * ecl_sum_data_alloc_writer( ecl_smspec_type * smspec ) {
   ecl_sum_data_type * data = ecl_sum_data_alloc( smspec );
+  ecl::ecl_sum_file_data_type * file_data = new ecl::ecl_sum_file_data_type( smspec );
+  ecl_sum_data_append_file_data( data, file_data );
   return data;
 }
 
@@ -381,12 +437,9 @@ static void ecl_sum_data_fwrite_unified_step( const ecl_sum_data_type * data , c
 static void ecl_sum_data_fwrite_unified( const ecl_sum_data_type * data , const char * ecl_case , bool fmt_case ) {
   char * filename = ecl_util_alloc_filename( NULL , ecl_case , ECL_UNIFIED_SUMMARY_FILE , fmt_case , 0 );
   fortio_type * fortio = fortio_open_writer( filename , fmt_case , ECL_ENDIAN_FLIP );
-  int report_step;
 
-  for (report_step = data->first_report_step; report_step <= data->last_report_step; report_step++) {
-    if (ecl_sum_data_has_report_step( data , report_step ))
-      ecl_sum_data_fwrite_report__( data , report_step , fortio );
-  }
+  for (size_t index = 0; index < data->data_list.size(); index++)
+    data->data_list[index]->fwrite_unified( fortio );
 
   fortio_fclose( fortio );
   free( filename );
@@ -394,20 +447,10 @@ static void ecl_sum_data_fwrite_unified( const ecl_sum_data_type * data , const 
 
 
 static void ecl_sum_data_fwrite_multiple( const ecl_sum_data_type * data , const char * ecl_case , bool fmt_case ) {
-  int report_step;
-
-  for (report_step = data->first_report_step; report_step <= data->last_report_step; report_step++) {
-    if (ecl_sum_data_has_report_step( data , report_step )) {
-      char * filename = ecl_util_alloc_filename( NULL , ecl_case , ECL_SUMMARY_FILE , fmt_case , report_step );
-      fortio_type * fortio = fortio_open_writer( filename , fmt_case , ECL_ENDIAN_FLIP );
-
-      ecl_sum_data_fwrite_report__( data , report_step , fortio );
-
-      fortio_fclose( fortio );
-      free( filename );
-    }
-  }
-
+  
+  for (size_t index = 0; index < data->data_list.size(); index++) 
+    data->data_list[index]->fwrite_multiple(ecl_case, fmt_case);
+  
 }
 
 
@@ -431,9 +474,13 @@ void ecl_sum_data_fwrite( const ecl_sum_data_type * data , const char * ecl_case
 
 
 
-time_t ecl_sum_data_get_sim_end   (const ecl_sum_data_type * data ) { return data->end_time; }
+time_t ecl_sum_data_get_sim_end   (const ecl_sum_data_type * data ) { 
+  return data->end_time;
+}
 
-time_t ecl_sum_data_get_data_start   ( const ecl_sum_data_type * data ) { return data->start_time; }
+time_t ecl_sum_data_get_data_start   ( const ecl_sum_data_type * data ) { 
+  return data->start_time; 
+}
 
 double ecl_sum_data_get_first_day( const ecl_sum_data_type * data) { return data->days_start; }
 
@@ -533,7 +580,7 @@ static int ecl_sum_data_get_index_from_sim_time( const ecl_sum_data_type * data 
   */
 
   int low_index = 0;
-  int high_index = vector_get_size(data->data) - 1;
+  int high_index = ecl_sum_data_get_length(data) - 1;
 
   // perform binary search
   while (low_index+1 < high_index) {
@@ -630,7 +677,7 @@ void ecl_sum_data_init_interp_from_sim_days( const ecl_sum_data_type * data , do
 double_vector_type * ecl_sum_data_alloc_seconds_solution(const ecl_sum_data_type * data, const smspec_node_type * node, double cmp_value, bool rates_clamp_lower) {
   double_vector_type * solution = double_vector_alloc(0, 0);
   const int param_index = smspec_node_get_params_index(node);
-  const int size = vector_get_size(data->data);
+  const int size = ecl_sum_data_get_length(data);
 
   if (size <= 1)
     return solution;
@@ -640,11 +687,11 @@ double_vector_type * ecl_sum_data_alloc_seconds_solution(const ecl_sum_data_type
 
     const ecl_sum_tstep_type * ministep = ecl_sum_data_iget_ministep(data, index);
     const ecl_sum_tstep_type * prev_ministep = ecl_sum_data_iget_ministep(data, prev_index);
-    double value = ecl_sum_tstep_iget(ministep, param_index);
-    double prev_value = ecl_sum_tstep_iget(prev_ministep, param_index);
+    double value      = ecl_sum_data_iget(data, index, param_index);
+    double prev_value = ecl_sum_data_iget(data, prev_index, param_index);
 
     // cmp_value in interval value (closed) and prev_value (open)
-    bool contained = value == cmp_value;
+    bool contained = (value == cmp_value);
     contained |= (util_double_min(prev_value, value) < cmp_value) &&
             (cmp_value < util_double_max(prev_value, value));
 
@@ -659,7 +706,6 @@ double_vector_type * ecl_sum_data_alloc_seconds_solution(const ecl_sum_data_type
     } else {
       double slope = (value - prev_value) / (time - prev_time);
       double seconds = (cmp_value - prev_value)/slope + prev_time;
-
       double_vector_append(solution, seconds);
     }
   }
@@ -667,50 +713,16 @@ double_vector_type * ecl_sum_data_alloc_seconds_solution(const ecl_sum_data_type
 }
 
 
-
-
-static void ecl_sum_data_append_tstep__( ecl_sum_data_type * data , ecl_sum_tstep_type * tstep) {
-  /*
-     Here the tstep is just appended naively, the vector will be
-     sorted by ministep_nr before the data instance is returned.
-  */
-
-  vector_append_owned_ref( data->data , tstep , ecl_sum_tstep_free__);
-  data->index_valid = false;
-}
-
-
-
-static int cmp_ministep( const void * arg1 , const void * arg2) {
-  const ecl_sum_tstep_type * ministep1 = ecl_sum_tstep_safe_cast_const( arg1 );
-  const ecl_sum_tstep_type * ministep2 = ecl_sum_tstep_safe_cast_const( arg2 );
-
-  time_t time1 = ecl_sum_tstep_get_sim_time( ministep1 );
-  time_t time2 = ecl_sum_tstep_get_sim_time( ministep2 );
-
-  if (time1 < time2)
-    return -1;
-  else if (time1 == time2)
-    return 0;
-  else
-    return 1;
-}
-
-
 static void ecl_sum_data_build_index( ecl_sum_data_type * sum_data ) {
-  /* Clear the existing index (if any): */
-  ecl_sum_data_clear_index( sum_data );
-
-  /*
-    Sort the internal storage vector after sim_time.
-  */
-  vector_sort( sum_data->data , cmp_ministep );
-
-
-  /* Identify various global first and last values.  */
-  {
-    const ecl_sum_tstep_type * first_ministep = (const ecl_sum_tstep_type*)vector_iget_const( sum_data->data, 0 );
-    const ecl_sum_tstep_type * last_ministep  = (const ecl_sum_tstep_type*)vector_get_last_const( sum_data->data );
+  int_vector_reset( sum_data->report_first_index);
+  int_vector_reset( sum_data->report_last_index); 
+  for (size_t list_index = 0; list_index < sum_data->data_list.size(); list_index++) {
+    sum_data->data_list[list_index]->update_report_vectors( sum_data->report_first_index, sum_data->report_last_index , 
+                                                            sum_data->data_list_first_index[list_index], sum_data->data_list_last_index[list_index]);
+  }
+  if (sum_data->data_list.size() > 0) {
+    const ecl_sum_tstep_type * first_ministep = ecl_sum_data_iget_ministep(sum_data, 0);
+    const ecl_sum_tstep_type * last_ministep  = ecl_sum_data_iget_ministep(sum_data, ecl_sum_data_get_length(sum_data)-1);
     /*
        In most cases the days_start and data_start_time will agree
        with the global simulation start; however in the case where we
@@ -722,37 +734,9 @@ static void ecl_sum_data_build_index( ecl_sum_data_type * sum_data ) {
     sum_data->sim_length      = ecl_sum_tstep_get_sim_days( last_ministep );
     sum_data->start_time      = ecl_sum_tstep_get_sim_time( first_ministep);
     sum_data->end_time        = ecl_sum_tstep_get_sim_time( last_ministep );
-  }
 
-  /* Build up the report -> ministep mapping. */
-  {
-    int internal_index;
-    for (internal_index = 0; internal_index < vector_get_size( sum_data->data ); internal_index++) {
-      const ecl_sum_tstep_type * ministep = ecl_sum_data_iget_ministep( sum_data , internal_index  );
-      int report_step = ecl_sum_tstep_get_report(ministep);
-
-      /* Indexing internal_index - report_step */
-      {
-        int current_first_index = int_vector_safe_iget( sum_data->report_first_index , report_step );
-        if (current_first_index < 0) /* i.e. currently not set. */
-            int_vector_iset( sum_data->report_first_index , report_step , internal_index);
-        else
-          if (internal_index  < current_first_index)
-            int_vector_iset( sum_data->report_first_index , report_step , internal_index);
-      }
-
-      {
-        int current_last_index =  int_vector_safe_iget( sum_data->report_last_index , report_step );
-        if (current_last_index < 0)
-          int_vector_iset( sum_data->report_last_index , report_step ,  internal_index);
-        else
-          if (internal_index > current_last_index)
-            int_vector_iset( sum_data->report_last_index , report_step , internal_index);
-      }
-
-      sum_data->first_report_step = util_int_min( sum_data->first_report_step , report_step );
-      sum_data->last_report_step  = util_int_max( sum_data->last_report_step  , report_step );
-    }
+    sum_data->first_report_step = sum_data->data_list[0]->get_first_report_step();
+    sum_data->last_report_step = sum_data->data_list.back()->get_last_report_step();
   }
   sum_data->index_valid = true;
 }
@@ -767,151 +751,64 @@ static void ecl_sum_data_build_index( ecl_sum_data_type * sum_data ) {
 */
 
 ecl_sum_tstep_type * ecl_sum_data_add_new_tstep( ecl_sum_data_type * data , int report_step , double sim_seconds) {
-  int ministep_nr = vector_get_size( data->data );
-  ecl_sum_tstep_type * tstep = ecl_sum_tstep_alloc_new( report_step , ministep_nr , sim_seconds , data->smspec );
-  ecl_sum_tstep_type * prev_tstep = NULL;
-
-  if (vector_get_size( data->data ) > 0)
-    prev_tstep = (ecl_sum_tstep_type*)vector_get_last( data->data );
-
-  ecl_sum_data_append_tstep__( data , tstep );
-  {
-    bool rebuild_index = true;
-
-    /*
-      In the simple case that we just add another timestep to the
-      currently active report_step, we do a limited update of the
-      index, otherwise we call ecl_sum_data_build_index() to get a
-      full recalculation of the index.
-    */
-
-    if (prev_tstep != NULL) {
-      if (ecl_sum_tstep_get_report( prev_tstep ) == ecl_sum_tstep_get_report( tstep )) {        // Same report step
-        if (ecl_sum_tstep_get_sim_days( prev_tstep ) < ecl_sum_tstep_get_sim_days( tstep )) {   // This tstep will become the new latest tstep
-          int internal_index = vector_get_size( data->data ) - 1;
-          int_vector_iset( data->report_last_index , report_step , internal_index );
-
-          data->sim_length = ecl_sum_tstep_get_sim_days( tstep );
-          data->end_time = ecl_sum_tstep_get_sim_time(tstep);
-
-          rebuild_index = false;
-        }
-      }
-    }
-    if (rebuild_index)
-      ecl_sum_data_build_index( data );
+  ecl::ecl_sum_file_data_type * file_data = data->data_list.back();
+  ecl_sum_tstep_type * tstep = file_data->add_new_tstep( report_step, sim_seconds );
+  if (tstep) {
+    data->data_list_last_index.back()++;
   }
-  ecl_smspec_lock( data->smspec );
-
+  ecl_sum_data_build_index( data );
   return tstep;
 }
 
 
-
-
-/**
-   Malformed/incomplete files:
-   ----------------------------
-   Observe that ECLIPSE works in the following way:
-
-     1. At the start of a report step a summary data section
-        containing only the 'SEQHDR' keyword is written - this is
-        currently an 'invalid' summary section.
-
-     2. ECLIPSE simulates as best it can.
-
-     3. When the time step is complete data is written to the summary
-        file.
-
-   Now - if ECLIPSE goes down in flames during step 2 a malformed
-   summary file will be left around, to handle this situation
-   reasonably gracefully we check that the ecl_file instance has at
-   least one "PARAMS" keyword.
-
-   One ecl_file corresponds to one report_step (limited by SEQHDR); in
-   the case of non unfied summary files these objects correspond to
-   one BASE.Annnn or BASE.Snnnn file, in the case of unified files the
-   calling routine will read the unified summary file partly.
-*/
-
-static void ecl_sum_data_add_ecl_file(ecl_sum_data_type * data         ,
-                                      int   report_step                ,
-                                      const ecl_file_view_type * summary_view,
-                                      const ecl_smspec_type * smspec) {
-
-
-  int num_ministep  = ecl_file_view_get_num_named_kw( summary_view , PARAMS_KW);
-  if (num_ministep > 0) {
-    int ikw;
-
-    for (ikw = 0; ikw < num_ministep; ikw++) {
-      ecl_kw_type * ministep_kw = ecl_file_view_iget_named_kw( summary_view , MINISTEP_KW , ikw);
-      ecl_kw_type * params_kw   = ecl_file_view_iget_named_kw( summary_view , PARAMS_KW   , ikw);
-
-      {
-        int ministep_nr = ecl_kw_iget_int( ministep_kw , 0 );
-        ecl_sum_tstep_type * tstep = ecl_sum_tstep_alloc_from_file( report_step ,
-                                                                    ministep_nr ,
-                                                                    params_kw ,
-                                                                    ecl_file_view_get_src_file( summary_view ),
-                                                                    smspec );
-
-        if (tstep)
-            ecl_sum_data_append_tstep__( data , tstep );
-      }
-    }
+int * ecl_sum_data_alloc_param_mapping( int * current_param_mapping, int * old_param_mapping, size_t size) {
+  int * new_param_mapping = (int*)util_malloc( size * sizeof * new_param_mapping );
+  for (size_t i = 0; i < size; i++) {
+    if (current_param_mapping[i] >= 0)
+      new_param_mapping[i] = old_param_mapping[ current_param_mapping[i] ];
+    else
+      new_param_mapping[i] = -1;
   }
+  return new_param_mapping;
 }
 
 
 void ecl_sum_data_add_case(ecl_sum_data_type * self, const ecl_sum_data_type * other) {
-  int * param_mapping = NULL;
-  bool  header_equal = ecl_smspec_equal( self->smspec , other->smspec);
-  float default_value = 0;
 
-  if (!header_equal)
-    param_mapping = ecl_smspec_alloc_mapping( self->smspec , other->smspec );
-
-
+  int max_tstep_nr = -1;
   for (int tstep_nr = 0; tstep_nr < ecl_sum_data_get_length( other ); tstep_nr++) {
     ecl_sum_tstep_type * other_tstep = ecl_sum_data_iget_ministep( other , tstep_nr );
+    if (ecl_sum_tstep_get_sim_time(other_tstep) < ecl_sum_data_get_data_start(self))
+      max_tstep_nr = tstep_nr;
+  }
+  if (max_tstep_nr >= 0) {
 
-    /*
-      The dataset 'self' is the authorative in the timeinterval where it has
-      data, so if 'other' also has data in the same time interval that is
-      discarded. In most cases 'other' will represent a history case, and 'self'
-      is a prediction which has been restarted.
+    int * current_param_mapping = ecl_smspec_alloc_mapping( self->smspec , other->smspec );
 
-      After implementing the time_interval_contains() based check it turned out
-      that the smspec structure also contains a restart_step integer value in
-      the DIMENS vector which could probably be used to achieve the same thing.
-      That field is currently not used.
-    */
+    int max_other_list_index = ecl_sum_data_get_list_index_from_ministep_index(other, max_tstep_nr);
+    self->data_list_first_index.back() += max_tstep_nr + 1;
+    self->data_list_last_index.back() += max_tstep_nr + 1;
 
-    if (!ecl_sum_data_check_sim_time(self, ecl_sum_tstep_get_sim_time(other_tstep))) {
-      ecl_sum_tstep_type * new_tstep;
-
-      if (header_equal)
-        new_tstep = ecl_sum_tstep_alloc_copy( other_tstep );
+    for (int list_index = max_other_list_index; list_index >= 0; list_index--) {
+      self->data_list.insert( self->data_list.begin(), other->data_list[list_index] );
+      self->data_list_first_index.insert( self->data_list_first_index.begin(), other->data_list_first_index[list_index] );
+      if (list_index == max_other_list_index)
+        self->data_list_last_index.insert( self->data_list_last_index.begin(), max_tstep_nr );
       else
-        new_tstep = ecl_sum_tstep_alloc_remap_copy( other_tstep , self->smspec , default_value , param_mapping );
+        self->data_list_last_index.insert( self->data_list_last_index.begin(), other->data_list_last_index[list_index] );
 
-      ecl_sum_data_append_tstep__( self , new_tstep );
+      self->param_map.insert( self->param_map.begin(), ecl_sum_data_alloc_param_mapping(current_param_mapping, other->param_map[list_index], ecl_smspec_get_params_size( self->smspec ) ) );
 
     }
+
+    free( current_param_mapping );
+
+   
   }
 
-  ecl_sum_data_build_index( self );
-  free( param_mapping );
-}
+  ecl_sum_data_build_index(self);
+  
 
-
-static bool ecl_sum_data_check_file( ecl_file_type * ecl_file ) {
-  if (ecl_file_has_kw( ecl_file , PARAMS_KW ) &&
-      (ecl_file_get_num_named_kw( ecl_file , PARAMS_KW ) == ecl_file_get_num_named_kw( ecl_file , MINISTEP_KW)))
-    return true;
-  else
-    return false;
 }
 
 
@@ -925,65 +822,13 @@ static bool ecl_sum_data_check_file( ecl_file_type * ecl_file ) {
 */
 
 bool ecl_sum_data_fread(ecl_sum_data_type * data , const stringlist_type * filelist) {
-  if (stringlist_get_size( filelist ) == 0)
-    return false;
-
-  {
-    ecl_file_enum file_type = ecl_util_get_file_type( stringlist_iget( filelist , 0 ) , NULL , NULL);
-    if ((stringlist_get_size( filelist ) > 1) && (file_type != ECL_SUMMARY_FILE))
-      util_abort("%s: internal error - when calling with more than one file - you can not supply a unified file - come on?! \n",__func__);
-
-    {
-      int filenr;
-      if (file_type == ECL_SUMMARY_FILE) {
-
-        /* Not unified. */
-        for (filenr = 0; filenr < stringlist_get_size( filelist ); filenr++) {
-          const char * data_file = stringlist_iget( filelist , filenr);
-          ecl_file_enum file_type;
-          int report_step;
-          file_type = ecl_util_get_file_type( data_file , NULL , &report_step);
-          if (file_type != ECL_SUMMARY_FILE)
-            util_abort("%s: file:%s has wrong type \n",__func__ , data_file);
-          {
-            ecl_file_type * ecl_file = ecl_file_open( data_file , 0);
-            if (ecl_file && ecl_sum_data_check_file( ecl_file )) {
-              ecl_sum_data_add_ecl_file( data , report_step , ecl_file_get_global_view( ecl_file ) , data->smspec);
-              ecl_file_close( ecl_file );
-            }
-          }
-        }
-      } else if (file_type == ECL_UNIFIED_SUMMARY_FILE) {
-        ecl_file_type * ecl_file = ecl_file_open( stringlist_iget(filelist ,0 ) , 0);
-        if (ecl_file && ecl_sum_data_check_file( ecl_file )) {
-          int report_step = 1;   /* <- ECLIPSE numbering - starting at 1. */
-          while (true) {
-            /*
-              Observe that there is a number discrepancy between ECLIPSE
-              and the ecl_file_select_smryblock() function. ECLIPSE
-              starts counting report steps at 1; whereas the first
-              SEQHDR block in the unified summary file is block zero (in
-              ert counting).
-            */
-            ecl_file_view_type * summary_view = ecl_file_get_summary_view(ecl_file , report_step - 1 );
-            if (summary_view) {
-              ecl_sum_data_add_ecl_file( data , report_step , summary_view , data->smspec);
-              report_step++;
-            } else break;
-          }
-          ecl_file_close( ecl_file );
-        }
-      }
-    }
-
-
-    if (ecl_sum_data_get_length( data ) > 0) {
-      ecl_sum_data_build_index( data );
-      return true;
-    } else
-      return false;
-
+  ecl::ecl_sum_file_data_type * file_data = new ecl::ecl_sum_file_data_type( data->smspec );
+  if (file_data->fread( filelist )) {
+    ecl_sum_data_append_file_data( data, file_data );
+    ecl_sum_data_build_index(data);
+    return true;
   }
+  return false;  
 }
 
 
@@ -1021,7 +866,7 @@ void ecl_sum_data_summarize(const ecl_sum_data_type * data , FILE * stream) {
   fprintf(stream , "---------------------------------------------------------------\n");
   {
     int index;
-    for (index = 0; index < vector_get_size( data->data ); index++) {
+    for (index = 0; index < ecl_sum_data_get_length(data); index++) {
       const ecl_sum_tstep_type * ministep = ecl_sum_data_iget_ministep( data , index );
       int day,month,year;
       ecl_util_set_date_values( ecl_sum_tstep_get_sim_time( ministep ) , &day, &month , &year);
@@ -1056,7 +901,6 @@ int ecl_sum_data_iget_report_end( const ecl_sum_data_type * data , int report_st
 }
 
 
-
 /**
    Returns the first index included in report step @report_step.
    Observe that if the dataset does not include @report_step at all,
@@ -1087,9 +931,6 @@ int ecl_sum_data_iget_mini_step(const ecl_sum_data_type * data , int internal_in
 }
 
 
-
-
-
 /**
     This will look up a value based on an internal index. The internal
     index will ALWAYS run in the interval [0,num_ministep), without
@@ -1098,8 +939,15 @@ int ecl_sum_data_iget_mini_step(const ecl_sum_data_type * data , int internal_in
 
 
 double ecl_sum_data_iget( const ecl_sum_data_type * data , int time_index , int params_index ) {
-  const ecl_sum_tstep_type * ministep_data = ecl_sum_data_iget_ministep( data , time_index  );
-  return ecl_sum_tstep_iget( ministep_data , params_index);
+  int list_index = ecl_sum_data_get_list_index_from_ministep_index(data, time_index);
+  if (list_index < 0) 
+    throw std::invalid_argument(__func__ + std::string(": wrong index.") );
+  else {
+    ecl::ecl_sum_file_data_type * file_data = data->data_list[list_index];
+    int * param_map = data->param_map[list_index];
+    return file_data->iget( time_index - data->data_list_first_index[list_index] , param_map[params_index] );
+  }
+  return 0;
 }
 
 
@@ -1116,10 +964,7 @@ double ecl_sum_data_iget( const ecl_sum_data_type * data , int time_index , int 
 */
 
 double ecl_sum_data_interp_get(const ecl_sum_data_type * data , int time_index1 , int time_index2 , double weight1 , double weight2 , int params_index) {
-  const ecl_sum_tstep_type * ministep_data1 = ecl_sum_data_iget_ministep( data , time_index1 );
-  const ecl_sum_tstep_type * ministep_data2 = ecl_sum_data_iget_ministep( data , time_index2 );
-
-  return ecl_sum_tstep_iget( ministep_data1 , params_index ) * weight1 + ecl_sum_tstep_iget( ministep_data2 , params_index ) * weight2;
+  return ecl_sum_data_iget(data, time_index1, params_index) * weight1 + ecl_sum_data_iget(data, time_index2, params_index) * weight2;
 }
 
 
@@ -1234,7 +1079,7 @@ int ecl_sum_data_get_report_step_from_days(const ecl_sum_data_type * data , doub
 
     for (i=1; i < int_vector_size( data->report_last_index ); i++) {
       int ministep_index = int_vector_iget( data->report_last_index , i );
-      const ecl_sum_tstep_type * ministep = (const ecl_sum_tstep_type*)vector_iget_const( data->data , ministep_index );
+      const ecl_sum_tstep_type * ministep = ecl_sum_data_iget_ministep(data, ministep_index);
 
       double_vector_iset( days_map , i , ecl_sum_tstep_get_sim_days( ministep ));
       int_vector_iset( report_map , i , ecl_sum_tstep_get_report( ministep ));
@@ -1288,7 +1133,7 @@ int ecl_sum_data_get_report_step_from_time(const ecl_sum_data_type * data , time
 
     for (i=1; i < int_vector_size( data->report_last_index ); i++) {
       int ministep_index = int_vector_iget( data->report_last_index , i );
-      const ecl_sum_tstep_type * ministep = (const ecl_sum_tstep_type*)vector_iget_const( data->data , ministep_index );
+      const ecl_sum_tstep_type * ministep = ecl_sum_data_iget_ministep(data, ministep_index);
 
       time_t_vector_iset( time_map , i , ecl_sum_tstep_get_sim_time( ministep ));
       int_vector_iset( report_map , i , ecl_sum_tstep_get_report( ministep ));
@@ -1371,7 +1216,7 @@ void ecl_sum_data_init_time_vector( const ecl_sum_data_type * data , time_t_vect
     }
   } else {
     int i;
-    for (i = 1; i < vector_get_size(data->data); i++) {
+    for (i = 1; i < ecl_sum_data_get_length(data); i++) {
       const ecl_sum_tstep_type * ministep = ecl_sum_data_iget_ministep( data , i  );
       time_t_vector_append( time_vector , ecl_sum_tstep_get_sim_time( ministep ));
     }
@@ -1392,37 +1237,40 @@ void ecl_sum_data_init_data_vector( const ecl_sum_data_type * data , double_vect
     int report_step;
     for (report_step = data->first_report_step; report_step <= data->last_report_step; report_step++) {
       int last_index = int_vector_iget(data->report_last_index , report_step);
-      const ecl_sum_tstep_type * ministep = ecl_sum_data_iget_ministep( data , last_index );
-      double_vector_append( data_vector , ecl_sum_tstep_iget( ministep , data_index ));
+      double_vector_append(data_vector, ecl_sum_data_iget(data, last_index, data_index));
     }
   } else {
     int i;
-    for (i = 0; i < vector_get_size(data->data); i++) {
-      const ecl_sum_tstep_type * ministep = ecl_sum_data_iget_ministep( data , i  );
-      double_vector_append( data_vector , ecl_sum_tstep_iget( ministep , data_index ));
-    }
+    for (i = 0; i < ecl_sum_data_get_length(data); i++)
+      double_vector_append(data_vector, ecl_sum_data_iget(data, i, data_index));
   }
 }
 
 
 double_vector_type * ecl_sum_data_alloc_data_vector( const ecl_sum_data_type * data , int data_index , bool report_only) {
   double_vector_type * data_vector = double_vector_alloc(0,0);
-  ecl_sum_data_init_data_vector( data , data_vector , data_index , report_only);
+  double_vector_reset( data_vector );
+  double_vector_append( data_vector , ecl_smspec_get_start_time( data->smspec ));
+
+  for (size_t index = 0; index < data->data_list.size(); index++) {
+    int end_min_step = data->data_list_last_index[index] - data->data_list_first_index[index]; //last step in the file_data to be used
+    int * param_map = data->param_map[index];
+    data->data_list[index]->update_data_vector( data_vector, param_map[data_index], report_only, end_min_step);
+  }
+
   return data_vector;
 }
 
 
 void ecl_sum_data_init_double_vector(const ecl_sum_data_type * data, int params_index, double * output_data) {
   int i;
-  for (i = 0; i < vector_get_size(data->data); i++) {
-    const ecl_sum_tstep_type * ministep = ecl_sum_data_iget_ministep( data , i  );
-    output_data[i] = ecl_sum_tstep_iget(ministep, params_index);
-  }
+  for (i = 0; i < ecl_sum_data_get_length(data); i++)
+    output_data[i] = ecl_sum_data_iget(data, i, params_index);
 }
 
 void ecl_sum_data_init_datetime64_vector(const ecl_sum_data_type * data, int64_t * output_data, int multiplier) {
   int i;
-  for (i = 0; i < vector_get_size(data->data); i++) {
+  for (i = 0; i < ecl_sum_data_get_length(data); i++) {
     const ecl_sum_tstep_type * ministep = ecl_sum_data_iget_ministep( data , i  );
     output_data[i] = ecl_sum_tstep_get_sim_time(ministep) * multiplier;
   }
@@ -1477,13 +1325,12 @@ void ecl_sum_data_init_double_vector_interp(const ecl_sum_data_type * data,
 void ecl_sum_data_init_double_frame(const ecl_sum_data_type * data, const ecl_sum_vector_type * keywords, double *output_data) {
   int time_stride = ecl_sum_vector_get_size(keywords);
   int key_stride = 1;
-  for (int time_index=0; time_index < vector_get_size(data->data); time_index++) {
-    const ecl_sum_tstep_type * ministep = ecl_sum_data_iget_ministep(data , time_index);
+  for (int time_index=0; time_index < ecl_sum_data_get_length(data); time_index++) {
     for (int key_index = 0; key_index < ecl_sum_vector_get_size(keywords); key_index++) {
       int param_index = ecl_sum_vector_iget_param_index(keywords, key_index);
       int data_index = key_index*key_stride + time_index * time_stride;
 
-      output_data[data_index] = ecl_sum_tstep_iget(ministep, param_index);
+      output_data[data_index] = ecl_sum_data_iget(data, time_index, param_index);
     }
   }
 }
@@ -1546,11 +1393,11 @@ void ecl_sum_data_init_double_frame_interp(const ecl_sum_data_type * data,
 */
 
 int ecl_sum_data_get_length( const ecl_sum_data_type * data ) {
-  return vector_get_size( data->data );
+  return (int)data->data_list_last_index.back() + 1;
 }
 
 void ecl_sum_data_scale_vector(ecl_sum_data_type * data, int index, double scalar) {
-  int len = vector_get_size(data->data);
+  int len = ecl_sum_data_get_length(data);
   for (int i = 0; i < len; i++) {
     ecl_sum_tstep_type * ministep = ecl_sum_data_iget_ministep(data,i);
     ecl_sum_tstep_iscale(ministep, index, scalar);
@@ -1558,7 +1405,7 @@ void ecl_sum_data_scale_vector(ecl_sum_data_type * data, int index, double scala
 }
 
 void ecl_sum_data_shift_vector(ecl_sum_data_type * data, int index, double addend) {
-  int len = vector_get_size(data->data);
+  int len = ecl_sum_data_get_length(data);
   for (int i = 0; i < len; i++) {
     ecl_sum_tstep_type * ministep = ecl_sum_data_iget_ministep(data,i);
     ecl_sum_tstep_ishift(ministep, index, addend);
@@ -1597,6 +1444,7 @@ bool ecl_sum_data_report_step_compatible( const ecl_sum_data_type * data1 , cons
   bool compatible = true;
   int min_size = util_int_min( int_vector_size( data1->report_last_index ) , int_vector_size( data2->report_last_index));
   int i;
+
   for (i = 0; i < min_size; i++) {
     int time_index1 = int_vector_iget( data1->report_last_index , i );
     int time_index2 = int_vector_iget( data2->report_last_index , i );
@@ -1616,8 +1464,7 @@ bool ecl_sum_data_report_step_compatible( const ecl_sum_data_type * data1 , cons
 
 
 double ecl_sum_data_iget_last_value(const ecl_sum_data_type * data, int param_index) {
-  const ecl_sum_tstep_type * tstep = (const ecl_sum_tstep_type*)vector_get_last_const(data->data);
-  return ecl_sum_tstep_iget( tstep, param_index);
+  return ecl_sum_data_iget(data, ecl_sum_data_get_length(data)-1, param_index);
 }
 
 double ecl_sum_data_get_last_value(const ecl_sum_data_type * data, int param_index) {
@@ -1625,6 +1472,5 @@ double ecl_sum_data_get_last_value(const ecl_sum_data_type * data, int param_ind
 }
 
 double ecl_sum_data_iget_first_value(const ecl_sum_data_type * data, int param_index) {
-  const ecl_sum_tstep_type * tstep = (const ecl_sum_tstep_type*) vector_iget_const(data->data, 0);
-  return ecl_sum_tstep_iget(tstep, param_index);
+  return ecl_sum_data_iget(data, 0, param_index);
 }

--- a/lib/ecl/ecl_sum_file_data.cpp
+++ b/lib/ecl/ecl_sum_file_data.cpp
@@ -239,7 +239,7 @@ void ecl_sum_file_data_type::build_index( ) {
 void ecl_sum_file_data_type::update_data_vector( double_vector_type * data_vector , int data_index , bool report_only, int end_min_step) {
 
   if (end_min_step >= get_length())
-    throw std::invalid_argument(__PRETTY_FUNCTION__ + std::string(": argument 'end_min_step' too high."));
+    throw std::invalid_argument("ecl_sum_file_data_type::update_data_vector: argument 'end_min_step' too high.");
 
   if (report_only) {
     int report_step;

--- a/lib/ecl/ecl_sum_file_data.cpp
+++ b/lib/ecl/ecl_sum_file_data.cpp
@@ -29,25 +29,35 @@ ecl_sum_file_data_type::~ecl_sum_file_data_type() {
 }
 
 
-int ecl_sum_file_data_type::get_length() {
+int ecl_sum_file_data_type::get_length() const {
   return vector_get_size( data );
 }
 
-int  ecl_sum_file_data_type::get_first_report_step() {
+int  ecl_sum_file_data_type::get_first_report_step() const{
   return first_report_step;
 }
 
-int ecl_sum_file_data_type::get_last_report_step() {
+int ecl_sum_file_data_type::get_last_report_step() const {
   return last_report_step;
 }
 
 
 
-time_t ecl_sum_file_data_type::get_data_start() { return start_time; }
-time_t ecl_sum_file_data_type::get_sim_end() { return end_time; }
+time_t ecl_sum_file_data_type::get_data_start() const { return start_time; }
+time_t ecl_sum_file_data_type::get_sim_end() const { return end_time; }
+
+time_t ecl_sum_file_data_type::iget_sim_time(int time_index) const {
+  const ecl_sum_tstep_type * ministep = iget_ministep( time_index  );
+  return ecl_sum_tstep_get_sim_time(ministep);
+}
+
+double ecl_sum_file_data_type::iget_seconds(int time_index) const {
+  throw;
+  return 0;
+}
 
 
-double ecl_sum_file_data_type::iget( int time_index , int params_index ) {
+double ecl_sum_file_data_type::iget( int time_index , int params_index ) const {
   if (params_index >= 0) {
     const ecl_sum_tstep_type * ministep_data = iget_ministep( time_index  );
     return ecl_sum_tstep_iget( ministep_data , params_index); 

--- a/lib/ecl/ecl_sum_file_data.cpp
+++ b/lib/ecl/ecl_sum_file_data.cpp
@@ -1,0 +1,456 @@
+#include <stdexcept>
+
+#include "ert/ecl/ecl_sum_file_data.hpp"
+#include <ert/ecl/ecl_sum_tstep.hpp>
+#include <ert/ecl/ecl_kw.h>
+#include <ert/ecl/ecl_kw_magic.h>
+#include <ert/ecl/ecl_endian_flip.h>
+
+namespace ecl {
+
+
+ecl_sum_file_data_type::ecl_sum_file_data_type(ecl_smspec_type * smspec_) :
+  smspec( smspec_ )
+{
+  data = vector_alloc_new();
+  report_first_index = int_vector_alloc( 0 , INVALID_MINISTEP_NR );
+  report_last_index  = int_vector_alloc( 0 , INVALID_MINISTEP_NR );
+
+  clear_index( );
+
+}
+
+ecl_sum_file_data_type::~ecl_sum_file_data_type() {
+
+  vector_free( data );
+  int_vector_free( report_first_index );
+  int_vector_free( report_last_index  );
+
+}
+
+
+int ecl_sum_file_data_type::get_length() {
+  return vector_get_size( data );
+}
+
+int  ecl_sum_file_data_type::get_first_report_step() {
+  return first_report_step;
+}
+
+int ecl_sum_file_data_type::get_last_report_step() {
+  return last_report_step;
+}
+
+
+
+time_t ecl_sum_file_data_type::get_data_start() { return start_time; }
+time_t ecl_sum_file_data_type::get_sim_end() { return end_time; }
+
+
+double ecl_sum_file_data_type::iget( int time_index , int params_index ) {
+  if (params_index >= 0) {
+    const ecl_sum_tstep_type * ministep_data = iget_ministep( time_index  );
+    return ecl_sum_tstep_iget( ministep_data , params_index); 
+  }
+  else
+    return 0;
+}
+
+
+
+void ecl_sum_file_data_type::clear_index() {
+  int_vector_reset( report_first_index);
+  int_vector_reset( report_last_index);
+
+  first_report_step     =  1024 * 1024;
+  last_report_step      = -1024 * 1024;
+  days_start            = 0;
+  sim_length            = -1;
+  index_valid           = false;
+  start_time            = INVALID_TIME_T;
+  end_time              = INVALID_TIME_T;
+}
+
+
+void ecl_sum_file_data_type::append_tstep__(ecl_sum_tstep_type * tstep) {
+  /*
+     Here the tstep is just appended naively, the vector will be
+     sorted by ministep_nr before the data instance is returned.
+  */
+
+  vector_append_owned_ref( data , tstep , ecl_sum_tstep_free__);
+  index_valid = false;
+}
+
+
+/*
+  This function is meant to be called in write mode; and will create a
+  new and empty tstep which is appended to the current data. The tstep
+  will also be returned, so the calling scope can call
+  ecl_sum_tstep_iset() to set elements in the tstep.
+*/
+
+ecl_sum_tstep_type * ecl_sum_file_data_type::add_new_tstep( int report_step , double sim_seconds) {
+  int ministep_nr = vector_get_size( data );
+  ecl_sum_tstep_type * tstep = ecl_sum_tstep_alloc_new( report_step , ministep_nr , sim_seconds , smspec );
+  ecl_sum_tstep_type * prev_tstep = NULL;
+
+  if (vector_get_size( data ) > 0)
+    prev_tstep = (ecl_sum_tstep_type*)vector_get_last( data );
+
+  append_tstep__( tstep );
+  {
+    bool rebuild_index = true;
+
+    /*
+      In the simple case that we just add another timestep to the
+      currently active report_step, we do a limited update of the
+      index, otherwise we call ecl_sum_data_build_index() to get a
+      full recalculation of the index.
+    */
+
+    if (prev_tstep != NULL) {
+      if (ecl_sum_tstep_get_report( prev_tstep ) == ecl_sum_tstep_get_report( tstep )) {        // Same report step
+        if (ecl_sum_tstep_get_sim_days( prev_tstep ) < ecl_sum_tstep_get_sim_days( tstep )) {   // This tstep will become the new latest tstep
+          int internal_index = vector_get_size( data ) - 1;
+          int_vector_iset( report_last_index , report_step , internal_index );
+
+          sim_length = ecl_sum_tstep_get_sim_days( tstep );
+          end_time = ecl_sum_tstep_get_sim_time(tstep);
+
+          rebuild_index = false;
+        }
+      }
+    }
+    if (rebuild_index)
+      build_index();
+  }
+  ecl_smspec_lock( smspec );
+
+  return tstep;
+}
+
+
+ecl_sum_tstep_type * ecl_sum_file_data_type::iget_ministep( int internal_index ) const {
+  return (ecl_sum_tstep_type*)vector_iget( data , internal_index );
+}
+
+
+static int cmp_ministep( const void * arg1 , const void * arg2) {
+  const ecl_sum_tstep_type * ministep1 = ecl_sum_tstep_safe_cast_const( arg1 );
+  const ecl_sum_tstep_type * ministep2 = ecl_sum_tstep_safe_cast_const( arg2 );
+
+  time_t time1 = ecl_sum_tstep_get_sim_time( ministep1 );
+  time_t time2 = ecl_sum_tstep_get_sim_time( ministep2 );
+
+  if (time1 < time2)
+    return -1;
+  else if (time1 == time2)
+    return 0;
+  else
+    return 1;
+}
+
+
+void ecl_sum_file_data_type::update_report_vectors( int_vector_type * parent_report_first_index, int_vector_type * parent_report_last_index, int first_ministep, int last_ministep ) {
+  for (int index = 0; index < int_vector_size(report_first_index); index++) {  
+     if (int_vector_iget( report_first_index, index ) != INVALID_MINISTEP_NR) {
+        int first_parent_index = int_vector_iget( report_first_index , index ) + first_ministep;
+        int last_parent_index  = int_vector_iget( report_last_index , index ) + first_ministep;
+        if (first_parent_index <= last_ministep)
+        {
+           int_vector_append( parent_report_first_index, first_parent_index );
+           if (last_parent_index > last_ministep)
+             last_parent_index = last_ministep;
+           int_vector_append( parent_report_last_index, last_parent_index );
+        }
+        else
+           break;
+     }
+     else
+     {
+        int_vector_append( parent_report_first_index, INVALID_MINISTEP_NR );
+        int_vector_append( parent_report_last_index, INVALID_MINISTEP_NR );
+     }
+  }
+}
+
+
+void ecl_sum_file_data_type::build_index( ) {
+  /* Clear the existing index (if any): */
+  clear_index();
+
+  /*
+    Sort the internal storage vector after sim_time.
+  */
+  vector_sort( data , cmp_ministep );
+
+
+  /* Identify various global first and last values.  */
+  {
+    const ecl_sum_tstep_type * first_ministep = (const ecl_sum_tstep_type*)vector_iget_const( data, 0 );
+    const ecl_sum_tstep_type * last_ministep  = (const ecl_sum_tstep_type*)vector_get_last_const( data );
+    /*
+       In most cases the days_start and data_start_time will agree
+       with the global simulation start; however in the case where we
+       have loaded a summary case from a restarted simulation where
+       the case we have restarted from is not available - then there
+       will be a difference.
+    */
+    days_start      = ecl_sum_tstep_get_sim_days( first_ministep );
+    sim_length      = ecl_sum_tstep_get_sim_days( last_ministep );
+    start_time      = ecl_sum_tstep_get_sim_time( first_ministep);
+    end_time        = ecl_sum_tstep_get_sim_time( last_ministep );
+  }
+
+  /* Build up the report -> ministep mapping. */
+  {
+    int internal_index;
+    for (internal_index = 0; internal_index < vector_get_size( data ); internal_index++) {
+      const ecl_sum_tstep_type * ministep = iget_ministep( internal_index  );
+      int report_step = ecl_sum_tstep_get_report(ministep);
+      /* Indexing internal_index - report_step */
+      {
+        int current_first_index = int_vector_safe_iget( report_first_index , report_step );
+        if (current_first_index < 0) /* i.e. currently not set. */
+            int_vector_iset( report_first_index , report_step , internal_index);
+        else
+          if (internal_index  < current_first_index)
+            int_vector_iset( report_first_index , report_step , internal_index);
+      }
+
+      {
+        int current_last_index =  int_vector_safe_iget( report_last_index , report_step );
+        if (current_last_index < 0)
+          int_vector_iset( report_last_index , report_step ,  internal_index);
+        else
+          if (internal_index > current_last_index)
+            int_vector_iset( report_last_index , report_step , internal_index);
+      }
+
+      first_report_step = util_int_min( first_report_step , report_step );
+      last_report_step  = util_int_max( last_report_step  , report_step );
+    }
+  }
+  index_valid = true;
+}
+
+
+void ecl_sum_file_data_type::update_data_vector( double_vector_type * data_vector , int data_index , bool report_only, int end_min_step) {
+
+  if (end_min_step >= get_length())
+    throw std::invalid_argument(__PRETTY_FUNCTION__ + std::string(": argument 'end_min_step' too high."));
+
+  if (report_only) {
+    int report_step;
+    for (report_step = first_report_step; report_step <= last_report_step; report_step++) {
+      int last_index = int_vector_iget(report_last_index , report_step);
+      if (last_index <= end_min_step)
+        double_vector_append( data_vector, iget(last_index, data_index) );
+    }
+  } else {
+    int i;
+    for (i = 0; i <= end_min_step; i++)
+      double_vector_append( data_vector, iget(i, data_index) );
+  }
+}
+
+
+bool ecl_sum_file_data_type::has_report_step(int report_step ) const {
+  if (int_vector_safe_iget( report_first_index , report_step) >= 0)
+    return true;
+  else
+    return false;
+}
+
+
+// ******************** Start writing ***************************************************
+
+
+void ecl_sum_file_data_type::report2internal_range(int report_step , int * index1 , int * index2 ) const {
+  if (index1 != NULL)
+    *index1 = int_vector_safe_iget( report_first_index , report_step );
+
+  if (index2 != NULL)
+    *index2 = int_vector_safe_iget( report_last_index  , report_step );
+}
+
+
+void ecl_sum_file_data_type::fwrite_report__( int report_step , fortio_type * fortio) const {
+  {
+    ecl_kw_type * seqhdr_kw = ecl_kw_alloc( SEQHDR_KW , SEQHDR_SIZE , ECL_INT );
+    ecl_kw_iset_int( seqhdr_kw , 0 , 0 );
+    ecl_kw_fwrite( seqhdr_kw , fortio );
+    ecl_kw_free( seqhdr_kw );
+  }
+
+  {
+    int index , index1 , index2;
+
+    report2internal_range( report_step , &index1 , &index2);
+    for (index = index1; index <= index2; index++) {
+      const ecl_sum_tstep_type * tstep = iget_ministep( index );
+      ecl_sum_tstep_fwrite( tstep , ecl_smspec_get_index_map( smspec ) , fortio );
+    }
+  }
+}
+
+
+void ecl_sum_file_data_type::fwrite_unified( fortio_type * fortio ) const {
+
+  for (int report_step = first_report_step; report_step <= last_report_step; report_step++) {
+    if (has_report_step( report_step ))
+      fwrite_report__( report_step , fortio );
+  }
+}
+
+
+void ecl_sum_file_data_type::fwrite_multiple( const char * ecl_case , bool fmt_case ) const {
+  int report_step;
+
+  for (report_step = first_report_step; report_step <= last_report_step; report_step++) {
+    if (has_report_step( report_step )) {
+      char * filename = ecl_util_alloc_filename( NULL , ecl_case , ECL_SUMMARY_FILE , fmt_case , report_step );
+      fortio_type * fortio = fortio_open_writer( filename , fmt_case , ECL_ENDIAN_FLIP );
+
+      fwrite_report__( report_step , fortio );
+
+      fortio_fclose( fortio );
+      free( filename );
+    }
+  }
+
+}
+
+
+// ***************************** End writing *************************************
+
+// **************************** Start Reading ************************************
+
+bool ecl_sum_file_data_type::check_file( ecl_file_type * ecl_file ) {
+  if (ecl_file_has_kw( ecl_file , PARAMS_KW ) &&
+      (ecl_file_get_num_named_kw( ecl_file , PARAMS_KW ) == ecl_file_get_num_named_kw( ecl_file , MINISTEP_KW)))
+    return true;
+  else
+    return false;
+}
+
+/**
+   Malformed/incomplete files:
+   ----------------------------
+   Observe that ECLIPSE works in the following way:
+
+     1. At the start of a report step a summary data section
+        containing only the 'SEQHDR' keyword is written - this is
+        currently an 'invalid' summary section.
+
+     2. ECLIPSE simulates as best it can.
+
+     3. When the time step is complete data is written to the summary
+        file.
+
+   Now - if ECLIPSE goes down in flames during step 2 a malformed
+   summary file will be left around, to handle this situation
+   reasonably gracefully we check that the ecl_file instance has at
+   least one "PARAMS" keyword.
+
+   One ecl_file corresponds to one report_step (limited by SEQHDR); in
+   the case of non unfied summary files these objects correspond to
+   one BASE.Annnn or BASE.Snnnn file, in the case of unified files the
+   calling routine will read the unified summary file partly.
+*/
+
+void ecl_sum_file_data_type::add_ecl_file(int report_step, const ecl_file_view_type * summary_view, const ecl_smspec_type * smspec) {
+
+  int num_ministep  = ecl_file_view_get_num_named_kw( summary_view , PARAMS_KW);
+  if (num_ministep > 0) {
+    int ikw;
+
+    for (ikw = 0; ikw < num_ministep; ikw++) {
+      ecl_kw_type * ministep_kw = ecl_file_view_iget_named_kw( summary_view , MINISTEP_KW , ikw);
+      ecl_kw_type * params_kw   = ecl_file_view_iget_named_kw( summary_view , PARAMS_KW   , ikw);
+
+      {
+        int ministep_nr = ecl_kw_iget_int( ministep_kw , 0 );
+        ecl_sum_tstep_type * tstep = ecl_sum_tstep_alloc_from_file( report_step ,
+                                                                    ministep_nr ,
+                                                                    params_kw ,
+                                                                    ecl_file_view_get_src_file( summary_view ),
+                                                                    smspec );
+
+        if (tstep)
+            append_tstep__( tstep );
+      }
+    }
+  }
+}
+
+
+bool ecl_sum_file_data_type::fread(const stringlist_type * filelist) {
+  if (stringlist_get_size( filelist ) == 0)
+    return false;
+
+  {
+    ecl_file_enum file_type = ecl_util_get_file_type( stringlist_iget( filelist , 0 ) , NULL , NULL);
+    if ((stringlist_get_size( filelist ) > 1) && (file_type != ECL_SUMMARY_FILE))
+      util_abort("%s: internal error - when calling with more than one file - you can not supply a unified file - come on?! \n",__func__);
+
+    {
+      int filenr;
+      if (file_type == ECL_SUMMARY_FILE) {
+
+        /* Not unified. */
+        for (filenr = 0; filenr < stringlist_get_size( filelist ); filenr++) {
+          const char * data_file = stringlist_iget( filelist , filenr);
+          ecl_file_enum file_type;
+          int report_step;
+          file_type = ecl_util_get_file_type( data_file , NULL , &report_step);
+          if (file_type != ECL_SUMMARY_FILE)
+            util_abort("%s: file:%s has wrong type \n",__func__ , data_file);
+          {
+            ecl_file_type * ecl_file = ecl_file_open( data_file , 0);
+            if (ecl_file && check_file( ecl_file )) {
+              add_ecl_file( report_step , ecl_file_get_global_view( ecl_file ) , smspec);
+              ecl_file_close( ecl_file );
+            }
+          }
+        }
+      } else if (file_type == ECL_UNIFIED_SUMMARY_FILE) {
+        ecl_file_type * ecl_file = ecl_file_open( stringlist_iget(filelist ,0 ) , 0);
+        if (ecl_file && check_file( ecl_file )) {
+          int report_step = 1;   /* <- ECLIPSE numbering - starting at 1. */
+          while (true) {
+            /*
+              Observe that there is a number discrepancy between ECLIPSE
+              and the ecl_file_select_smryblock() function. ECLIPSE
+              starts counting report steps at 1; whereas the first
+              SEQHDR block in the unified summary file is block zero (in
+              ert counting).
+            */
+            ecl_file_view_type * summary_view = ecl_file_get_summary_view(ecl_file , report_step - 1 );
+            if (summary_view) {
+              add_ecl_file(report_step , summary_view , smspec);
+              report_step++;
+            } else break;
+          }
+          ecl_file_close( ecl_file );
+        }
+      }
+    }
+
+
+    if (get_length() > 0) {
+      build_index();
+      return true;
+    } else
+      return false;
+
+  }
+}
+
+// ***************************** End reading *************************************
+
+
+} //end namespace
+
+

--- a/lib/ecl/tests/ecl_sum_alloc_resampled_test.c
+++ b/lib/ecl/tests/ecl_sum_alloc_resampled_test.c
@@ -51,7 +51,6 @@ void test_correct_time_vector() {
   test_assert_double_equal(3.33333, ecl_sum_get_from_sim_time( ecl_sum_resampled, util_make_date_utc( 2,1,2010 ), node2) );
   test_assert_double_equal(10.0000, ecl_sum_get_from_sim_time( ecl_sum_resampled, util_make_date_utc( 4,1,2010 ), node3) );
 
-
   ecl_sum_free(ecl_sum_resampled);
   time_t_vector_free(t);
   ecl_sum_free(ecl_sum);

--- a/lib/ecl/tests/ecl_sum_data_intermediate_test.cpp
+++ b/lib/ecl/tests/ecl_sum_data_intermediate_test.cpp
@@ -1,0 +1,166 @@
+#include <vector>
+
+#include <ert/util/TestArea.hpp>
+#include <ert/util/test_util.hpp>
+#include <ert/util/double_vector.h>
+#include <ert/util/vector.h>
+
+#include <ert/ecl/ecl_sum.hpp>
+
+
+void assert_values(ecl_sum_type * ecl_sum) {
+  const ecl_smspec_type * smspec_resampled = ecl_sum_get_smspec(ecl_sum);
+  const smspec_node_type * node2 = ecl_smspec_iget_node(smspec_resampled, 2);
+
+  test_assert_string_equal( "BPR" , smspec_node_get_keyword(node2) );
+  test_assert_string_equal( "BARS" , smspec_node_get_unit(node2) );
+
+  double_vector_type * data = ecl_sum_alloc_data_vector( ecl_sum, 2, false );
+
+  test_assert_double_equal( double_vector_iget(data, 1), 2.0 );
+  test_assert_double_equal( double_vector_iget(data, 2), 6.0 );
+  test_assert_double_equal( double_vector_iget(data, 3), 10.0 );
+
+  double_vector_free( data );
+}
+
+
+void write_ecl_sum(bool unified) {
+  time_t start_time = util_make_date_utc( 1,1,2010 );
+  ecl_sum_type * ecl_sum = ecl_sum_alloc_writer( "CASE" , false , unified , ":" , start_time , true , 10 , 10 , 10 );
+  double sim_seconds = 0;
+
+  int num_dates = 4;
+  double ministep_length = 86400; // seconds in a day
+
+  smspec_node_type * node1 = ecl_sum_add_var( ecl_sum , "FOPT" , NULL   , 0   , "Barrels" , 99.0 );
+  smspec_node_type * node2 = ecl_sum_add_var( ecl_sum , "BPR"  , NULL   , 567 , "BARS"    , 0.0  );
+  smspec_node_type * node3 = ecl_sum_add_var( ecl_sum , "WWCT" , "OP-1" , 0   , "(1)"     , 0.0  );
+
+  for (int report_step = 0; report_step < num_dates; report_step++) {
+      {
+        ecl_sum_tstep_type * tstep = ecl_sum_add_tstep( ecl_sum , report_step + 1 , sim_seconds );
+        ecl_sum_tstep_set_from_node( tstep , node1 , report_step*2.0 );
+        ecl_sum_tstep_set_from_node( tstep , node2 , report_step*4.0 + 2.0 );
+        ecl_sum_tstep_set_from_node( tstep , node3 , report_step*6.0 + 4.0 );
+      }
+      sim_seconds += ministep_length * 3;
+  }
+  assert_values( ecl_sum );
+  ecl_sum_fwrite( ecl_sum );
+  ecl_sum_free(ecl_sum);
+}
+
+
+void write_restart_sum() {
+  time_t start_time = util_make_date_utc( 1,1,2010 );
+  int num_dates = 3;
+  double ministep_length = 86400; // seconds in a day
+  double sim_seconds = ministep_length * 2.5 * 3;
+  ecl_sum_type * ecl_sum = ecl_sum_alloc_restart_writer( "CASE_RESTART" , "CASE", false , true , ":" , start_time , true , 10 , 10 , 10 );
+ 
+  smspec_node_type * node2 = ecl_sum_add_var( ecl_sum , "BPR"  , NULL   , 567 , "BARS"    , 0.0  ); 
+  smspec_node_type * node1 = ecl_sum_add_var( ecl_sum , "FOPT" , NULL   , 0   , "Barrels" , 99.0 );
+
+  for (int report_step_ = 0; report_step_ < num_dates; report_step_++) {
+      {
+        int report_step = report_step_ + 3;
+        ecl_sum_tstep_type * tstep = ecl_sum_add_tstep( ecl_sum , report_step + 1 , sim_seconds );
+        ecl_sum_tstep_set_from_node( tstep , node1 , report_step*3.0 );
+        ecl_sum_tstep_set_from_node( tstep , node2 , report_step*4.0 + 2.0 );
+      }
+      sim_seconds += ministep_length * 3;
+  }  
+  ecl_sum_fwrite( ecl_sum );
+  ecl_sum_free(ecl_sum);
+}
+
+void write_restart_sum_1() {
+  time_t start_time = util_make_date_utc( 1,1,2010 );
+  int num_dates = 2;
+  double ministep_length = 86400; // seconds in a day
+  double sim_seconds = ministep_length * 4.0 * 3;
+  ecl_sum_type * ecl_sum = ecl_sum_alloc_restart_writer( "CASE_RESTART_1" , "CASE_RESTART", false , true , ":" , start_time , true , 10 , 10 , 10 );
+ 
+  smspec_node_type * node3 = ecl_sum_add_var( ecl_sum , "WWCT" , "OP-1" , 0   , "(1)"     , 0.0  );
+  smspec_node_type * node2 = ecl_sum_add_var( ecl_sum , "BPR"  , NULL   , 567 , "BARS"    , 0.0  );
+  smspec_node_type * node1 = ecl_sum_add_var( ecl_sum , "FOPT" , NULL   , 0   , "Barrels" , 99.0 ); 
+
+  for (int report_step_ = 0; report_step_ < num_dates; report_step_++) {
+      {
+        int report_step = report_step_ + 5;
+        ecl_sum_tstep_type * tstep = ecl_sum_add_tstep( ecl_sum , report_step + 1 , sim_seconds );
+        ecl_sum_tstep_set_from_node( tstep , node1 , report_step*5.0 );
+        ecl_sum_tstep_set_from_node( tstep , node2 , report_step*4.0 + 2.0 );
+        ecl_sum_tstep_set_from_node( tstep , node3 , report_step*6.0 + 4.0 );
+      }
+      sim_seconds += ministep_length * 3;
+  }  
+  ecl_sum_fwrite( ecl_sum );
+  ecl_sum_free(ecl_sum);
+}
+
+
+void test_read_write(bool unified) {
+  write_ecl_sum(unified);
+  ecl_sum_type * ecl_sum = ecl_sum_fread_alloc_case( "CASE" , ":");
+  assert_values(ecl_sum);
+  ecl_sum_free( ecl_sum );
+
+  write_restart_sum();
+  ecl_sum_type * ecl_sum_restart = ecl_sum_fread_alloc_case( "CASE_RESTART" , ":");
+
+  test_assert_int_equal( ecl_sum_get_data_length( ecl_sum_restart ), 6 );
+  double_vector_type * data = ecl_sum_alloc_data_vector( ecl_sum_restart, 2, false );
+  test_assert_double_equal( double_vector_iget(data, 1),  0.0 );
+  test_assert_double_equal( double_vector_iget(data, 2),  2.0 );
+  test_assert_double_equal( double_vector_iget(data, 3),  4.0 );
+  test_assert_double_equal( double_vector_iget(data, 4),  9.0 );
+  test_assert_double_equal( double_vector_iget(data, 5), 12.0 );
+  test_assert_double_equal( double_vector_iget(data, 6), 15.0 );
+  double_vector_free( data );
+  ecl_sum_free( ecl_sum_restart );
+
+  write_restart_sum_1();
+  ecl_sum_type * ecl_sum_restart_1 = ecl_sum_fread_alloc_case( "CASE_RESTART_1" , ":");
+  test_assert_int_equal( ecl_sum_get_data_length( ecl_sum_restart_1 ), 7 );
+  data = ecl_sum_alloc_data_vector( ecl_sum_restart_1, 3, false );
+  test_assert_double_equal( double_vector_iget(data, 1),  0.0 );
+  test_assert_double_equal( double_vector_iget(data, 2),  2.0 );
+  test_assert_double_equal( double_vector_iget(data, 3),  4.0 );
+  test_assert_double_equal( double_vector_iget(data, 4),  9.0 );
+  test_assert_double_equal( double_vector_iget(data, 5), 12.0 );
+  test_assert_double_equal( double_vector_iget(data, 6), 25.0 );
+  test_assert_double_equal( double_vector_iget(data, 7), 30.0 );
+  double_vector_free( data );
+
+  data = ecl_sum_alloc_data_vector( ecl_sum_restart_1, 1, false );
+  test_assert_double_equal( double_vector_iget(data, 1),  0.0 );
+  test_assert_double_equal( double_vector_iget(data, 2),  0.0 );
+  test_assert_double_equal( double_vector_iget(data, 3),  0.0 );
+  test_assert_double_equal( double_vector_iget(data, 4),  0.0 );
+  test_assert_double_equal( double_vector_iget(data, 5),  0.0 );
+  test_assert_double_equal( double_vector_iget(data, 6), 34.0 );
+  test_assert_double_equal( double_vector_iget(data, 7), 40.0 );
+  double_vector_free( data );
+
+  const ecl_smspec_type * smspec = ecl_sum_get_smspec(ecl_sum_restart_1);
+  const smspec_node_type * node3 = ecl_smspec_iget_node(smspec, 3);
+  time_t day = 86400;
+  time_t t0 = util_make_date_utc( 1,1,2010 );
+  time_t t1 = t0 + 3 * day;     //step 2
+  time_t t2 = t0 + 6.75 * day;  //directly between step 3 and 4
+
+  test_assert_double_equal(2.0000, ecl_sum_get_from_sim_time( ecl_sum_restart_1, t1, node3) );
+  test_assert_double_equal(6.5000, ecl_sum_get_from_sim_time( ecl_sum_restart_1, t2, node3) );
+
+  ecl_sum_free( ecl_sum_restart_1 );
+}
+
+
+
+int main() {
+  test_read_write(true);
+  test_read_write(false);
+  return 0;
+}

--- a/lib/ecl/tests/ecl_sum_writer.c
+++ b/lib/ecl/tests/ecl_sum_writer.c
@@ -164,7 +164,7 @@ void test_ecl_sum_alloc_restart_writer() {
 
       for (int time_index=0; time_index < ecl_sum_get_data_length( case1 ); time_index++)
          test_assert_double_equal(  ecl_sum_get_general_var( case1 , time_index , "FOPT"), ecl_sum_get_general_var( case2 , time_index , "FOPT"));
-
+      
       ecl_sum_free(case2);
       ecl_sum_free(case1);
       ecl_file_close(restart_file);

--- a/lib/include/ert/ecl/ecl_smspec.h
+++ b/lib/include/ert/ecl/ecl_smspec.h
@@ -46,6 +46,7 @@ typedef struct ecl_smspec_struct ecl_smspec_type;
 */
 
   int * ecl_smspec_alloc_mapping( const ecl_smspec_type * self, const ecl_smspec_type * other);
+  int * ecl_smspec_alloc_self_mapping( const ecl_smspec_type * self );
   const int_vector_type * ecl_smspec_get_index_map( const ecl_smspec_type * smspec );
   void                ecl_smspec_index_node( ecl_smspec_type * ecl_smspec , smspec_node_type * smspec_node);
   void                ecl_smspec_insert_node(ecl_smspec_type * ecl_smspec, smspec_node_type * smspec_node);

--- a/lib/include/ert/ecl/ecl_sum_data.h
+++ b/lib/include/ert/ecl/ecl_sum_data.h
@@ -42,6 +42,7 @@ typedef struct ecl_sum_data_struct ecl_sum_data_type ;
   void                     ecl_sum_data_fwrite( const ecl_sum_data_type * data , const char * ecl_case , bool fmt_case , bool unified);
   bool                     ecl_sum_data_fread( ecl_sum_data_type * data , const stringlist_type * filelist);
   ecl_sum_data_type      * ecl_sum_data_alloc_writer( ecl_smspec_type * smspec );
+  void                     ecl_sum_data_reset_self_map( ecl_sum_data_type * data );
   ecl_sum_data_type      * ecl_sum_data_alloc( ecl_smspec_type * smspec);
   double                   ecl_sum_data_time2days( const ecl_sum_data_type * data , time_t sim_time);
   int                      ecl_sum_data_get_report_step_from_time(const ecl_sum_data_type * data , time_t sim_time);

--- a/lib/include/ert/ecl/ecl_sum_file_data.hpp
+++ b/lib/include/ert/ecl/ecl_sum_file_data.hpp
@@ -1,0 +1,65 @@
+
+#include <ert/util/vector.hpp>
+#include <ert/util/double_vector.h>
+
+#include <ert/ecl/ecl_smspec.hpp>
+#include <ert/ecl/ecl_sum_tstep.hpp>
+#include <ert/ecl/ecl_file.hpp>
+
+namespace ecl {
+
+#define INVALID_MINISTEP_NR -1
+#define INVALID_TIME_T 0
+
+class ecl_sum_file_data_type {
+
+  double  days_start;
+  double  sim_length;
+  int first_report_step;
+  int last_report_step;
+  ecl_smspec_type * smspec;
+  vector_type * data;
+  int_vector_type * report_first_index;
+  int_vector_type * report_last_index;
+  bool         index_valid;
+  time_t       start_time;             /* In the case of restarts the start might disagree with the value reported
+                                          in the smspec file. */
+  time_t       end_time;
+
+
+  void                 clear_index();
+  void                 append_tstep__(ecl_sum_tstep_type * tstep);
+
+  void                 build_index();
+  bool                 has_report_step(int report_step ) const;
+  void                 report2internal_range(int report_step , int * index1 , int * index2 ) const;
+  void                 fwrite_report__( int report_step , fortio_type * fortio) const;
+  bool                 check_file( ecl_file_type * ecl_file );
+  void                 add_ecl_file(int report_step, const ecl_file_view_type * summary_view, const ecl_smspec_type * smspec);
+
+  public:
+    ecl_sum_file_data_type(ecl_smspec_type * smspec);
+    ~ecl_sum_file_data_type();
+
+    int                  get_length();
+    time_t               get_data_start();
+    time_t               get_sim_end();
+    int                  get_first_report_step();
+    int                  get_last_report_step();
+    double               iget( int time_index , int params_index );
+    ecl_sum_tstep_type * iget_ministep( int internal_index ) const;
+
+    ecl_sum_tstep_type * add_new_tstep(int report_step , double sim_seconds);
+    void                 update_data_vector( double_vector_type * data_vector , int data_index , bool report_only, int end_min_step);
+    void                 update_report_vectors( int_vector_type * parent_report_first_index, int_vector_type * parent_report_last_index, int first_mini_step, int last_ministep );
+    void                 fwrite_unified( fortio_type * fortio ) const;
+    void                 fwrite_multiple( const char * ecl_case , bool fmt_case ) const;
+    bool                 fread(const stringlist_type * filelist);
+
+
+};
+
+
+
+
+}

--- a/lib/include/ert/ecl/ecl_sum_file_data.hpp
+++ b/lib/include/ert/ecl/ecl_sum_file_data.hpp
@@ -41,12 +41,14 @@ class ecl_sum_file_data_type {
     ecl_sum_file_data_type(ecl_smspec_type * smspec);
     ~ecl_sum_file_data_type();
 
-    int                  get_length();
-    time_t               get_data_start();
-    time_t               get_sim_end();
-    int                  get_first_report_step();
-    int                  get_last_report_step();
-    double               iget( int time_index , int params_index );
+    int                  get_length() const;
+    time_t               get_data_start() const;
+    time_t               get_sim_end() const;
+    int                  get_first_report_step() const;
+    int                  get_last_report_step() const;
+    double               iget( int time_index , int params_index ) const;
+    time_t               iget_sim_time(int time_index ) const;
+    double               iget_seconds(int time_index) const;
     ecl_sum_tstep_type * iget_ministep( int internal_index ) const;
 
     ecl_sum_tstep_type * add_new_tstep(int report_step , double sim_seconds);


### PR DESCRIPTION
**Task**
Refactor ecl_sum_data to be compatible to use the new unsmry_loader. 


**Approach**
The data contained in ecl_sum_data is split in severl ecl_sum_file_data_type instances. 


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
