### PR TITLE
Unsmry loader fixup

### DIFF
--- a/lib/ecl/ecl_sum_file_data.cpp
+++ b/lib/ecl/ecl_sum_file_data.cpp
@@ -416,8 +416,13 @@ int ecl_sum_file_data::get_time_report(int end_index, time_t *data) {
 
 
 void ecl_sum_file_data::get_data(int params_index, int length, double *data) {
-  for (int time_index=0; time_index < length; time_index++)
-    data[time_index] = this->iget(time_index, params_index);
+  if (this->loader) {
+    const auto tmp_data = loader->get_vector(params_index);
+    memcpy(data, tmp_data.data(), length * sizeof data);
+  } else {
+    for (int time_index=0; time_index < length; time_index++)
+      data[time_index] = this->iget(time_index, params_index);
+  }
 }
 
 

--- a/lib/ecl/ecl_sum_file_data.cpp
+++ b/lib/ecl/ecl_sum_file_data.cpp
@@ -372,9 +372,12 @@ void ecl_sum_file_data::build_index( ) {
   if (this->loader) {
     int offset = ecl_smspec_get_first_step(this->ecl_smspec) - 1;
     std::vector<int> report_steps = this->loader->report_steps(offset);
+    std::vector<time_t> sim_time = this->loader->sim_time();
+    std::vector<double> sim_seconds = this->loader->sim_seconds();
+
     for (int i=0; i < this->loader->length(); i++) {
-      this->index.add(this->loader->iget_sim_time(i),
-                      this->loader->iget_sim_seconds(i),
+      this->index.add(sim_time[i],
+                      sim_seconds[i],
                       report_steps[i]);
     }
   } else {

--- a/lib/ecl/ecl_sum_tstep.cpp
+++ b/lib/ecl/ecl_sum_tstep.cpp
@@ -147,10 +147,10 @@ void ecl_sum_tstep_free__( void * __ministep) {
    will select the DAYS variety if both are present.
 */
 
-static void ecl_sum_tstep_set_time_info_from_seconds( ecl_sum_tstep_type * tstep , time_t sim_start , float sim_seconds) {
+static void ecl_sum_tstep_set_time_info_from_seconds( ecl_sum_tstep_type * tstep , time_t sim_start , double sim_seconds) {
   tstep->sim_seconds = sim_seconds;
   tstep->sim_time = sim_start;
-  util_inplace_forward_seconds_utc( &tstep->sim_time , tstep->sim_seconds );
+  util_inplace_forward_seconds_utc( &tstep->sim_time , tstep->sim_seconds);
 }
 
 

--- a/lib/ecl/ecl_unsmry_loader.cpp
+++ b/lib/ecl/ecl_unsmry_loader.cpp
@@ -56,18 +56,17 @@ std::vector<double> unsmry_loader::get_vector(int pos) const {
   if (pos >= size)
      throw std::invalid_argument("unsmry_loader::get_vector: argument 'pos' mst be less than size of PARAMS.");
 
-   std::vector<double> data(this->length());
-   int_vector_type * index_map = int_vector_alloc( 1 , pos);
-   char buffer[4];
+  std::vector<double> data(this->length());
+  int_vector_type * index_map = int_vector_alloc( 1 , pos);
+  char buffer[4];
 
-   for (int index = 0; index < this->length(); index++) {
-      ecl_file_view_index_fload_kw(file_view, PARAMS_KW, index, index_map, buffer);
-      float * data_value = (float*) buffer;
-      data[index] = *data_value;
-      printf("%d: %18.12f -> %18.12lf \n",index, *data_value, data[index]);
-   }
-   int_vector_free( index_map );
-   return data;
+  for (int index = 0; index < this->length(); index++) {
+    ecl_file_view_index_fload_kw(file_view, PARAMS_KW, index, index_map, buffer);
+    float * data_value = (float*) buffer;
+    data[index] = *data_value;
+  }
+  int_vector_free( index_map );
+  return data;
 }
 
 

--- a/lib/ecl/tests/ecl_sum_writer.cpp
+++ b/lib/ecl/tests/ecl_sum_writer.cpp
@@ -95,7 +95,7 @@ void test_write_read( ) {
   int nz = 12;
   int num_dates = 5;
   int num_ministep = 10;
-  double ministep_length = 36000; // Seconds
+  double ministep_length = 86400; // Seconds - numerical value chosen to avoid rounding problems when converting between seconds and days.
   {
     test_work_area_type * work_area = test_work_area_alloc("sum/write");
     ecl_sum_type * ecl_sum;

--- a/lib/ecl/tests/ecl_unsmry_loader_test.cpp
+++ b/lib/ecl/tests/ecl_unsmry_loader_test.cpp
@@ -42,9 +42,9 @@ void test_load() {
   test_assert_true( util_file_exists("CASE.UNSMRY") );
   ecl::unsmry_loader * loader = new ecl::unsmry_loader(ecl_sum_get_smspec(ecl_sum), "CASE.UNSMRY");
 
-  const std::vector<float>& FOPT_value = loader->get_vector(1);
-  const std::vector<float>& BPR_value  = loader->get_vector(2);
-  const std::vector<float>& WWCT_value = loader->get_vector(3);
+  const std::vector<double> FOPT_value = loader->get_vector(1);
+  const std::vector<double> BPR_value  = loader->get_vector(2);
+  const std::vector<double> WWCT_value = loader->get_vector(3);
   test_assert_int_equal( FOPT_value.size(), 4 );
   test_assert_double_equal( FOPT_value[3] , 6.0 );
   test_assert_double_equal( BPR_value[2]  , 10.0 );

--- a/lib/private-include/detail/ecl/ecl_unsmry_loader.hpp
+++ b/lib/private-include/detail/ecl/ecl_unsmry_loader.hpp
@@ -13,8 +13,11 @@ public:
   unsmry_loader(const ecl_smspec_type * smspec, const std::string& filename);
   ~unsmry_loader();
 
-  const std::vector<float>& get_vector(int pos);
+  const std::vector<float>& get_vector(int pos) const;
+  std::vector<double> sim_seconds() const;
+  std::vector<time_t> sim_time() const;
   int length() const;
+
   time_t iget_sim_time(int time_index) const;
   double iget_sim_seconds(int time_index) const;
   std::vector<int> report_steps(int offset) const;
@@ -31,9 +34,9 @@ private:
   ecl_file_type      * file;
   ecl_file_view_type * file_view;
 
-  std::map<int, std::vector<float>> cache;
+  mutable std::map<int, std::vector<float>> cache;
 
-  void read_data(int pos);
+  void read_data(int pos) const;
 };
 
 

--- a/lib/private-include/detail/ecl/ecl_unsmry_loader.hpp
+++ b/lib/private-include/detail/ecl/ecl_unsmry_loader.hpp
@@ -13,7 +13,7 @@ public:
   unsmry_loader(const ecl_smspec_type * smspec, const std::string& filename);
   ~unsmry_loader();
 
-  const std::vector<float>& get_vector(int pos) const;
+  std::vector<double> get_vector(int pos) const;
   std::vector<double> sim_seconds() const;
   std::vector<time_t> sim_time() const;
   int length() const;
@@ -21,7 +21,7 @@ public:
   time_t iget_sim_time(int time_index) const;
   double iget_sim_seconds(int time_index) const;
   std::vector<int> report_steps(int offset) const;
-  float iget(int time_index, int params_index) const;
+  double iget(int time_index, int params_index) const;
 
 private:
   int size;           //Number of entries in the smspec index
@@ -33,10 +33,6 @@ private:
   std::array<int,3>    date_index;
   ecl_file_type      * file;
   ecl_file_view_type * file_view;
-
-  mutable std::map<int, std::vector<float>> cache;
-
-  void read_data(int pos) const;
 };
 
 


### PR DESCRIPTION
Changes to the unsmry loader:

1. Actually use the load vector functionality.
2. Directly return `std::vector<double>` - do not go through `float`.
3. Convert floating point value with `round()` before shifting seconds in time calculations.
4. Do not cache the vectors in the unsmry loader.
