### PR TITLE
fortio_data_fseek: set back to level of libecl pr no. 423.

### DIFF
--- a/lib/ecl/fortio.c
+++ b/lib/ecl/fortio.c
@@ -452,16 +452,14 @@ void fortio_data_fseek(fortio_type* fortio, offset_type data_offset, size_t data
     if(data_element >= element_count) {
         util_abort("%s: Element index is out of range: 0 <= %d < %d \n", __func__, data_element, element_count);
     }
+    {
+      int block_index = data_element / block_size;
+      int headers = (block_index + 1) * 4;
+      int trailers = block_index * 4;
+      offset_type bytes_to_skip = data_offset + headers + trailers + (data_element * element_size);
 
-    fseek( fortio->stream, data_offset, SEEK_SET );
-    int block_index = data_element / block_size;
-    int err = eclfio_skip( fortio->stream, fortio->opts, block_index );
-    if( err ) util_abort( "%s: error skipping %d sub reords\n",
-                          __func__,
-                          block_index );
-    int item_index = (data_element % block_size) * element_size;
-    int header_size = sizeof( int32_t );
-    fseek( fortio->stream, header_size + item_index, SEEK_CUR );
+      fortio_fseek(fortio, bytes_to_skip, SEEK_SET);
+    }
 }
 
 int fortio_fclean(fortio_type * fortio) {


### PR DESCRIPTION
**Task**
Current testtime run on jenkins has reached more than 61000 s. This must be reduced. 


**Approach**
In file fortio.c, fortio_data_fseek: set back to level of libecl pr no. 423.


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
