### PR TITLE
Smspec cxx string

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -89,6 +89,7 @@ add_library(ecl util/rng.cpp
                 util/ecl_version.cpp
                 util/perm_vector.cpp
                 util/test_util.cpp
+                util/cxx_string_util.cpp
                 ${opt_srcs}
 
                 ecl/ecl_rsthead.cpp

--- a/lib/ecl/smspec_node.cpp
+++ b/lib/ecl/smspec_node.cpp
@@ -511,7 +511,7 @@ static void smspec_node_set_gen_keys( smspec_node_type * smspec_node , const cha
   case(ECL_SMSPEC_MISC_VAR):
     // KEYWORD
     /* Misc variable - i.e. date or CPU time ... */
-    smspec_node->gen_key1 = util_alloc_string_copy( smspec_node->keyword.c_str() );
+    smspec_node->gen_key1 = smspec_node->keyword;
     break;
   case(ECL_SMSPEC_BLOCK_VAR):
     // KEYWORD:NUM

--- a/lib/ecl/smspec_node.cpp
+++ b/lib/ecl/smspec_node.cpp
@@ -22,6 +22,7 @@
 #include <time.h>
 
 #include <string>
+#include <set>
 
 #include <ert/util/hash.hpp>
 #include <ert/util/util.h>
@@ -54,7 +55,7 @@
 struct smspec_node_struct {
   UTIL_TYPE_ID_DECLARATION;
   std::string            wgname;
-  char                 * keyword;            /* The value of the KEYWORDS vector for this elements. */
+  std::string            keyword;            /* The value of the KEYWORDS vector for this elements. */
   char                 * unit;               /* The value of the UNITS vector for this elements. */
   int                    num;                /* The value of the NUMS vector for this elements - NB this will have the value SMSPEC_NUMS_INVALID if the smspec file does not have a NUMS vector. */
   char                 * lgr_name;           /* The lgr name of the current variable - will be NULL for non-lgr variables. */
@@ -125,24 +126,24 @@ UTIL_SAFE_CAST_FUNCTION( smspec_node , SMSPEC_TYPE_ID )
 static UTIL_SAFE_CAST_FUNCTION_CONST( smspec_node , SMSPEC_TYPE_ID )
 
 
-char * smspec_alloc_block_num_key( const char * join_string , const char * keyword , int num) {
+  char * smspec_alloc_block_num_key( const char * join_string , const std::string& keyword , int num) {
   return util_alloc_sprintf(ECL_SUM_KEYFMT_BLOCK_NUM,
-                            keyword ,
+                            keyword.c_str() ,
                             join_string ,
                             num );
 }
 
-char * smspec_alloc_aquifer_key( const char * join_string , const char * keyword , int num) {
+char * smspec_alloc_aquifer_key( const char * join_string , const std::string& keyword , int num) {
   return util_alloc_sprintf(ECL_SUM_KEYFMT_AQUIFER,
-                            keyword ,
+                            keyword.c_str(),
                             join_string ,
                             num );
 }
 
 
-char * smspec_alloc_local_block_key( const char * join_string , const char * keyword , const char * lgr_name , int i , int j , int k) {
+char * smspec_alloc_local_block_key( const char * join_string , const std::string& keyword , const char * lgr_name , int i , int j , int k) {
   return util_alloc_sprintf(ECL_SUM_KEYFMT_LOCAL_BLOCK ,
-                            keyword ,
+                            keyword.c_str() ,
                             join_string ,
                             lgr_name ,
                             join_string ,
@@ -150,43 +151,43 @@ char * smspec_alloc_local_block_key( const char * join_string , const char * key
 }
 
 
-char * smspec_alloc_region_key( const char * join_string , const char * keyword , int num) {
+char * smspec_alloc_region_key( const char * join_string , const std::string& keyword , int num) {
   return util_alloc_sprintf(ECL_SUM_KEYFMT_REGION ,
-                            keyword ,
+                            keyword.c_str(),
                             join_string ,
                             num );
 }
 
-char * smspec_alloc_region_2_region_r1r2_key( const char * join_string , const char * keyword , int r1, int r2) {
+char * smspec_alloc_region_2_region_r1r2_key( const char * join_string , const std::string& keyword , int r1, int r2) {
   return util_alloc_sprintf(ECL_SUM_KEYFMT_REGION_2_REGION_R1R2,
-                            keyword,
+                            keyword.c_str(),
                             join_string,
                             r1,
                             r2);
 }
 
-char * smspec_alloc_region_2_region_num_key( const char * join_string , const char * keyword , int num) {
+char * smspec_alloc_region_2_region_num_key( const char * join_string , const std::string& keyword , int num) {
   return util_alloc_sprintf(ECL_SUM_KEYFMT_REGION_2_REGION_NUM,
-                            keyword ,
+                            keyword.c_str() ,
                             join_string ,
                             num);
 }
 
 
 
-char * smspec_alloc_block_ijk_key( const char * join_string , const char * keyword , int i , int j , int k) {
+char * smspec_alloc_block_ijk_key( const char * join_string , const std::string& keyword , int i , int j , int k) {
   return util_alloc_sprintf(ECL_SUM_KEYFMT_BLOCK_IJK ,
-                            keyword,
+                            keyword.c_str(),
                             join_string ,
                             i,j,k);
 }
 
 
 
-char * smspec_alloc_completion_ijk_key( const char * join_string , const char * keyword, const std::string& wgname , int i , int j , int k) {
+char * smspec_alloc_completion_ijk_key( const char * join_string , const std::string& keyword, const std::string& wgname , int i , int j , int k) {
   if (wgname.size() > 0)
     return util_alloc_sprintf( ECL_SUM_KEYFMT_COMPLETION_IJK ,
-                               keyword ,
+                               keyword.c_str() ,
                                join_string ,
                                wgname.c_str(),
                                join_string ,
@@ -197,10 +198,10 @@ char * smspec_alloc_completion_ijk_key( const char * join_string , const char * 
 
 
 
-char * smspec_alloc_completion_num_key( const char * join_string , const char * keyword, const std::string& wgname , int num) {
+char * smspec_alloc_completion_num_key( const char * join_string , const std::string& keyword, const std::string& wgname , int num) {
   if (wgname.size() > 0)
     return util_alloc_sprintf(ECL_SUM_KEYFMT_COMPLETION_NUM,
-                              keyword ,
+                              keyword.c_str() ,
                               join_string ,
                               wgname.c_str() ,
                               join_string ,
@@ -216,21 +217,21 @@ char * smspec_alloc_completion_num_key( const char * join_string , const char * 
   use the wgname value must therefore accept a NULL value for wgname. HMM: Uncertain about this?
 */
 
-static char * smspec_alloc_wgname_key( const char * join_string , const char * keyword , const std::string& wgname) {
+static char * smspec_alloc_wgname_key( const char * join_string , const std::string& keyword , const std::string& wgname) {
   if (wgname.size() > 0)
     return util_alloc_sprintf(ECL_SUM_KEYFMT_WELL,
-                              keyword ,
+                              keyword.c_str() ,
                               join_string ,
                               wgname.c_str() );
   else
     return NULL;
 }
 
-char * smspec_alloc_group_key( const char * join_string , const char * keyword , const std::string& wgname) {
+char * smspec_alloc_group_key( const char * join_string , const std::string& keyword , const std::string& wgname) {
   return smspec_alloc_wgname_key( join_string , keyword , wgname );
 }
 
-char * smspec_alloc_well_key( const char * join_string , const char * keyword , const std::string& wgname) {
+char * smspec_alloc_well_key( const char * join_string , const std::string& keyword , const std::string& wgname) {
   return smspec_alloc_wgname_key( join_string , keyword , wgname );
 }
 
@@ -238,10 +239,10 @@ char * smspec_alloc_well_key( const char * join_string , const char * keyword , 
   return smspec_alloc_wgname_key( join_string , keyword , wgname );
 }
 
-char * smspec_alloc_segment_key( const char * join_string , const char * keyword , const std::string& wgname , int num) {
+char * smspec_alloc_segment_key( const char * join_string , const std::string& keyword , const std::string& wgname , int num) {
   if (wgname.size() > 0)
     return util_alloc_sprintf(ECL_SUM_KEYFMT_SEGMENT ,
-                              keyword ,
+                              keyword.c_str() ,
                               join_string ,
                               wgname.c_str(),
                               join_string ,
@@ -251,10 +252,10 @@ char * smspec_alloc_segment_key( const char * join_string , const char * keyword
 }
 
 
-char * smspec_alloc_local_well_key( const char * join_string , const char * keyword , const char * lgr_name , const std::string& wgname) {
+char * smspec_alloc_local_well_key( const char * join_string , const std::string& keyword , const char * lgr_name , const std::string& wgname) {
   if (wgname.size() > 0)
     return util_alloc_sprintf( ECL_SUM_KEYFMT_LOCAL_WELL ,
-                               keyword ,
+                               keyword.c_str() ,
                                join_string ,
                                lgr_name ,
                                join_string ,
@@ -263,10 +264,10 @@ char * smspec_alloc_local_well_key( const char * join_string , const char * keyw
     return NULL;
 }
 
-char * smspec_alloc_local_completion_key( const char * join_string, const char * keyword , const char * lgr_name , const std::string& wgname , int i , int j , int k) {
+char * smspec_alloc_local_completion_key( const char * join_string, const std::string& keyword , const char * lgr_name , const std::string& wgname , int i , int j , int k) {
   if (wgname.size() > 0)
     return util_alloc_sprintf(ECL_SUM_KEYFMT_LOCAL_COMPLETION ,
-                              keyword  ,
+                              keyword.c_str(),
                               join_string ,
                               lgr_name ,
                               join_string ,
@@ -279,12 +280,12 @@ char * smspec_alloc_local_completion_key( const char * join_string, const char *
 
 /*****************************************************************/
 
-static void smspec_node_set_keyword( smspec_node_type * smspec_node , const char * keyword ) {
+static void smspec_node_set_keyword( smspec_node_type * smspec_node , const std::string& keyword ) {
   // ECLIPSE Standard: Max eight characters - everything beyond is silently dropped
   // This function can __ONLY__ be called on time; run-time chaning of keyword is not
   // allowed.
-  if (smspec_node->keyword == NULL)
-    smspec_node->keyword = util_alloc_substring_copy( keyword , 0 , 8);
+  if (smspec_node->keyword.size() == 0)
+    smspec_node->keyword = keyword;
   else
     util_abort("%s: fatal error - attempt to change keyword runtime detected - aborting\n",__func__);
 }
@@ -296,9 +297,6 @@ static void smspec_node_set_invalid_flags( smspec_node_type * smspec_node) {
   smspec_node->historical     = false;
 }
 
-static char LAST_CHAR(const char * s) {
-  return s[ strlen(s) - 1];
-}
 
 
 bool smspec_node_identify_rate(const char * keyword) {
@@ -363,10 +361,10 @@ static void smspec_node_set_flags( smspec_node_type * smspec_node) {
      Check if this is a rate variabel - that info is used when
      interpolating results to true_time between ministeps.
   */
-  smspec_node->rate_variable = smspec_node_identify_rate(smspec_node->keyword);
-  if (LAST_CHAR(smspec_node->keyword) == 'H')
+  smspec_node->rate_variable = smspec_node_identify_rate(smspec_node->keyword.c_str());
+  if (smspec_node->keyword.back() == 'H')
     smspec_node->historical = true;
-  smspec_node->total_variable = smspec_node_identify_total(smspec_node->keyword, smspec_node->var_type);
+  smspec_node->total_variable = smspec_node_identify_total(smspec_node->keyword.c_str(), smspec_node->var_type);
 }
 
 /**
@@ -399,7 +397,6 @@ smspec_node_type * smspec_node_alloc_new(int params_index, float default_value) 
 
   node->var_type      = ECL_SMSPEC_INVALID_VAR;
   node->unit          = NULL;
-  node->keyword       = NULL;
   node->lgr_name      = NULL;
   node->lgr_ijk       = NULL;
 
@@ -494,7 +491,7 @@ static void smspec_node_set_gen_keys( smspec_node_type * smspec_node , const cha
     break;
   case(ECL_SMSPEC_FIELD_VAR):
     // KEYWORD
-    smspec_node->gen_key1 = util_alloc_string_copy( smspec_node->keyword );
+    smspec_node->gen_key1 = util_alloc_string_copy( smspec_node->keyword.c_str() );
     break;
   case(ECL_SMSPEC_GROUP_VAR):
     // KEYWORD:WGNAME
@@ -524,7 +521,7 @@ static void smspec_node_set_gen_keys( smspec_node_type * smspec_node , const cha
   case(ECL_SMSPEC_MISC_VAR):
     // KEYWORD
     /* Misc variable - i.e. date or CPU time ... */
-    smspec_node->gen_key1 = util_alloc_string_copy( smspec_node->keyword );
+    smspec_node->gen_key1 = util_alloc_string_copy( smspec_node->keyword.c_str() );
     break;
   case(ECL_SMSPEC_BLOCK_VAR):
     // KEYWORD:NUM
@@ -822,7 +819,7 @@ smspec_node_type* smspec_node_alloc_copy( const smspec_node_type* node ) {
     copy->gen_key2 = util_alloc_string_copy( node->gen_key2 );
     copy->var_type = node->var_type;
     copy->wgname = node->wgname;
-    copy->keyword = util_alloc_string_copy( node->keyword );
+    copy->keyword = node->keyword;
     copy->unit = util_alloc_string_copy( node->unit );
     copy->num = node->num;
 
@@ -850,7 +847,6 @@ smspec_node_type* smspec_node_alloc_copy( const smspec_node_type* node ) {
 
 void smspec_node_free( smspec_node_type * index ) {
   free( index->unit );
-  free( index->keyword );
   free( index->ijk );
   free( index->gen_key1 );
   free( index->gen_key2 );
@@ -893,7 +889,7 @@ const char * smspec_node_get_wgname( const smspec_node_type * smspec_node) {
 }
 
 const char * smspec_node_get_keyword( const smspec_node_type * smspec_node) {
-  return smspec_node->keyword;
+  return smspec_node->keyword.c_str();
 }
 
 
@@ -994,7 +990,7 @@ bool smspec_node_need_nums( const smspec_node_type * smspec_node ) {
 
 
 void smspec_node_fprintf( const smspec_node_type * smspec_node , FILE * stream) {
-  fprintf(stream, "KEYWORD: %s \n",smspec_node->keyword);
+  fprintf(stream, "KEYWORD: %s \n",smspec_node->keyword.c_str());
   fprintf(stream, "WGNAME : %s \n",smspec_node->wgname.c_str());
   fprintf(stream, "UNIT   : %s \n",smspec_node->unit);
   fprintf(stream, "TYPE   : %d \n",smspec_node->var_type);
@@ -1003,7 +999,7 @@ void smspec_node_fprintf( const smspec_node_type * smspec_node , FILE * stream) 
 
 
 static bool smspec_node_equal_MISC( const smspec_node_type * node1, const smspec_node_type * node2) {
-  return util_string_equal( node1->keyword , node2->keyword);
+  return node1->keyword == node2->keyword;
 }
 
 
@@ -1013,34 +1009,22 @@ static bool smspec_node_equal_MISC( const smspec_node_type * node1, const smspec
 */
 
 static int smspec_node_cmp_MISC( const smspec_node_type * node1, const smspec_node_type * node2) {
-  static const char* early_vars[] = {"TIME",
-                                     "DAYS",
-                                     "DAY",
-                                     "MONTH",
-                                     "YEAR",
-                                     "YEARS"};
+  static const std::set<std::string> early_vars = {"TIME", "DAYS", "DAY", "MONTH", "YEAR", "YEARS"};
 
   if (smspec_node_equal_MISC( node1, node2) )
     return 0;
 
-  bool node1_early = false;
-  bool node2_early = false;
+  bool node1_early = !( early_vars.find(node1->keyword) == early_vars.end() );
+  bool node2_early = !( early_vars.find(node2->keyword) == early_vars.end() );
 
-  for (int i=0; i < 6; i++) {
-    if (util_string_equal( node1->keyword, early_vars[i] ))
-      node1_early = true;
 
-    if (util_string_equal( node2->keyword, early_vars[i] ))
-      node2_early = true;
-
-  }
   if (node1_early && !node2_early)
     return -1;
 
   if (!node1_early && node2_early)
     return 1;
 
-  return strcmp( node1->keyword, node2->keyword);
+  return node1->keyword.compare(node2->keyword);
 }
 
 
@@ -1068,7 +1052,7 @@ static int smspec_node_cmp_LGRIJK( const smspec_node_type * node1, const smspec_
 
 
 static int smspec_node_cmp_KEYWORD_LGR_LGRIJK( const smspec_node_type * node1, const smspec_node_type * node2) {
-  int keyword_cmp = strcmp( node1->keyword , node2->keyword);
+  int keyword_cmp = node1->keyword.compare(node2->keyword);
   if (keyword_cmp != 0)
     return keyword_cmp;
 
@@ -1081,7 +1065,7 @@ static int smspec_node_cmp_KEYWORD_LGR_LGRIJK( const smspec_node_type * node1, c
 
 
 static int smspec_node_cmp_KEYWORD_WGNAME_NUM( const smspec_node_type * node1, const smspec_node_type * node2) {
-  int keyword_cmp = strcmp( node1->keyword , node2->keyword);
+  int keyword_cmp = node1->keyword.compare(node2->keyword);
   if (keyword_cmp != 0)
     return keyword_cmp;
 
@@ -1093,7 +1077,7 @@ static int smspec_node_cmp_KEYWORD_WGNAME_NUM( const smspec_node_type * node1, c
 }
 
 static int smspec_node_cmp_KEYWORD_WGNAME_LGR( const smspec_node_type * node1, const smspec_node_type * node2) {
-  int keyword_cmp = strcmp( node1->keyword , node2->keyword);
+  int keyword_cmp = node1->keyword.compare(node2->keyword);
   if (keyword_cmp != 0)
     return keyword_cmp;
 
@@ -1106,7 +1090,7 @@ static int smspec_node_cmp_KEYWORD_WGNAME_LGR( const smspec_node_type * node1, c
 
 
 static int smspec_node_cmp_KEYWORD_WGNAME_LGR_LGRIJK( const smspec_node_type * node1, const smspec_node_type * node2) {
-  int keyword_cmp = strcmp( node1->keyword , node2->keyword);
+  int keyword_cmp = node1->keyword.compare(node2->keyword);
   if (keyword_cmp != 0)
     return keyword_cmp;
 
@@ -1125,7 +1109,7 @@ static int smspec_node_cmp_KEYWORD_WGNAME_LGR_LGRIJK( const smspec_node_type * n
 
 
 static int smspec_node_cmp_KEYWORD_WGNAME( const smspec_node_type * node1, const smspec_node_type * node2) {
-  int keyword_cmp = strcmp( node1->keyword , node2->keyword);
+  int keyword_cmp = node1->keyword.compare(node2->keyword);
   if (keyword_cmp != 0)
     return keyword_cmp;
 
@@ -1144,7 +1128,7 @@ static int smspec_node_cmp_KEYWORD_WGNAME( const smspec_node_type * node1, const
 
 
 static int smspec_node_cmp_KEYWORD_NUM( const smspec_node_type * node1, const smspec_node_type * node2) {
-  int keyword_cmp = strcmp( node1->keyword , node2->keyword);
+  int keyword_cmp = node1->keyword.compare(node2->keyword);
   if (keyword_cmp != 0)
     return keyword_cmp;
 
@@ -1153,7 +1137,7 @@ static int smspec_node_cmp_KEYWORD_NUM( const smspec_node_type * node1, const sm
 
 
 static int smspec_node_cmp_KEYWORD( const smspec_node_type * node1, const smspec_node_type * node2) {
-  return strcmp( node1->keyword , node2->keyword );
+  return node1->keyword.compare(node2->keyword);
 }
 
 static int smspec_node_cmp_key1( const smspec_node_type * node1, const smspec_node_type * node2) {

--- a/lib/ecl/smspec_node.cpp
+++ b/lib/ecl/smspec_node.cpp
@@ -811,7 +811,7 @@ smspec_node_type* smspec_node_alloc_copy( const smspec_node_type* node ) {
   if( !node ) return NULL;
 
   {
-    smspec_node_type* copy = (smspec_node_type*)util_malloc( sizeof * copy );
+    smspec_node_type * copy = new smspec_node_type();
     UTIL_TYPE_ID_INIT( copy, SMSPEC_TYPE_ID );
     copy->gen_key1 = util_alloc_string_copy( node->gen_key1 );
     copy->gen_key2 = util_alloc_string_copy( node->gen_key2 );

--- a/lib/ecl/smspec_node.cpp
+++ b/lib/ecl/smspec_node.cpp
@@ -38,7 +38,7 @@
 #include <ert/ecl/ecl_file.hpp>
 #include <ert/ecl/ecl_kw_magic.hpp>
 
-
+#include "detail/util/string_util.hpp"
 
 
 /**
@@ -63,8 +63,8 @@ struct smspec_node_struct {
 
   /*------------------------------------------- All members below this line are *derived* quantities. */
 
-  char                 * gen_key1;           /* The main composite key, i.e. WWCT:OP3 for this element. */
-  char                 * gen_key2;           /* Some of the ijk based elements will have both a xxx:i,j,k and a xxx:num key. Some of the region_2_region elements will have both a xxx:num and a xxx:r2-r2 key. Mostly NULL. */
+  std::string            gen_key1;           /* The main composite key, i.e. WWCT:OP3 for this element. */
+  std::string            gen_key2;           /* Some of the ijk based elements will have both a xxx:i,j,k and a xxx:num key. Some of the region_2_region elements will have both a xxx:num and a xxx:r2-r2 key. Mostly NULL. */
   ecl_smspec_var_type    var_type;           /* The variable type */
   int                  * ijk;                /* The ijk coordinates (NB: OFFSET 1) corresponding to the nums value - will be NULL if not relevant. */
   bool                   rate_variable;      /* Is this a rate variable (i.e. WOPR) or a state variable (i.e. BPR). Relevant when doing time interpolation. */
@@ -126,23 +126,23 @@ UTIL_SAFE_CAST_FUNCTION( smspec_node , SMSPEC_TYPE_ID )
 static UTIL_SAFE_CAST_FUNCTION_CONST( smspec_node , SMSPEC_TYPE_ID )
 
 
-  char * smspec_alloc_block_num_key( const char * join_string , const std::string& keyword , int num) {
-  return util_alloc_sprintf(ECL_SUM_KEYFMT_BLOCK_NUM,
+std::string smspec_alloc_block_num_key( const char * join_string , const std::string& keyword , int num) {
+  return ecl::util::string_format(ECL_SUM_KEYFMT_BLOCK_NUM,
                             keyword.c_str() ,
                             join_string ,
                             num );
 }
 
-char * smspec_alloc_aquifer_key( const char * join_string , const std::string& keyword , int num) {
-  return util_alloc_sprintf(ECL_SUM_KEYFMT_AQUIFER,
+std::string smspec_alloc_aquifer_key( const char * join_string , const std::string& keyword , int num) {
+  return ecl::util::string_format(ECL_SUM_KEYFMT_AQUIFER,
                             keyword.c_str(),
                             join_string ,
                             num );
 }
 
 
-char * smspec_alloc_local_block_key( const char * join_string , const std::string& keyword , const std::string& lgr_name , int i , int j , int k) {
-  return util_alloc_sprintf(ECL_SUM_KEYFMT_LOCAL_BLOCK ,
+std::string smspec_alloc_local_block_key( const char * join_string , const std::string& keyword , const std::string& lgr_name , int i , int j , int k) {
+  return ecl::util::string_format(ECL_SUM_KEYFMT_LOCAL_BLOCK ,
                             keyword.c_str() ,
                             join_string ,
                             lgr_name.c_str() ,
@@ -151,23 +151,23 @@ char * smspec_alloc_local_block_key( const char * join_string , const std::strin
 }
 
 
-char * smspec_alloc_region_key( const char * join_string , const std::string& keyword , int num) {
-  return util_alloc_sprintf(ECL_SUM_KEYFMT_REGION ,
+std::string smspec_alloc_region_key( const char * join_string , const std::string& keyword , int num) {
+  return ecl::util::string_format(ECL_SUM_KEYFMT_REGION ,
                             keyword.c_str(),
                             join_string ,
                             num );
 }
 
-char * smspec_alloc_region_2_region_r1r2_key( const char * join_string , const std::string& keyword , int r1, int r2) {
-  return util_alloc_sprintf(ECL_SUM_KEYFMT_REGION_2_REGION_R1R2,
+std::string smspec_alloc_region_2_region_r1r2_key( const char * join_string , const std::string& keyword , int r1, int r2) {
+  return ecl::util::string_format(ECL_SUM_KEYFMT_REGION_2_REGION_R1R2,
                             keyword.c_str(),
                             join_string,
                             r1,
                             r2);
 }
 
-char * smspec_alloc_region_2_region_num_key( const char * join_string , const std::string& keyword , int num) {
-  return util_alloc_sprintf(ECL_SUM_KEYFMT_REGION_2_REGION_NUM,
+std::string smspec_alloc_region_2_region_num_key( const char * join_string , const std::string& keyword , int num) {
+  return ecl::util::string_format(ECL_SUM_KEYFMT_REGION_2_REGION_NUM,
                             keyword.c_str() ,
                             join_string ,
                             num);
@@ -175,18 +175,18 @@ char * smspec_alloc_region_2_region_num_key( const char * join_string , const st
 
 
 
-char * smspec_alloc_block_ijk_key( const char * join_string , const std::string& keyword , int i , int j , int k) {
-  return util_alloc_sprintf(ECL_SUM_KEYFMT_BLOCK_IJK ,
-                            keyword.c_str(),
-                            join_string ,
-                            i,j,k);
+std::string smspec_alloc_block_ijk_key( const char * join_string , const std::string& keyword , int i , int j , int k) {
+  return ecl::util::string_format(ECL_SUM_KEYFMT_BLOCK_IJK ,
+                                  keyword.c_str(),
+                                  join_string ,
+                                  i,j,k);
 }
 
 
 
-char * smspec_alloc_completion_ijk_key( const char * join_string , const std::string& keyword, const std::string& wgname , int i , int j , int k) {
+std::string smspec_alloc_completion_ijk_key( const char * join_string , const std::string& keyword, const std::string& wgname , int i , int j , int k) {
   if (wgname.size() > 0)
-    return util_alloc_sprintf( ECL_SUM_KEYFMT_COMPLETION_IJK ,
+    return ecl::util::string_format( ECL_SUM_KEYFMT_COMPLETION_IJK ,
                                keyword.c_str() ,
                                join_string ,
                                wgname.c_str(),
@@ -198,9 +198,9 @@ char * smspec_alloc_completion_ijk_key( const char * join_string , const std::st
 
 
 
-char * smspec_alloc_completion_num_key( const char * join_string , const std::string& keyword, const std::string& wgname , int num) {
+std::string smspec_alloc_completion_num_key( const char * join_string , const std::string& keyword, const std::string& wgname , int num) {
   if (wgname.size() > 0)
-    return util_alloc_sprintf(ECL_SUM_KEYFMT_COMPLETION_NUM,
+    return ecl::util::string_format(ECL_SUM_KEYFMT_COMPLETION_NUM,
                               keyword.c_str() ,
                               join_string ,
                               wgname.c_str() ,
@@ -217,31 +217,34 @@ char * smspec_alloc_completion_num_key( const char * join_string , const std::st
   use the wgname value must therefore accept a NULL value for wgname. HMM: Uncertain about this?
 */
 
-static char * smspec_alloc_wgname_key( const char * join_string , const std::string& keyword , const std::string& wgname) {
+static std::string smspec_alloc_wgname_key( const char * join_string , const std::string& keyword , const std::string& wgname) {
   if (wgname.size() > 0)
-    return util_alloc_sprintf(ECL_SUM_KEYFMT_WELL,
-                              keyword.c_str() ,
-                              join_string ,
-                              wgname.c_str() );
+    return ecl::util::string_format(ECL_SUM_KEYFMT_WELL,
+                                    keyword.c_str() ,
+                                    join_string ,
+                                    wgname.c_str() );
   else
-    return NULL;
+    return "";
 }
 
-char * smspec_alloc_group_key( const char * join_string , const std::string& keyword , const std::string& wgname) {
+std::string smspec_alloc_group_key( const char * join_string , const std::string& keyword , const std::string& wgname) {
   return smspec_alloc_wgname_key( join_string , keyword , wgname );
 }
 
-char * smspec_alloc_well_key( const char * join_string , const std::string& keyword , const std::string& wgname) {
+std::string smspec_alloc_well_key( const char * join_string , const std::string& keyword , const std::string& wgname) {
   return smspec_alloc_wgname_key( join_string , keyword , wgname );
 }
 
 char * smspec_alloc_well_key( const char * join_string , const char * keyword , const char * wgname) {
-  return smspec_alloc_wgname_key( join_string , keyword , wgname );
+  return util_alloc_sprintf( ECL_SUM_KEYFMT_WELL,
+                             keyword,
+                             join_string,
+                             wgname);
 }
 
-char * smspec_alloc_segment_key( const char * join_string , const std::string& keyword , const std::string& wgname , int num) {
+std::string smspec_alloc_segment_key( const char * join_string , const std::string& keyword , const std::string& wgname , int num) {
   if (wgname.size() > 0)
-    return util_alloc_sprintf(ECL_SUM_KEYFMT_SEGMENT ,
+    return ecl::util::string_format(ECL_SUM_KEYFMT_SEGMENT ,
                               keyword.c_str() ,
                               join_string ,
                               wgname.c_str(),
@@ -252,9 +255,9 @@ char * smspec_alloc_segment_key( const char * join_string , const std::string& k
 }
 
 
-char * smspec_alloc_local_well_key( const char * join_string , const std::string& keyword , const std::string& lgr_name , const std::string& wgname) {
+std::string smspec_alloc_local_well_key( const char * join_string , const std::string& keyword , const std::string& lgr_name , const std::string& wgname) {
   if (wgname.size() > 0)
-    return util_alloc_sprintf( ECL_SUM_KEYFMT_LOCAL_WELL ,
+    return ecl::util::string_format( ECL_SUM_KEYFMT_LOCAL_WELL ,
                                keyword.c_str() ,
                                join_string ,
                                lgr_name.c_str() ,
@@ -264,9 +267,9 @@ char * smspec_alloc_local_well_key( const char * join_string , const std::string
     return NULL;
 }
 
-char * smspec_alloc_local_completion_key( const char * join_string, const std::string& keyword , const std::string& lgr_name , const std::string& wgname , int i , int j , int k) {
+std::string smspec_alloc_local_completion_key( const char * join_string, const std::string& keyword , const std::string& lgr_name , const std::string& wgname , int i , int j , int k) {
   if (wgname.size() > 0)
-    return util_alloc_sprintf(ECL_SUM_KEYFMT_LOCAL_COMPLETION ,
+    return ecl::util::string_format(ECL_SUM_KEYFMT_LOCAL_COMPLETION ,
                               keyword.c_str(),
                               join_string ,
                               lgr_name.c_str() ,
@@ -391,9 +394,6 @@ smspec_node_type * smspec_node_alloc_new(int params_index, float default_value) 
   smspec_node_set_default( node , default_value );
 
   node->ijk           = NULL;
-
-  node->gen_key1      = NULL;
-  node->gen_key2      = NULL;
 
   node->var_type      = ECL_SMSPEC_INVALID_VAR;
   node->lgr_ijk       = NULL;
@@ -813,8 +813,8 @@ smspec_node_type* smspec_node_alloc_copy( const smspec_node_type* node ) {
   {
     smspec_node_type * copy = new smspec_node_type();
     UTIL_TYPE_ID_INIT( copy, SMSPEC_TYPE_ID );
-    copy->gen_key1 = util_alloc_string_copy( node->gen_key1 );
-    copy->gen_key2 = util_alloc_string_copy( node->gen_key2 );
+    copy->gen_key1 = node->gen_key1;
+    copy->gen_key2 = node->gen_key2;
     copy->var_type = node->var_type;
     copy->wgname = node->wgname;
     copy->keyword = node->keyword;
@@ -845,8 +845,6 @@ smspec_node_type* smspec_node_alloc_copy( const smspec_node_type* node ) {
 
 void smspec_node_free( smspec_node_type * index ) {
   free( index->ijk );
-  free( index->gen_key1 );
-  free( index->gen_key2 );
   free( index->lgr_ijk );
 
   delete index;
@@ -871,21 +869,33 @@ void smspec_node_set_params_index( smspec_node_type * smspec_node , int params_i
   smspec_node->params_index = params_index;
 }
 
+
+namespace {
+
+  const char * get_cstring(const std::string& s) {
+    if (s.empty())
+      return NULL;
+    else
+      return s.c_str();
+  }
+
+}
+
 const char * smspec_node_get_gen_key1( const smspec_node_type * smspec_node) {
-  return smspec_node->gen_key1;
+  return get_cstring( smspec_node->gen_key1 );
 }
 
 const char * smspec_node_get_gen_key2( const smspec_node_type * smspec_node) {
-  return smspec_node->gen_key2;
+  return get_cstring( smspec_node->gen_key2 );
 }
 
 
 const char * smspec_node_get_wgname( const smspec_node_type * smspec_node) {
-  return smspec_node->wgname.c_str();
+  return get_cstring( smspec_node->wgname );
 }
 
 const char * smspec_node_get_keyword( const smspec_node_type * smspec_node) {
-  return smspec_node->keyword.c_str();
+  return get_cstring( smspec_node->keyword );
 }
 
 
@@ -1136,15 +1146,15 @@ static int smspec_node_cmp_KEYWORD( const smspec_node_type * node1, const smspec
 }
 
 static int smspec_node_cmp_key1( const smspec_node_type * node1, const smspec_node_type * node2) {
-  if (!node1->gen_key1) {
-    if (!node2->gen_key1)
+  if (node1->gen_key1.empty()) {
+    if (node2->gen_key1.empty())
       return 0;
     else
       return -1;
-  } else if (!node2->gen_key1) {
+  } else if (node2->gen_key1.empty()) {
     return 1;
   }
-  return util_strcmp_int( node1->gen_key1 , node2->gen_key1 );
+  return util_strcmp_int( node1->gen_key1.c_str() , node2->gen_key1.c_str() );
 }
 
 

--- a/lib/ecl/smspec_node.cpp
+++ b/lib/ecl/smspec_node.cpp
@@ -176,12 +176,6 @@ std::string smspec_alloc_region_2_region_num_key( const char * join_string , con
 
 
 
-std::string smspec_alloc_block_ijk_key( const char * join_string , const std::string& keyword , int i , int j , int k) {
-  return ecl::util::string_format(ECL_SUM_KEYFMT_BLOCK_IJK ,
-                                  keyword.c_str(),
-                                  join_string ,
-                                  i,j,k);
-}
 
 
 
@@ -236,11 +230,30 @@ std::string smspec_alloc_well_key( const char * join_string , const std::string&
   return smspec_alloc_wgname_key( join_string , keyword , wgname );
 }
 
+
+/*
+  The smspec_alloc_well_key and smspec_alloc_block_ijk_key() require C linkage due to external use.
+*/
+
 char * smspec_alloc_well_key( const char * join_string , const char * keyword , const char * wgname) {
   return util_alloc_sprintf( ECL_SUM_KEYFMT_WELL,
                              keyword,
                              join_string,
                              wgname);
+}
+
+char * smspec_alloc_block_ijk_key( const char * join_string , const char * keyword , int i , int j , int k) {
+  return util_alloc_sprintf(ECL_SUM_KEYFMT_BLOCK_IJK,
+                            keyword,
+                            join_string,
+                            i,j,k);
+}
+
+std::string smspec_alloc_block_ijk_key( const char * join_string , const std::string& keyword , int i , int j , int k) {
+  return ecl::util::string_format(ECL_SUM_KEYFMT_BLOCK_IJK ,
+                                  keyword.c_str(),
+                                  join_string ,
+                                  i,j,k);
 }
 
 std::string smspec_alloc_segment_key( const char * join_string , const std::string& keyword , const std::string& wgname , int num) {

--- a/lib/ecl/tests/ecl_sum_data_intermediate_test.cpp
+++ b/lib/ecl/tests/ecl_sum_data_intermediate_test.cpp
@@ -60,6 +60,7 @@ void verify_CASE1() {
     for (int j=0; j < 4; j++) {
       test_assert_double_equal( double_vector_iget(d, j), (i - 1)*10 + (j + 1)*100);
     }
+    double_vector_free(d);
   }
   ecl_sum_free(sum);
 }
@@ -103,6 +104,7 @@ void verify_CASE2() {
     //test_assert_int_equal(4, double_vector_size(d));
     for (int j=1; j < 4; j++)
       test_assert_double_equal( double_vector_iget(d, j-1), (1 - i)*100 + j*1000);
+    double_vector_free(d);
   }
 
   ecl_sum_free(sum);
@@ -112,7 +114,6 @@ void verify_CASE2() {
   for (int i=0; i < 2; i++) {
     double_vector_type * d = ecl_sum_alloc_data_vector(sum, i+1, false);
     //test_assert_int_equal(double_vector_size(d), 7);
-    double_vector_fprintf(d, stdout, "d", "%g");
     ieq(d,0,(1 - i)*10  + 100);
     ieq(d,1,(1 - i)*10  + 200);
     ieq(d,2,(1 - i)*10  + 300);
@@ -162,6 +163,7 @@ void verify_CASE3() {
     for (int j=0; j < 4; j++) {
       test_assert_double_equal( double_vector_iget(d, j), (2 - i)*1000 + (j + 1)*10000);
     }
+    double_vector_free(d);
   }
   ecl_sum_free(sum);
 

--- a/lib/private-include/detail/util/string_util.hpp
+++ b/lib/private-include/detail/util/string_util.hpp
@@ -1,0 +1,13 @@
+#ifndef ECL_STRING_UTIL
+#define ECL_STRING_UTIL
+
+
+#include <string>
+namespace ecl {
+  namespace util {
+    std::string string_format(const char * fmt, ...);
+  }
+}
+
+
+#endif

--- a/lib/util/cxx_string_util.cpp
+++ b/lib/util/cxx_string_util.cpp
@@ -1,0 +1,45 @@
+/*
+  Copyright (C) 2018  Equinor Statoil ASA, Norway.
+
+  The file 'cxx_string_util.cpp' is part of ERT - Ensemble based Reservoir Tool.
+
+  ERT is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE.
+
+  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+  for more details.
+*/
+
+#include <string>
+#include <stdarg.h>
+
+
+namespace ecl {
+  namespace util {
+
+    std::string string_format(const char* fmt, ...) {
+      int length;
+      std::string s;
+      {
+        va_list va;
+        va_start(va, fmt);
+        length = vsnprintf(NULL, 0, fmt, va);
+        va_end(va);
+      }
+      s.resize(length + 1);
+      {
+        va_list va;
+        va_start(va, fmt);
+        vsprintf((char *) s.data(), fmt, va);
+        va_end(va);
+      }
+      return s;
+    }
+  }
+}


### PR DESCRIPTION
Use cxx std::string and std::arry in smspec_node.

NB: The last commit is a nasty bug which was accidentally found while searchng for memory leaks with valgrind.
