### PR TITLE
Stringlist append

### DIFF
--- a/applications/ecl/kw_extract.c
+++ b/applications/ecl/kw_extract.c
@@ -54,7 +54,7 @@ int main(int argc, char ** argv) {
 
 
     for (int iarg=3; iarg < argc; iarg++)
-      stringlist_append_ref(kw_set, argv[iarg]);
+      stringlist_append_copy(kw_set, argv[iarg]);
 
     if (!ecl_util_fmt_file(src_file, &fmt_src))
       util_exit("Hmm - could not determine formatted/unformatted status for:%s \n",src_file);

--- a/lib/include/ert/util/stringlist.hpp
+++ b/lib/include/ert/util/stringlist.hpp
@@ -50,8 +50,6 @@ typedef bool ( file_pred_ftype) (const char *, const void *);
   void              stringlist_clear(stringlist_type * );
 
   void              stringlist_append_copy(stringlist_type * , const char *);
-  void              stringlist_append_ref(stringlist_type * , const char *);
-  void              stringlist_append_owned_ref(stringlist_type * , const char *);
 
   const      char * stringlist_safe_iget( const stringlist_type * stringlist , int index);
   bool              stringlist_unique(const stringlist_type * stringlist );
@@ -86,14 +84,10 @@ typedef bool ( file_pred_ftype) (const char *, const void *);
   stringlist_type * stringlist_alloc_argv_copy(const char **      , int );
   stringlist_type * stringlist_alloc_argv_ref (const char **      , int );
   stringlist_type * stringlist_alloc_argv_owned_ref(const char ** argv , int argc);
-  stringlist_type * stringlist_alloc_shallow_copy(const stringlist_type *);
-  stringlist_type * stringlist_alloc_shallow_copy_with_offset(const stringlist_type * stringlist, int offset);
-  stringlist_type * stringlist_alloc_shallow_copy_with_limits(const stringlist_type * stringlist, int offset , int num_strings);
   stringlist_type * stringlist_alloc_from_split( const char * input_string , const char * sep );
   stringlist_type * stringlist_fread_alloc(FILE * );
 
   void              stringlist_append_stringlist_copy(stringlist_type *  , const stringlist_type * );
-  void              stringlist_append_stringlist_ref(stringlist_type *   , const stringlist_type * );
   void              stringlist_insert_stringlist_copy(stringlist_type *  , const stringlist_type *, int);
 
   bool              stringlist_equal(const stringlist_type *  , const stringlist_type *);

--- a/lib/util/hash.cpp
+++ b/lib/util/hash.cpp
@@ -453,8 +453,10 @@ stringlist_type * hash_alloc_stringlist(const hash_type * hash) {
   stringlist_type * stringlist = stringlist_alloc_new();
   char ** keylist = hash_alloc_keylist__(hash);
   int i;
-  for (i = 0; i < hash_get_size( hash ); i++)
-    stringlist_append_owned_ref( stringlist , keylist[i] );
+  for (i = 0; i < hash_get_size( hash ); i++) {
+    stringlist_append_copy( stringlist , keylist[i] );
+    free(keylist[i]);
+  }
 
   free( keylist );
   return stringlist;

--- a/lib/util/parser.cpp
+++ b/lib/util/parser.cpp
@@ -405,8 +405,9 @@ stringlist_type * basic_parser_tokenize_buffer(
     if( is_in_quoters( buffer[position], parser ) )  {
       int length   = length_of_quotation( &buffer[position] );
       char * token = alloc_quoted_token( &buffer[position], length, strip_quote_marks );
-      stringlist_append_owned_ref( tokens, token );
+      stringlist_append_copy( tokens, token );
       position += length;
+      free(token);
       continue;
     }
 
@@ -452,9 +453,9 @@ stringlist_type * basic_parser_tokenize_buffer(
 
       if (token_length > 0) { /* We do not insert empty tokens. */
         token[token_length] = '\0';
-        stringlist_append_owned_ref( tokens, token );
-      } else
-        free( token );    /* The whole thing is discarded. */
+        stringlist_append_copy( tokens, token );
+      }
+      free( token );
 
       position += length;
       continue;

--- a/lib/util/path_stack.cpp
+++ b/lib/util/path_stack.cpp
@@ -94,8 +94,9 @@ bool path_stack_push( path_stack_type * path_stack , const char * path ) {
 
 void path_stack_push_cwd( path_stack_type * path_stack ) {
   char * cwd = util_alloc_cwd();
-  stringlist_append_owned_ref( path_stack->storage , cwd);
-  stringlist_append_ref( path_stack->stack , cwd );
+  stringlist_append_copy( path_stack->storage , cwd);
+  stringlist_append_copy( path_stack->stack , cwd );
+  free(cwd);
 }
 
 const char * path_stack_pop( path_stack_type * path_stack ) {

--- a/lib/util/tests/ert_util_spawn.cpp
+++ b/lib/util/tests/ert_util_spawn.cpp
@@ -161,7 +161,8 @@ void test_spawn_redirect_threaded() {
       util_make_path( path );
       char * script = util_alloc_filename( path , "script" , NULL);
       make_script(script, stdout_msg, stderr_msg);
-      stringlist_append_owned_ref(script_fullpaths, script);
+      stringlist_append_copy(script_fullpaths, script);
+      free(script);
       free(path);
    }
 

--- a/lib/util/tests/ert_util_stringlist_test.cpp
+++ b/lib/util/tests/ert_util_stringlist_test.cpp
@@ -29,19 +29,15 @@ void test_char() {
   const char * S2 = "S2";
   const char * S3 = "S3";
   stringlist_type * s = stringlist_alloc_new();
-  stringlist_append_ref( s , S1 );
-  stringlist_append_ref( s , S2 );
-  stringlist_append_ref( s , S3 );
+  stringlist_append_copy( s , S1 );
+  stringlist_append_copy( s , S2 );
+  stringlist_append_copy( s , S3 );
 
   {
-    char ** ref = stringlist_alloc_char_ref( s );
     char ** copy = stringlist_alloc_char_copy( s );
     int i;
 
     for (i=0; i < stringlist_get_size( s ); i++) {
-      if (ref[i] != stringlist_iget(s , i))
-        exit(1);
-
       if (strcmp( stringlist_iget( s , i ) , copy[i]) != 0)
         exit(1);
 
@@ -67,9 +63,9 @@ void test_join() {
     test_assert_string_equal("", empty_join);
   }
 
-  stringlist_append_ref( s , elt0 );
-  stringlist_append_ref( s , elt1 );
-  stringlist_append_ref( s , elt2 );
+  stringlist_append_copy( s , elt0 );
+  stringlist_append_copy( s , elt1 );
+  stringlist_append_copy( s , elt2 );
 
   const char * sep0 = "";
   const char * sep1 = "!!!";
@@ -84,18 +80,18 @@ void test_join() {
   test_assert_string_equal( j2, "AAA abc BBB abc CCC");
 
   stringlist_type * s1 = stringlist_alloc_new();
-  stringlist_append_ref( s1 , elt0 );
+  stringlist_append_copy( s1 , elt0 );
   test_assert_string_equal( "AAA", stringlist_alloc_joined_string( s1, sep0));
   test_assert_string_equal( "AAA", stringlist_alloc_joined_string( s1, sep1));
   test_assert_string_equal( "AAA", stringlist_alloc_joined_string( s1, sep2));
 
   stringlist_type * sub = stringlist_alloc_new();
-  stringlist_append_ref( sub , elt0 );
-  stringlist_append_ref( sub , elt1 );
-  stringlist_append_ref( sub , elt2 );
-  stringlist_append_ref( sub , elt3 );
-  stringlist_append_ref( sub , elt4 );
-  stringlist_append_ref( sub , elt5 );
+  stringlist_append_copy( sub , elt0 );
+  stringlist_append_copy( sub , elt1 );
+  stringlist_append_copy( sub , elt2 );
+  stringlist_append_copy( sub , elt3 );
+  stringlist_append_copy( sub , elt4 );
+  stringlist_append_copy( sub , elt5 );
   test_assert_string_equal( "CCC:DDD:EEE", stringlist_alloc_joined_substring( sub, 2, 5, ":"));
 }
 
@@ -107,9 +103,9 @@ void test_reverse() {
   const char *s2 = "CCC";
 
   stringlist_type * s = stringlist_alloc_new();
-  stringlist_append_ref( s , s0 );
-  stringlist_append_ref( s , s1 );
-  stringlist_append_ref( s , s2 );
+  stringlist_append_copy( s , s0 );
+  stringlist_append_copy( s , s1 );
+  stringlist_append_copy( s , s2 );
 
   stringlist_reverse(s);
 
@@ -121,9 +117,9 @@ void test_reverse() {
 
 void test_iget_as_int() {
   stringlist_type * s = stringlist_alloc_new();
-  stringlist_append_ref(s , "1000" );
-  stringlist_append_ref(s , "1000X" );
-  stringlist_append_ref(s , "XXXX" );
+  stringlist_append_copy(s , "1000" );
+  stringlist_append_copy(s , "1000X" );
+  stringlist_append_copy(s , "XXXX" );
 
   {
     int value;
@@ -145,9 +141,9 @@ void test_iget_as_int() {
 
 void test_iget_as_double() {
   stringlist_type * s = stringlist_alloc_new();
-  stringlist_append_ref(s , "1000.90" );
-  stringlist_append_ref(s , "1000" );
-  stringlist_append_ref(s , "XXXX" );
+  stringlist_append_copy(s , "1000.90" );
+  stringlist_append_copy(s , "1000" );
+  stringlist_append_copy(s , "XXXX" );
 
   {
     double value;
@@ -170,20 +166,20 @@ void test_iget_as_double() {
 
 void test_iget_as_bool() {
   stringlist_type * s = stringlist_alloc_new();
-  stringlist_append_ref(s , "TRUE" );
-  stringlist_append_ref(s , "True" );
-  stringlist_append_ref(s , "true" );
-  stringlist_append_ref(s , "T" );
-  stringlist_append_ref(s , "1" );
+  stringlist_append_copy(s , "TRUE" );
+  stringlist_append_copy(s , "True" );
+  stringlist_append_copy(s , "true" );
+  stringlist_append_copy(s , "T" );
+  stringlist_append_copy(s , "1" );
 
-  stringlist_append_ref(s , "FALSE" );
-  stringlist_append_ref(s , "False" );
-  stringlist_append_ref(s , "false" );
-  stringlist_append_ref(s , "F" );
-  stringlist_append_ref(s , "0" );
+  stringlist_append_copy(s , "FALSE" );
+  stringlist_append_copy(s , "False" );
+  stringlist_append_copy(s , "false" );
+  stringlist_append_copy(s , "F" );
+  stringlist_append_copy(s , "0" );
 
-  stringlist_append_ref(s , "not_so_bool" );
-  stringlist_append_ref(s , "8" );
+  stringlist_append_copy(s , "not_so_bool" );
+  stringlist_append_copy(s , "8" );
 
 
   {
@@ -353,7 +349,7 @@ bool not_FILE_predicate(const char * name, const void * arg) {
 void test_predicate_matching() {
   test_work_area_type * work_area = test_work_area_alloc("predicate_test");
   stringlist_type * s = stringlist_alloc_new();
-  stringlist_append_ref(s, "s");
+  stringlist_append_copy(s, "s");
   stringlist_select_files(s, "does/not/exist", NULL, NULL);
   test_assert_int_equal(stringlist_get_size(s), 0);
 
@@ -395,13 +391,13 @@ void test_unique() {
 
   test_assert_true( stringlist_unique( s ));
 
-  stringlist_append_ref( s, "S1");
+  stringlist_append_copy( s, "S1");
   test_assert_true( stringlist_unique( s ));
 
-  stringlist_append_ref( s, "S2");
+  stringlist_append_copy( s, "S2");
   test_assert_true( stringlist_unique( s ));
 
-  stringlist_append_ref( s, "S2");
+  stringlist_append_copy( s, "S2");
   test_assert_false( stringlist_unique( s ));
 }
 

--- a/python/ecl/util/util/stringlist.py
+++ b/python/ecl/util/util/stringlist.py
@@ -1,18 +1,18 @@
-#  Copyright (C) 2011  Statoil ASA, Norway. 
-#   
-#  The file 'stringlist.py' is part of ERT - Ensemble based Reservoir Tool. 
-#   
-#  ERT is free software: you can redistribute it and/or modify 
-#  it under the terms of the GNU General Public License as published by 
-#  the Free Software Foundation, either version 3 of the License, or 
-#  (at your option) any later version. 
-#   
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-#  FITNESS FOR A PARTICULAR PURPOSE.   
-#   
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-#  for more details. 
+#  Copyright (C) 2011  Statoil ASA, Norway.
+#
+#  The file 'stringlist.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
 """
 Simple wrapping of stringlist 'class' from C library.
 
@@ -23,7 +23,7 @@ higher level than the (char ** string , int size) convention.
 For a pure Python application you should just stick with a normal
 Python list of string objects; but when interfacing with the C
 libraries there are situations where you might need to instantiate a
-StringList object. 
+StringList object.
 
 The StringList constructor can take an optional argument which should
 be an iterable consisting of strings, and the strings property will
@@ -58,7 +58,7 @@ class StringList(BaseCClass):
     def __init__(self, initial=None):
         """
         Creates a new stringlist instance.
-        
+
         Creates a new stringlist instance. The optional argument
         @initial should be an iterable of strings which will be the
         initial content of the StringList; the content will be copied
@@ -124,7 +124,7 @@ class StringList(BaseCClass):
     def __getitem__(self, index):
         """
         Implements [] read operator on the stringlist.
-        
+
         The __getitem__ method supports negative, i.e. from the right,
         indexing; but not slices.
         """
@@ -157,7 +157,7 @@ class StringList(BaseCClass):
             self.append( s )
         return self
 
-    
+
     def __add__(self , other):
         copy = StringList( initial = self )
         copy += other
@@ -173,15 +173,15 @@ class StringList(BaseCClass):
             if not s in self:
                 self.append( s )
         return self
-    
-                
+
+
     def __or__(self , other):
         copy = StringList( initial = self )
         copy |= other
         return copy
 
-    
-    
+
+
     def contains(self, s):
         """
         Checks if the list contains @s.
@@ -222,8 +222,8 @@ class StringList(BaseCClass):
 
     def pop(self):
         """
-        Will remove the last element from the list and return it. 
-        
+        Will remove the last element from the list and return it.
+
         Will raise IndexError if list is empty.
         """
         if not self.empty():
@@ -275,7 +275,7 @@ class StringList(BaseCClass):
 
         The string comparison can be altered with the value of the
         optional cmp_flag parameter:
-        
+
              0 : Normal strcmp() string comparison
              1 : util_strcmp_int() string comparison
              2 : util_strcmp_float() string comparison


### PR DESCRIPTION
Simplify the stringlist implementation - it will *always* take ownership of the strings. This is a simplification - step towards replacing the whole thing with `std::vector<std::string>`

Statoil/libres#360