### PR TITLE
Remove function initialize double_vector from API

### DIFF
--- a/lib/ecl/ecl_sum.cpp
+++ b/lib/ecl/ecl_sum.cpp
@@ -895,17 +895,9 @@ int ecl_sum_iget_mini_step( const ecl_sum_type * ecl_sum , int internal_index ){
 }
 
 
-void ecl_sum_init_time_vector( const ecl_sum_type * ecl_sum , time_t_vector_type * time_vector , bool report_only ) {
-  ecl_sum_data_init_time_vector( ecl_sum->data , time_vector , report_only );
-}
-
 
 time_t_vector_type * ecl_sum_alloc_time_vector( const ecl_sum_type * ecl_sum  , bool report_only) {
   return ecl_sum_data_alloc_time_vector( ecl_sum->data , report_only );
-}
-
-void ecl_sum_init_data_vector( const ecl_sum_type * ecl_sum , double_vector_type * data_vector , int data_index , bool report_only ) {
-  ecl_sum_data_init_data_vector( ecl_sum->data , data_vector , data_index , report_only );
 }
 
 

--- a/lib/ecl/ecl_sum_data.cpp
+++ b/lib/ecl/ecl_sum_data.cpp
@@ -1385,7 +1385,7 @@ time_t_vector_type *  ecl_sum_data_alloc_time_vector( const ecl_sum_data_type * 
 }
 
 
-void ecl_sum_data_init_data_vector( const ecl_sum_data_type * data , double_vector_type * data_vector , int data_index , bool report_only) {
+static void ecl_sum_data_init_data_vector( const ecl_sum_data_type * data , double_vector_type * data_vector , int data_index , bool report_only) {
   double_vector_reset( data_vector );
   double_vector_append( data_vector , ecl_smspec_get_start_time( data->smspec ));
   if (report_only) {

--- a/lib/include/ert/ecl/ecl_sum.h
+++ b/lib/include/ert/ecl/ecl_sum.h
@@ -160,10 +160,6 @@ typedef struct ecl_sum_struct       ecl_sum_type;
   double ecl_sum_iget_general_var(const ecl_sum_type * ecl_sum , int internal_index , const char * lookup_kw);
 
 
-  void                 ecl_sum_init_data_vector(const ecl_sum_type * ecl_sum ,
-                                                double_vector_type * data_vector ,
-                                                int data_index ,
-                                                bool report_only );
   double_vector_type * ecl_sum_alloc_data_vector( const ecl_sum_type * ecl_sum  , int data_index , bool report_only);
   time_t_vector_type * ecl_sum_alloc_time_vector( const ecl_sum_type * ecl_sum  , bool report_only);
   time_t       ecl_sum_get_data_start( const ecl_sum_type * ecl_sum );

--- a/lib/include/ert/ecl/ecl_sum_data.h
+++ b/lib/include/ert/ecl/ecl_sum_data.h
@@ -50,7 +50,6 @@ typedef struct ecl_sum_data_struct ecl_sum_data_type ;
   bool                     ecl_sum_data_check_sim_days( const ecl_sum_data_type * data , double sim_days);
   int                      ecl_sum_data_get_num_ministep( const ecl_sum_data_type * data );
   double_vector_type     * ecl_sum_data_alloc_data_vector( const ecl_sum_data_type * data , int data_index , bool report_only);
-  void                     ecl_sum_data_init_data_vector( const ecl_sum_data_type * data , double_vector_type * data_vector , int data_index , bool report_only);
   void                     ecl_sum_data_init_time_vector( const ecl_sum_data_type * data , time_t_vector_type * time_vector , bool report_only);
   time_t_vector_type     * ecl_sum_data_alloc_time_vector( const ecl_sum_data_type * data , bool report_only);
   time_t                   ecl_sum_data_get_data_start( const ecl_sum_data_type * data );


### PR DESCRIPTION
Minor simplification in the #432 process.
