### PR TITLE
Swap include

### DIFF
--- a/lib/include/ert/ecl/ecl_box.h
+++ b/lib/include/ert/ecl/ecl_box.h
@@ -1,29 +1,29 @@
 /*
-   Copyright (C) 2011  Statoil ASA, Norway. 
-    
-   The file 'ecl_box.h' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'ecl_box.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #ifndef ERT_ECL_BOX_H
 #define ERT_ECL_BOX_H
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <ert/ecl/ecl_grid.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct ecl_box_struct ecl_box_type;
 

--- a/lib/include/ert/ecl/ecl_grav.h
+++ b/lib/include/ert/ecl/ecl_grav.h
@@ -18,15 +18,15 @@
 
 #ifndef ERT_ECL_GRAV_H
 #define ERT_ECL_GRAV_H
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <ert/ecl/ecl_file.h>
 #include <ert/ecl/ecl_file_view.h>
 #include <ert/ecl/ecl_grid.h>
 #include <ert/ecl/ecl_region.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 typedef struct ecl_grav_struct            ecl_grav_type;
 typedef struct ecl_grav_survey_struct     ecl_grav_survey_type;
 

--- a/lib/include/ert/ecl/ecl_nnc_data.h
+++ b/lib/include/ert/ecl/ecl_nnc_data.h
@@ -18,14 +18,15 @@
 
 #ifndef ECL_NNC_DATA_H
 #define ECL_NNC_DATA_H
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <ert/util/type_macros.h>
 
 #include <ert/ecl/ecl_nnc_geometry.h>
 #include <ert/ecl/ecl_nnc_export.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct ecl_nnc_data_struct ecl_nnc_data_type;
 

--- a/lib/include/ert/ecl/ecl_nnc_export.h
+++ b/lib/include/ert/ecl/ecl_nnc_export.h
@@ -20,15 +20,16 @@
 #ifndef ERT_ECL_NNC_EXPORT
 #define ERT_ECL_NNC_EXPORT
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <math.h>
 
 #include <ert/ecl/ecl_grid.h>
 #include <ert/ecl/ecl_file.h>
 #include <ert/ecl/ecl_kw.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define ERT_ECL_DEFAULT_NNC_TRANS HUGE_VAL
 

--- a/lib/include/ert/ecl/ecl_nnc_geometry.h
+++ b/lib/include/ert/ecl/ecl_nnc_geometry.h
@@ -18,13 +18,14 @@
 
 #ifndef ERT_NNC_GEOMETRY_H
 #define ERT_NNC_GEOMETRY_H
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <ert/util/type_macros.h>
 
 #include <ert/ecl/ecl_grid.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct ecl_nnc_geometry_struct ecl_nnc_geometry_type;
 typedef struct ecl_nnc_pair_struct ecl_nnc_pair_type;

--- a/lib/include/ert/ecl/ecl_region.h
+++ b/lib/include/ert/ecl/ecl_region.h
@@ -18,9 +18,6 @@
 
 #ifndef ERT_ECL_REGION_H
 #define ERT_ECL_REGION_H
-#ifdef __cplusplus
-extern "C" {
-#endif
 #include <stdbool.h>
 
 #include <ert/util/int_vector.h>
@@ -31,6 +28,9 @@ extern "C" {
 #include <ert/ecl/ecl_grid.h>
 #include <ert/ecl/layer.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef enum {
   SELECT_ALL           =  0,

--- a/lib/include/ert/ecl/layer.h
+++ b/lib/include/ert/ecl/layer.h
@@ -19,15 +19,16 @@
 #ifndef ERT_LAYER_H
 #define ERT_LAYER_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <ert/util/int_vector.h>
 #include <ert/util/struct_vector.h>
 #include <ert/util/type_macros.h>
 
 #include <ert/ecl/ecl_grid.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /*
    The elements in this enum are (ab)used as indexes into a int[] vector;

--- a/lib/include/ert/ecl_well/well_conn.h
+++ b/lib/include/ert/ecl_well/well_conn.h
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2011  Statoil ASA, Norway. 
-   
-   The file 'well_conn.h' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'well_conn.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 
@@ -21,15 +21,16 @@
 #define ERT_WELL_CONN_H
 
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-  
+
 #include <stdbool.h>
 
 #include <ert/util/type_macros.h>
 
 #include <ert/ecl/ecl_rsthead.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
   typedef enum {
     well_conn_dirX  = 1,

--- a/lib/include/ert/ecl_well/well_info.h
+++ b/lib/include/ert/ecl_well/well_info.h
@@ -1,36 +1,37 @@
 /*
-   Copyright (C) 2011  Statoil ASA, Norway. 
-    
-   The file 'well_info.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'well_info.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #ifndef ERT_WELL_INFO_H
 #define ERT_WELL_INFO_H
 
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <ert/ecl/ecl_file.h>
 #include <ert/ecl/ecl_grid.h>
 
 #include <ert/ecl_well/well_ts.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
   typedef struct well_info_struct well_info_type;
-  
+
   well_info_type *  well_info_alloc(const ecl_grid_type * grid);
   void              well_info_add_UNRST_wells2( well_info_type * well_info , ecl_file_view_type * rst_view, bool load_segment_information);
   void              well_info_add_UNRST_wells( well_info_type * well_info , ecl_file_type * rst_file, bool load_segment_information);
@@ -44,7 +45,7 @@ extern "C" {
   int               well_info_get_num_wells( const well_info_type * well_info );
   const char      * well_info_iget_well_name( const well_info_type * well_info, int well_index);
   bool              well_info_has_well( well_info_type * well_info , const char * well_name );
-  
+
   well_state_type * well_info_get_state_from_time( const well_info_type * well_info , const char * well_name , time_t sim_time);
   well_state_type * well_info_get_state_from_report( const well_info_type * well_info , const char * well_name , int report_step );
   well_state_type * well_info_iget_state( const well_info_type * well_info , const char * well_name , int time_index);

--- a/lib/include/ert/ecl_well/well_state.h
+++ b/lib/include/ert/ecl_well/well_state.h
@@ -20,9 +20,6 @@
 #ifndef ERT_WELL_STATE_H
 #define ERT_WELL_STATE_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <time.h>
 
@@ -35,6 +32,9 @@ extern "C" {
 #include <ert/ecl_well/well_segment_collection.h>
 #include <ert/ecl_well/well_branch_collection.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define GLOBAL_GRID_NAME   "GLOBAL" // The name assigned to the global grid for name based lookup.
 

--- a/lib/include/ert/ecl_well/well_ts.h
+++ b/lib/include/ert/ecl_well/well_ts.h
@@ -1,31 +1,31 @@
 /*
-   Copyright (C) 2011  Statoil ASA, Norway. 
-    
-   The file 'well_ts.h' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'well_ts.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 
 #ifndef ERT_WELL_TS_H
 #define ERT_WELL_TS_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <ert/ecl_well/well_state.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
   typedef struct well_ts_struct well_ts_type;
 


### PR DESCRIPTION
Have moved the real content from `xxx.h` to `xxx.hpp` and keeping `xxx.h` as a temporary compatability.
