### PR TITLE
Add ecl.ecl compat

### DIFF
--- a/python/ecl/CMakeLists.txt
+++ b/python/ecl/CMakeLists.txt
@@ -13,6 +13,11 @@ add_subdirectory(summary)
 add_subdirectory(util)
 add_subdirectory(well)
 
+
+if (INSTALL_ERT_LEGACY)
+  add_subdirectory(ecl)
+endif()
+
 configure_file(ecl_lib_info_build.py.in   ${PROJECT_BINARY_DIR}/${PYTHON_INSTALL_PREFIX}/ecl/__ecl_lib_info.py )
 configure_file(ecl_lib_info_install.py.in ${PROJECT_BINARY_DIR}/${PYTHON_INSTALL_PREFIX}/ecl_lib_info_install.py )
 install(FILES ${PROJECT_BINARY_DIR}/${PYTHON_INSTALL_PREFIX}/ecl_lib_info_install.py DESTINATION ${PYTHON_INSTALL_PREFIX}/ecl RENAME __ecl_lib_info.py)

--- a/python/ecl/ecl/CMakeLists.txt
+++ b/python/ecl/ecl/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(PYTHON_SOURCES
+    __init__.py
+)
+add_python_package("python.ecl.ecl"  ${PYTHON_INSTALL_PREFIX}/ecl/ecl "${PYTHON_SOURCES}" True)
+

--- a/python/ecl/ecl/__init__.py
+++ b/python/ecl/ecl/__init__.py
@@ -1,0 +1,12 @@
+# The structure of the python packages have been reorganized several times,
+# unfortunately we have not managed to deprecate properly and guide users over
+# to the new layout. We therefor now have two(?) varietes of old layout which
+# must(?) be supported for a while.
+#
+# from ert.ecl import EclEgrid
+# from ecl.ecl import EclGrid
+#
+# Both of these legacy forms are controlled by the cmake switch
+# INSTALL_ERT_LEGACY.
+
+from ert.ecl import *

--- a/python/ecl/ecl_type.py
+++ b/python/ecl/ecl_type.py
@@ -13,6 +13,7 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
+from __future__ import absolute_import
 
 from cwrap import BaseCClass, BaseCEnum
 from ecl import EclPrototype

--- a/python/ecl/ecl_util.py
+++ b/python/ecl/ecl_util.py
@@ -24,7 +24,7 @@ BaseCEnum class from cwrap.
 In addition to the enum definitions there are a few stateless
 functions from ecl_util.c which are not bound to any class type.
 """
-
+from __future__ import absolute_import
 import ctypes
 
 from cwrap import BaseCEnum

--- a/python/tests/ecl_tests/CMakeLists.txt
+++ b/python/tests/ecl_tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_SOURCES
     __init__.py
     test_deprecation.py
+    test_ecl_ecl.py
     test_removed.py
     test_ecl_3dkw.py
     test_ecl_file_statoil.py
@@ -74,6 +75,10 @@ addPythonTest(tests.ecl_tests.test_geertsma.GeertsmaTest)
 addPythonTest(tests.ecl_tests.test_ecl_type.EclDataTypeTest)
 addPythonTest(tests.ecl_tests.test_region.RegionTest)
 addPythonTest(tests.ecl_tests.test_debug.DebugTest)
+
+if (INSTALL_ERT_LEGACY)
+  addPythonTest(tests.ecl_tests.test_ecl_ecl.EclEclTest)
+endif()
 
 
 addPythonTest(tests.ecl_tests.test_ecl_file_statoil.EclFileStatoilTest)

--- a/python/tests/ecl_tests/test_ecl_ecl.py
+++ b/python/tests/ecl_tests/test_ecl_ecl.py
@@ -1,0 +1,15 @@
+from tests import EclTest
+
+class EclEclTest(EclTest):
+
+    def test_import(self):
+        import ecl.ecl as ecl
+        grid = ecl.EclGrid
+        sum = ecl.EclSum
+        f = ecl.EclFile
+        rft = ecl.EclRFTFile
+
+    def test_import2(self):
+        from ecl.ecl import EclFile
+        from ecl.ecl import EclGrid
+        from ecl.ecl import EclSum


### PR DESCRIPTION
To support the form:
```
import ecl.ecl as ecl

grid = ecl.EclGrid( "CASE.EGRID")
```
which is widely used. 

We **really** need to get deprecation going.