### PR TITLE
WIP: Export kw as numpy with ecl_grid pandas frame as input

### DIFF
--- a/lib/ecl/ecl_grid.cpp
+++ b/lib/ecl/ecl_grid.cpp
@@ -502,6 +502,7 @@ which splits the lower face along the 0-3 diagnoal and the upper face
 along the 5-6 diagonal.
 */
 
+#define INDEX_DATA_FRAME_SIZE 4
 
 static const int tetrahedron_permutations[2][12][3] = {{
                                                         // K-
@@ -7093,7 +7094,7 @@ ecl_kw_type * ecl_grid_alloc_volume_kw( const ecl_grid_type * grid , bool active
 
 
 //Note: global_index must be allocated w/ ecl_grid->total_active or ecl_grid->global_size int32 data points
-//      index_data must be allocated w/ (4 * ecl_grid->total_active or ecl_grid->global_size) int32 data points.
+//      index_data must be allocated w/ (INDEX_DATA_FRAME_SIZE * ecl_grid->total_active or ecl_grid->global_size) int32 data points.
 void ecl_grid_export_index(const ecl_grid_type * grid, int * global_index, int * index_data , bool active_only) {
   int pos_indx = 0;
   int pos_data = 0;
@@ -7109,6 +7110,11 @@ void ecl_grid_export_index(const ecl_grid_type * grid, int * global_index, int *
           index_data[pos_data++] = grid->cells[g].active_index[0];
         }          
       }
+}
+
+bool ecl_grid_export_data_as_int( ecl_grid_type * grid, int index_size, int * global_index, ecl_kw_type * kw, int * output) {
+  
+  return true;
 }
 
 //

--- a/lib/ecl/ecl_grid.cpp
+++ b/lib/ecl/ecl_grid.cpp
@@ -502,7 +502,6 @@ which splits the lower face along the 0-3 diagnoal and the upper face
 along the 5-6 diagonal.
 */
 
-#define INDEX_DATA_FRAME_SIZE 4
 
 static const int tetrahedron_permutations[2][12][3] = {{
                                                         // K-
@@ -7094,7 +7093,7 @@ ecl_kw_type * ecl_grid_alloc_volume_kw( const ecl_grid_type * grid , bool active
 
 
 //Note: global_index must be allocated w/ ecl_grid->total_active or ecl_grid->global_size int32 data points
-//      index_data must be allocated w/ (INDEX_DATA_FRAME_SIZE * ecl_grid->total_active or ecl_grid->global_size) int32 data points.
+//      index_data must be allocated w/ (4 * ecl_grid->total_active or ecl_grid->global_size) int32 data points.
 void ecl_grid_export_index(const ecl_grid_type * grid, int * global_index, int * index_data , bool active_only) {
   int pos_indx = 0;
   int pos_data = 0;

--- a/lib/ecl/ecl_grid.cpp
+++ b/lib/ecl/ecl_grid.cpp
@@ -7112,9 +7112,28 @@ void ecl_grid_export_index(const ecl_grid_type * grid, int * global_index, int *
       }
 }
 
-bool ecl_grid_export_data_as_int( ecl_grid_type * grid, int index_size, int * global_index, ecl_kw_type * kw, int * output) {
-  
-  return true;
+//Note: index_size must equal allocated size of output
+void ecl_grid_export_data_as_int( ecl_grid_type * grid, int index_size, int * global_index, ecl_kw_type * kw, int * output) {
+  int * input = ecl_kw_get_int_ptr(kw);
+  if (index_size == ecl_kw_get_size(kw)) {
+    for (int g = 0; g < index_size; g++)
+      output[g] = input[g];
+  }
+  else if (index_size == grid->size) {
+    for (int g = 0; g < index_size; g++) {
+      int active_index = grid->index_map[g];
+      if (active_index >= 0)
+        output[g] = input[active_index];
+      else
+        output[g] = 0;
+    }    
+  }
+  else if (index_size == grid->total_active) {
+    for (int active_index = 0; active_index < index_size; active_index++) {
+      int g = grid->inv_index_map[active_index];
+      output[active_index] = input[g];
+    }
+  }
 }
 
 //

--- a/lib/ecl/ecl_grid.cpp
+++ b/lib/ecl/ecl_grid.cpp
@@ -7136,4 +7136,29 @@ void ecl_grid_export_data_as_int( ecl_grid_type * grid, int index_size, int * gl
   }
 }
 
+
+//Note: index_size must equal allocated size of output
+void ecl_grid_export_data_as_double( ecl_grid_type * grid, int index_size, int * global_index, ecl_kw_type * kw, double * output) {
+
+  if (index_size == ecl_kw_get_size(kw)) {
+    for (int g = 0; g < index_size; g++)
+      output[g] = ecl_kw_iget_as_double(kw, g);
+  }
+  else if (index_size == grid->size) {
+    for (int g = 0; g < index_size; g++) {
+      int active_index = grid->index_map[g];
+      if (active_index >= 0)
+        output[g] = ecl_kw_iget_as_double(kw, active_index);
+      else
+        output[g] = 0;
+    }    
+  }
+  else if (index_size == grid->total_active) {
+    for (int active_index = 0; active_index < index_size; active_index++) {
+      int g = grid->inv_index_map[active_index];
+      output[active_index] = ecl_kw_iget_as_double(kw, g);
+    }
+  }
+}
+
 //

--- a/lib/ecl/ecl_grid.cpp
+++ b/lib/ecl/ecl_grid.cpp
@@ -7113,51 +7113,22 @@ void ecl_grid_export_index(const ecl_grid_type * grid, int * global_index, int *
 }
 
 //Note: index_size must equal allocated size of output
-void ecl_grid_export_data_as_int( ecl_grid_type * grid, int index_size, int * global_index, ecl_kw_type * kw, int * output) {
+void ecl_grid_export_data_as_int( ecl_grid_type * grid, int index_size, int * data_index, ecl_kw_type * kw, int * output) {
   int * input = ecl_kw_get_int_ptr(kw);
-  if (index_size == ecl_kw_get_size(kw)) {
-    for (int g = 0; g < index_size; g++)
-      output[g] = input[g];
-  }
-  else if (index_size == grid->size) {
-    for (int g = 0; g < index_size; g++) {
-      int active_index = grid->index_map[g];
-      if (active_index >= 0)
-        output[g] = input[active_index];
-      else
-        output[g] = 0;
-    }    
-  }
-  else if (index_size == grid->total_active) {
-    for (int active_index = 0; active_index < index_size; active_index++) {
-      int g = grid->inv_index_map[active_index];
-      output[active_index] = input[g];
-    }
+  for (int i=0; i < index_size; i++) {
+    int di = data_index[i];
+    if (di >= 0)
+      output[i] = input[di];
   }
 }
 
 
 //Note: index_size must equal allocated size of output
-void ecl_grid_export_data_as_double( ecl_grid_type * grid, int index_size, int * global_index, ecl_kw_type * kw, double * output) {
-
-  if (index_size == ecl_kw_get_size(kw)) {
-    for (int g = 0; g < index_size; g++)
-      output[g] = ecl_kw_iget_as_double(kw, g);
-  }
-  else if (index_size == grid->size) {
-    for (int g = 0; g < index_size; g++) {
-      int active_index = grid->index_map[g];
-      if (active_index >= 0)
-        output[g] = ecl_kw_iget_as_double(kw, active_index);
-      else
-        output[g] = 0;
-    }    
-  }
-  else if (index_size == grid->total_active) {
-    for (int active_index = 0; active_index < index_size; active_index++) {
-      int g = grid->inv_index_map[active_index];
-      output[active_index] = ecl_kw_iget_as_double(kw, g);
-    }
+void ecl_grid_export_data_as_double( ecl_grid_type * grid, int index_size, int * data_index, ecl_kw_type * kw, double * output) {
+  for (int i=0; i < index_size; i++) {
+    int di = data_index[i];
+    if (di >= 0)
+      output[i] = ecl_kw_iget_as_double(kw, di);
   }
 }
 

--- a/lib/include/ert/ecl/ecl_grid.hpp
+++ b/lib/include/ert/ecl/ecl_grid.hpp
@@ -263,6 +263,7 @@ extern "C" {
   ert_ecl_unit_enum ecl_grid_get_unit_system(const ecl_grid_type * grid);
   void ecl_grid_export_index(const ecl_grid_type * grid, int * global_index, int * index_data , bool active_only);
   void ecl_grid_export_data_as_int( ecl_grid_type * grid, int index_size, int * global_index, ecl_kw_type * kw, int * output);
+  void ecl_grid_export_data_as_double( ecl_grid_type * grid, int index_size, int * global_index, ecl_kw_type * kw, double * output);
 
   UTIL_IS_INSTANCE_HEADER( ecl_grid );
   UTIL_SAFE_CAST_HEADER( ecl_grid );

--- a/lib/include/ert/ecl/ecl_grid.hpp
+++ b/lib/include/ert/ecl/ecl_grid.hpp
@@ -262,6 +262,7 @@ extern "C" {
 
   ert_ecl_unit_enum ecl_grid_get_unit_system(const ecl_grid_type * grid);
   void ecl_grid_export_index(const ecl_grid_type * grid, int * global_index, int * index_data , bool active_only);
+  bool ecl_grid_export_data_as_int( ecl_grid_type * grid, int index_size, int * global_index, ecl_kw_type * kw, int * output);
 
   UTIL_IS_INSTANCE_HEADER( ecl_grid );
   UTIL_SAFE_CAST_HEADER( ecl_grid );

--- a/lib/include/ert/ecl/ecl_grid.hpp
+++ b/lib/include/ert/ecl/ecl_grid.hpp
@@ -262,7 +262,7 @@ extern "C" {
 
   ert_ecl_unit_enum ecl_grid_get_unit_system(const ecl_grid_type * grid);
   void ecl_grid_export_index(const ecl_grid_type * grid, int * global_index, int * index_data , bool active_only);
-  bool ecl_grid_export_data_as_int( ecl_grid_type * grid, int index_size, int * global_index, ecl_kw_type * kw, int * output);
+  void ecl_grid_export_data_as_int( ecl_grid_type * grid, int index_size, int * global_index, ecl_kw_type * kw, int * output);
 
   UTIL_IS_INSTANCE_HEADER( ecl_grid );
   UTIL_SAFE_CAST_HEADER( ecl_grid );

--- a/python/ecl/grid/ecl_grid.py
+++ b/python/ecl/grid/ecl_grid.py
@@ -118,7 +118,7 @@ class EclGrid(BaseCClass):
     _export_mapaxes               = EclPrototype("ecl_kw_obj ecl_grid_alloc_mapaxes_kw(ecl_grid)")
     _get_unit_system              = EclPrototype("ecl_unit_enum ecl_grid_get_unit_system(ecl_grid)")
     _export_index_frame           = EclPrototype("void ecl_grid_export_index(ecl_grid, int*, int*, bool)")
-    _export_data_as_int           = EclPrototype("bool ecl_grid_export_data_as_int(ecl_grid, int, int*, ecl_kw, int*)")
+    _export_data_as_int           = EclPrototype("void ecl_grid_export_data_as_int(ecl_grid, int, int*, ecl_kw, int*)")
 
 
 
@@ -1279,13 +1279,11 @@ class EclGrid(BaseCClass):
 
         if kw.type is EclTypeEnum.ECL_INT_TYPE:
             data = numpy.zeros( len(global_index), dtype=numpy.int32 )
-            if self._export_data_as_int( len(global_index), 
-                                         global_index.ctypes.data_as(ctypes.POINTER(ctypes.c_int32)), 
-                                         kw, 
-                                         data.ctypes.data_as(ctypes.POINTER(ctypes.c_int32))  ):
-                return data
-            else:
-                raise Exception("EclGrid.export_data failed.")
+            self._export_data_as_int( len(global_index), 
+                                       global_index.ctypes.data_as(ctypes.POINTER(ctypes.c_int32)), 
+                                       kw, 
+                                       data.ctypes.data_as(ctypes.POINTER(ctypes.c_int32))  )
+            return data
         elif kw.type is EclTypeEnum.ECL_FLOAT_TYPE:
             return None
         elif kw.type is EclTypeEnum.ECL_DOUBLE_TYPE:

--- a/python/ecl/grid/ecl_grid.py
+++ b/python/ecl/grid/ecl_grid.py
@@ -119,6 +119,7 @@ class EclGrid(BaseCClass):
     _get_unit_system              = EclPrototype("ecl_unit_enum ecl_grid_get_unit_system(ecl_grid)")
     _export_index_frame           = EclPrototype("void ecl_grid_export_index(ecl_grid, int*, int*, bool)")
     _export_data_as_int           = EclPrototype("void ecl_grid_export_data_as_int(ecl_grid, int, int*, ecl_kw, int*)")
+    _export_data_as_double        = EclPrototype("void ecl_grid_export_data_as_double(ecl_grid, int, int*, ecl_kw, double*)")
 
 
 
@@ -1284,10 +1285,13 @@ class EclGrid(BaseCClass):
                                        kw, 
                                        data.ctypes.data_as(ctypes.POINTER(ctypes.c_int32))  )
             return data
-        elif kw.type is EclTypeEnum.ECL_FLOAT_TYPE:
-            return None
-        elif kw.type is EclTypeEnum.ECL_DOUBLE_TYPE:
-            return None
+        elif kw.type is EclTypeEnum.ECL_FLOAT_TYPE or kw.type is EclTypeEnum.ECL_DOUBLE_TYPE:
+            data = numpy.zeros( len(global_index), dtype=numpy.float64 )
+            self._export_data_as_double( len(global_index), 
+                                         global_index.ctypes.data_as(ctypes.POINTER(ctypes.c_int32)), 
+                                         kw, 
+                                         data.ctypes.data_as(ctypes.POINTER(ctypes.c_double))  )            
+            return data
         else:
             raise TypeError("Keyword must be either int, float or double.")
 

--- a/python/tests/ecl_tests/test_grid_pandas.py
+++ b/python/tests/ecl_tests/test_grid_pandas.py
@@ -37,37 +37,55 @@ class GridPandasTest(EclTest):
                               [1, 2, 0, 3] ])
     assert( np.array_equal(df.values, index_matrix) )
 
-    kw = EclKW('qq', 4, EclTypeEnum.ECL_INT_TYPE)
-    kw[0] = 0
-    kw[1] = 2
-    kw[2] = 8
-    kw[3] = 9
-    data = grid.export_data(df, kw)
+    kw_int_active = EclKW('int_act', 4, EclTypeEnum.ECL_INT_TYPE)
+    kw_int_active[0] = 9
+    kw_int_active[1] = 8
+    kw_int_active[2] = 7
+    kw_int_active[3] = 6
+    data = grid.export_data(df, kw_int_active)
     assert( len(data) == 4 )
-    assert( np.array_equal(data, np.array([0, 2, 8, 9]))  )
+    assert( np.array_equal(data, np.array([9, 8, 7, 6]))  )
 
-    kw = EclKW('qq', 6, EclTypeEnum.ECL_INT_TYPE)
-    kw[0] = 0
-    kw[1] = 2
-    kw[2] = 4
-    kw[3] = 6
-    kw[4] = 8
-    kw[5] = 9
-    data = grid.export_data(df, kw)
+    kw_float_active = EclKW('float_at', 4, EclTypeEnum.ECL_FLOAT_TYPE)
+    kw_float_active[0] = 10.5
+    kw_float_active[1] = 9.25
+    kw_float_active[2] = 2.0
+    kw_float_active[3] = 1.625
+    data = grid.export_data(df, kw_float_active)
+    assert( len(data) == 4 )
+    assert( np.array_equal(data, np.array([10.5, 9.25, 2.0, 1.625])) )
+
+    kw_int_global = EclKW('int_glob', 6, EclTypeEnum.ECL_INT_TYPE)
+    kw_int_global[0] = 0
+    kw_int_global[1] = 2
+    kw_int_global[2] = 4
+    kw_int_global[3] = 6
+    kw_int_global[4] = 8
+    kw_int_global[5] = 9
+    data = grid.export_data(df, kw_int_global)
     assert( len(data) == 4)
     assert( np.array_equal(data, np.array([0, 2, 8, 9]))  )
 
-    df = grid.export_index()
+    kw_double_global = EclKW('double_g', 6, EclTypeEnum.ECL_DOUBLE_TYPE)
+    kw_double_global[0] = 1.1
+    kw_double_global[1] = 2.2
+    kw_double_global[2] = 3.3
+    kw_double_global[3] = 4.4
+    kw_double_global[4] = 5.5
+    kw_double_global[5] = 6.6
+    data = grid.export_data(df, kw_double_global)
+    assert( np.array_equal(data, np.array([1.1, 2.2, 5.5, 6.6])) )
+
+    df = grid.export_index()      #DataFrame has now 6 rows
     global_index = df.index;
     assert( np.array_equal(global_index, np.array([0, 1, 2, 3, 4, 5])) )
     
-    kw = EclKW('q', 4, EclTypeEnum.ECL_INT_TYPE)
-    kw[0] = 9;
-    kw[1] = 8;
-    kw[2] = 7;
-    kw[3] = 6;
-    data = grid.export_data(df, kw)
+    data = grid.export_data(df, kw_int_active)
     assert( np.array_equal(data, np.array([9, 8, 0, 0, 7, 6])) )
+
+    data = grid.export_data(df, kw_float_active)
+    assert( np.array_equal(data, np.array([10.5, 9.25, 0.0, 0.0, 2.0, 1.625])) )
+
     
     
    

--- a/python/tests/ecl_tests/test_grid_pandas.py
+++ b/python/tests/ecl_tests/test_grid_pandas.py
@@ -18,6 +18,10 @@
 import numpy as np
 import pandas as pd
 
+from ecl import  EclTypeEnum
+
+from ecl.eclfile import EclKW
+
 from ecl.grid import EclGrid
 
 from tests import EclTest
@@ -33,3 +37,13 @@ class GridPandasTest(EclTest):
                               [1, 2, 0, 3] ])
     assert( np.array_equal(df.values, index_matrix) )
 
+    kw = EclKW('qq', 6, EclTypeEnum.ECL_INT_TYPE)
+    kw[0] = 0;
+    kw[1] = 2;
+    kw[2] = 4;
+    kw[3] = 6;
+    kw[4] = 8;
+    kw[5] = 9;
+    data = grid.export_data(df, kw)
+    assert( len(data) == 4 )
+    #assert( np.array_equal(data, np.array([0, 2, 8, 9]))  )

--- a/python/tests/ecl_tests/test_grid_pandas.py
+++ b/python/tests/ecl_tests/test_grid_pandas.py
@@ -28,7 +28,7 @@ from tests import EclTest
 
 class GridPandasTest(EclTest):
 
-  def test_dataframe(self):
+  def test_dataframe_actnum(self):
     grid = EclGrid.create_rectangular( (2,3,1), (1,1,1) , actnum=[1, 1, 0, 0, 1, 1])
     df = grid.export_index(True)
     index_matrix = np.array([ [0, 0, 0, 0],
@@ -37,13 +37,38 @@ class GridPandasTest(EclTest):
                               [1, 2, 0, 3] ])
     assert( np.array_equal(df.values, index_matrix) )
 
-    kw = EclKW('qq', 6, EclTypeEnum.ECL_INT_TYPE)
-    kw[0] = 0;
-    kw[1] = 2;
-    kw[2] = 4;
-    kw[3] = 6;
-    kw[4] = 8;
-    kw[5] = 9;
+    kw = EclKW('qq', 4, EclTypeEnum.ECL_INT_TYPE)
+    kw[0] = 0
+    kw[1] = 2
+    kw[2] = 8
+    kw[3] = 9
     data = grid.export_data(df, kw)
     assert( len(data) == 4 )
-    #assert( np.array_equal(data, np.array([0, 2, 8, 9]))  )
+    assert( np.array_equal(data, np.array([0, 2, 8, 9]))  )
+
+    kw = EclKW('qq', 6, EclTypeEnum.ECL_INT_TYPE)
+    kw[0] = 0
+    kw[1] = 2
+    kw[2] = 4
+    kw[3] = 6
+    kw[4] = 8
+    kw[5] = 9
+    data = grid.export_data(df, kw)
+    assert( len(data) == 4)
+    assert( np.array_equal(data, np.array([0, 2, 8, 9]))  )
+
+    df = grid.export_index()
+    global_index = df.index;
+    assert( np.array_equal(global_index, np.array([0, 1, 2, 3, 4, 5])) )
+    
+    kw = EclKW('q', 4, EclTypeEnum.ECL_INT_TYPE)
+    kw[0] = 9;
+    kw[1] = 8;
+    kw[2] = 7;
+    kw[3] = 6;
+    data = grid.export_data(df, kw)
+    assert( np.array_equal(data, np.array([9, 8, 0, 0, 7, 6])) )
+    
+    
+   
+    


### PR DESCRIPTION
**Task**
Make a function in EclGrid: export_data(index_frame, kw) -> numpy.array. 
index_frame is created by EclGrid.export_index(bool active_only) and is a pandas.DataFrame
len(numpy.array) = len(index_frame.index) and can be either global size or total_active size.


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
