### PR TITLE
Smspec node: Recognise a few segment-related variable types

### DIFF
--- a/lib/ecl/smspec_node.cpp
+++ b/lib/ecl/smspec_node.cpp
@@ -18,6 +18,7 @@
 
 #include <string.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <math.h>
 #include <time.h>
 
@@ -317,7 +318,8 @@ static void smspec_node_set_invalid_flags( smspec_node_type * smspec_node) {
 
 
 bool smspec_node_identify_rate(const char * keyword) {
-  const char *rate_vars[] = {"OPR" , "GPR" , "WPR" , "LPR", "OIR", "GIR", "WIR", "LIR", "GOR" , "WCT"};
+  const char *rate_vars[] = {"OPR" , "GPR" , "WPR" , "LPR", "OIR", "GIR", "WIR", "LIR", "GOR" , "WCT",
+                             "OFR" , "GFR" , "WFR"};
   int num_rate_vars = sizeof( rate_vars ) / sizeof( rate_vars[0] );
   bool  is_rate           = false;
   int ivar;
@@ -368,6 +370,16 @@ bool smspec_node_identify_total(const char * keyword, ecl_smspec_var_type var_ty
         break;
       }
     }
+  }
+  else if (var_type == ECL_SMSPEC_SEGMENT_VAR) {
+    const char *total_vars[] = {"OFT", "GFT", "WFT"};
+    const char *var_substring = &keyword[1];
+    const size_t num_total_vars = sizeof(total_vars) / sizeof(total_vars[0]);
+    for (size_t ivar = 0; ivar < num_total_vars; ivar++)
+      if (strncmp(total_vars[ivar], var_substring, strlen(total_vars[ivar])) == 0) {
+        is_total = true;
+        break;
+      }
   }
   return is_total;
 }

--- a/lib/ecl/tests/ecl_smspec_node.cpp
+++ b/lib/ecl/tests/ecl_smspec_node.cpp
@@ -25,6 +25,74 @@
 #include <ert/ecl/smspec_node.hpp>
 
 
+static void test_identify_rate_variable() {
+  const char* rate_vars[] = {
+    "WOPR" , "GGPR" , "FWPR" , "WLPR" , "WOIR" , "FGIR" , "GWIR" ,
+    "WLIR" , "GGOR" , "FWCT" , "SOFR" , "SGFR" , "SWFR" ,
+  };
+
+  const auto n_var = sizeof(rate_vars) / sizeof(rate_vars[0]);
+
+  for (auto var = rate_vars, end = rate_vars + n_var; var != end; ++var)
+    test_assert_true(smspec_node_identify_rate(*var));
+
+  test_assert_false(smspec_node_identify_rate("SPR"));
+  test_assert_false(smspec_node_identify_rate("SOFT"));
+  test_assert_false(smspec_node_identify_rate("SGFT"));
+  test_assert_false(smspec_node_identify_rate("SWFT"));
+}
+
+static void test_identify_total_variable() {
+  test_assert_true(smspec_node_identify_total("WOPT", ECL_SMSPEC_WELL_VAR));
+  test_assert_true(smspec_node_identify_total("GGPT", ECL_SMSPEC_GROUP_VAR));
+  test_assert_true(smspec_node_identify_total("FWPT", ECL_SMSPEC_FIELD_VAR));
+  test_assert_true(smspec_node_identify_total("RGIT", ECL_SMSPEC_REGION_VAR));
+  test_assert_true(smspec_node_identify_total("CWIT", ECL_SMSPEC_COMPLETION_VAR));
+
+  test_assert_true(smspec_node_identify_total("WOPTF", ECL_SMSPEC_WELL_VAR));
+  test_assert_true(smspec_node_identify_total("GOPTS", ECL_SMSPEC_GROUP_VAR));
+  test_assert_true(smspec_node_identify_total("FOIT", ECL_SMSPEC_FIELD_VAR));
+  test_assert_true(smspec_node_identify_total("ROVPT", ECL_SMSPEC_REGION_VAR));
+  test_assert_true(smspec_node_identify_total("COVIT", ECL_SMSPEC_COMPLETION_VAR));
+
+  test_assert_true(smspec_node_identify_total("WMWT", ECL_SMSPEC_WELL_VAR));
+  test_assert_true(smspec_node_identify_total("GWVPT", ECL_SMSPEC_GROUP_VAR));
+  test_assert_true(smspec_node_identify_total("FWVIT", ECL_SMSPEC_FIELD_VAR));
+  test_assert_true(smspec_node_identify_total("RGMT", ECL_SMSPEC_REGION_VAR));
+  test_assert_true(smspec_node_identify_total("CGPTF", ECL_SMSPEC_COMPLETION_VAR));
+
+  test_assert_true(smspec_node_identify_total("WSGT", ECL_SMSPEC_WELL_VAR));
+  test_assert_true(smspec_node_identify_total("GGST", ECL_SMSPEC_GROUP_VAR));
+  test_assert_true(smspec_node_identify_total("FFGT", ECL_SMSPEC_FIELD_VAR));
+  test_assert_true(smspec_node_identify_total("RGCT", ECL_SMSPEC_REGION_VAR));
+  test_assert_true(smspec_node_identify_total("CGIMT", ECL_SMSPEC_COMPLETION_VAR));
+
+  test_assert_true(smspec_node_identify_total("WWGPT", ECL_SMSPEC_WELL_VAR));
+  test_assert_true(smspec_node_identify_total("GWGIT", ECL_SMSPEC_GROUP_VAR));
+  test_assert_true(smspec_node_identify_total("FEGT", ECL_SMSPEC_FIELD_VAR));
+  test_assert_true(smspec_node_identify_total("REXGT", ECL_SMSPEC_REGION_VAR));
+  test_assert_true(smspec_node_identify_total("CGVPT", ECL_SMSPEC_COMPLETION_VAR));
+
+  test_assert_true(smspec_node_identify_total("WGVIT", ECL_SMSPEC_WELL_VAR));
+  test_assert_true(smspec_node_identify_total("GLPT", ECL_SMSPEC_GROUP_VAR));
+  test_assert_true(smspec_node_identify_total("FVPT", ECL_SMSPEC_FIELD_VAR));
+  test_assert_true(smspec_node_identify_total("RVIT", ECL_SMSPEC_REGION_VAR));
+  test_assert_true(smspec_node_identify_total("CNPT", ECL_SMSPEC_COMPLETION_VAR));
+
+  test_assert_true(smspec_node_identify_total("WNIT", ECL_SMSPEC_WELL_VAR));
+  test_assert_true(smspec_node_identify_total("GCPT", ECL_SMSPEC_GROUP_VAR));
+  test_assert_true(smspec_node_identify_total("FCIT", ECL_SMSPEC_FIELD_VAR));
+
+  test_assert_true(smspec_node_identify_total("SOFT", ECL_SMSPEC_SEGMENT_VAR));
+  test_assert_true(smspec_node_identify_total("SGFT", ECL_SMSPEC_SEGMENT_VAR));
+  test_assert_true(smspec_node_identify_total("SWFT", ECL_SMSPEC_SEGMENT_VAR));
+
+  test_assert_false(smspec_node_identify_total("SOPT", ECL_SMSPEC_SEGMENT_VAR));
+  test_assert_false(smspec_node_identify_total("HEI!", ECL_SMSPEC_SEGMENT_VAR));
+  test_assert_false(smspec_node_identify_total("xXx", ECL_SMSPEC_SEGMENT_VAR));
+  test_assert_false(smspec_node_identify_total("SPR", ECL_SMSPEC_SEGMENT_VAR));
+}
+
 void test_cmp_types() {
   const int dims[3] = {10,10,10};
   smspec_node_type * field_node = smspec_node_alloc( ECL_SMSPEC_FIELD_VAR , NULL , "FOPT" , "UNIT" , ":" , dims , 0 , 0 , 0 );
@@ -121,4 +189,6 @@ int main(int argc, char ** argv) {
   test_cmp_types();
   test_cmp_well();
   test_cmp_region( );
+  test_identify_rate_variable();
+  test_identify_total_variable();
 }


### PR DESCRIPTION
This commit extends predicates `smspec_node_identify_rate()` and `smspec_node_identify_total()` to recognise the segment-related summary vectors
```
SOFR, SGFR, SWFR
```
as rate quantities and
```
SOFT, SGFT, SWFT
```
as total/cumulative quantities.

While here, expand the `ecl_smspec_node` unit test to exercise these predicates and include tests for the existing vector names too.

**Task**
_Extend libecl's knowledge of summary vectors to include a few segment-related quantities_


**Approach**
_Append new keyword strings to the hard-coded lists in the relevant predicate functions_


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally