### PR TITLE
WIP: Fix ecl sum panda frame

### DIFF
--- a/lib/ecl/ecl_smspec.cpp
+++ b/lib/ecl/ecl_smspec.cpp
@@ -327,8 +327,18 @@ int * ecl_smspec_alloc_mapping( const ecl_smspec_type * self, const ecl_smspec_t
 */
 
 
-const smspec_node_type * ecl_smspec_iget_node_w_node_index( const ecl_smspec_type * smspec , int index ) {
-  return (const smspec_node_type*)vector_iget_const( smspec->smspec_nodes , index );
+const smspec_node_type * ecl_smspec_iget_node_w_node_index( const ecl_smspec_type * smspec , int node_index ) {
+  return (const smspec_node_type*)vector_iget_const( smspec->smspec_nodes , node_index );
+}
+
+
+/*
+  The ecl_smspec_iget_node() function is only retained for compatibility; should be
+  replaced with calls to the more explicit: ecl_smspec_iget_node_w_node_index().
+*/
+
+const smspec_node_type * ecl_smspec_iget_node(const ecl_smspec_type * smspec, int index) {
+  return ecl_smspec_iget_node_w_node_index(smspec, index);
 }
 
 const smspec_node_type * ecl_smspec_iget_node_w_params_index( const ecl_smspec_type * smspec , int params_index ) {

--- a/lib/ecl/ecl_smspec.cpp
+++ b/lib/ecl/ecl_smspec.cpp
@@ -1099,6 +1099,7 @@ void ecl_smspec_insert_node(ecl_smspec_type * ecl_smspec, smspec_node_type * sms
     if (!ecl_smspec->write_mode)
       util_abort("%s: internal error \n",__func__);
     smspec_node_set_params_index( smspec_node , internal_index);
+    ecl_smspec->inv_index_map.push_back(internal_index);
 
     if (internal_index >= ecl_smspec->params_size)
       ecl_smspec_set_params_size( ecl_smspec , internal_index + 1);

--- a/lib/ecl/ecl_smspec.cpp
+++ b/lib/ecl/ecl_smspec.cpp
@@ -305,7 +305,7 @@ int * ecl_smspec_alloc_mapping( const ecl_smspec_type * self, const ecl_smspec_t
 
 
   for (int i=0; i < ecl_smspec_num_nodes( self ); i++) {
-    const smspec_node_type * self_node = ecl_smspec_iget_node( self , i );
+    const smspec_node_type * self_node = ecl_smspec_iget_node_w_node_index( self , i );
     int self_index = smspec_node_get_params_index( self_node );
     const char * key = smspec_node_get_gen_key1( self_node );
     if (ecl_smspec_has_general_var( other , key)) {
@@ -326,8 +326,13 @@ int * ecl_smspec_alloc_mapping( const ecl_smspec_type * self, const ecl_smspec_t
 */
 
 
-const smspec_node_type * ecl_smspec_iget_node( const ecl_smspec_type * smspec , int index ) {
+const smspec_node_type * ecl_smspec_iget_node_w_node_index( const ecl_smspec_type * smspec , int index ) {
   return (const smspec_node_type*)vector_iget_const( smspec->smspec_nodes , index );
+}
+
+const smspec_node_type * ecl_smspec_iget_node_w_params_index( const ecl_smspec_type * smspec , int params_index ) {
+  int node_index = smspec->inv_index_map[params_index];
+  return ecl_smspec_iget_node_w_node_index(smspec, node_index);
 }
 
 int ecl_smspec_num_nodes( const ecl_smspec_type * smspec) {
@@ -347,7 +352,7 @@ int ecl_smspec_get_node_index(const ecl_smspec_type * smspec, int params_index) 
 static ecl_data_type get_wgnames_type(const ecl_smspec_type * smspec) {
   size_t max_len = 0;
   for(int i = 0; i < ecl_smspec_num_nodes(smspec); ++i) {
-    const smspec_node_type * node = ecl_smspec_iget_node(smspec, i);
+    const smspec_node_type * node = ecl_smspec_iget_node_w_node_index(smspec, i);
     const char * name = smspec_node_get_wgname( node );
     if(name)
       max_len = util_size_t_max(max_len, strlen(name));
@@ -439,7 +444,7 @@ static void ecl_smspec_fortio_fwrite( const ecl_smspec_type * smspec , fortio_ty
     nums_kw = ecl_kw_alloc( NUMS_KW , num_nodes , ECL_INT);
 
   for (int i=0; i < ecl_smspec_num_nodes( smspec ); i++) {
-    const smspec_node_type * smspec_node = ecl_smspec_iget_node( smspec , i );
+    const smspec_node_type * smspec_node = ecl_smspec_iget_node_w_node_index( smspec , i );
     /*
       It is possible to add variables with deferred initialisation
       with the ecl_sum_add_blank_var() function. Before these

--- a/lib/ecl/ecl_smspec.cpp
+++ b/lib/ecl/ecl_smspec.cpp
@@ -23,6 +23,7 @@
 #include <errno.h>
 
 #include <vector>
+#include <map>
 
 #include <ert/util/hash.hpp>
 #include <ert/util/util.h>
@@ -120,7 +121,7 @@ struct ecl_smspec_struct {
   bool                 write_mode;
   bool                 need_nums;
   int_vector_type    * index_map;
-  std::vector<int>     inv_index_map;
+  std::map<int, int>   inv_index_map;
 
   /*-----------------------------------------------------------------*/
 
@@ -331,7 +332,7 @@ const smspec_node_type * ecl_smspec_iget_node_w_node_index( const ecl_smspec_typ
 }
 
 const smspec_node_type * ecl_smspec_iget_node_w_params_index( const ecl_smspec_type * smspec , int params_index ) {
-  int node_index = smspec->inv_index_map[params_index];
+  int node_index = smspec->inv_index_map.at(params_index);
   return ecl_smspec_iget_node_w_node_index(smspec, node_index);
 }
 
@@ -339,10 +340,6 @@ int ecl_smspec_num_nodes( const ecl_smspec_type * smspec) {
   return vector_get_size( smspec->smspec_nodes );
 }
 
-
-int ecl_smspec_get_node_index(const ecl_smspec_type * smspec, int params_index) {
-  return smspec->inv_index_map[params_index];
-}
 
 /**
  * Returns an ecl data type for which all names will fit. If the maximum name
@@ -1104,7 +1101,7 @@ void ecl_smspec_insert_node(ecl_smspec_type * ecl_smspec, smspec_node_type * sms
     if (!ecl_smspec->write_mode)
       util_abort("%s: internal error \n",__func__);
     smspec_node_set_params_index( smspec_node , internal_index);
-    ecl_smspec->inv_index_map.push_back(internal_index);
+    ecl_smspec->inv_index_map.insert( std::make_pair(internal_index, internal_index) );
 
     if (internal_index >= ecl_smspec->params_size)
       ecl_smspec_set_params_size( ecl_smspec , internal_index + 1);
@@ -1245,10 +1242,9 @@ static bool ecl_smspec_fread_header(ecl_smspec_type * ecl_smspec, const char * h
 
         if (smspec_node) {
           ecl_smspec_add_node( ecl_smspec , smspec_node );
-          ecl_smspec->inv_index_map.push_back( node_count++ );
+          ecl_smspec->inv_index_map.insert( std::make_pair(params_index, node_count) );
+          node_count++;
         }
-        else
-          ecl_smspec->inv_index_map.push_back(-1);
 
         free( kw );
         free( well );

--- a/lib/ecl/ecl_sum.cpp
+++ b/lib/ecl/ecl_sum.cpp
@@ -782,7 +782,7 @@ ecl_sum_type * ecl_sum_alloc_resample(const ecl_sum_type * ecl_sum, const char *
   const int * grid_dims  = ecl_smspec_get_grid_dims(ecl_sum->smspec);
 
   bool time_in_days = false;
-  const smspec_node_type * node = ecl_smspec_iget_node(ecl_sum->smspec, 0);
+  const smspec_node_type * node = ecl_smspec_iget_node_w_node_index(ecl_sum->smspec, 0);
   if ( util_string_equal(smspec_node_get_unit(node), "DAYS" ) )
     time_in_days = true;
 
@@ -791,7 +791,7 @@ ecl_sum_type * ecl_sum_alloc_resample(const ecl_sum_type * ecl_sum, const char *
 
 
   for (int i = 0; i < ecl_smspec_num_nodes(ecl_sum->smspec); i++) {
-    const smspec_node_type * node = ecl_smspec_iget_node(ecl_sum->smspec, i);
+    const smspec_node_type * node = ecl_smspec_iget_node_w_node_index(ecl_sum->smspec, i);
     if (util_string_equal(smspec_node_get_gen_key1(node), "TIME"))
       continue;
 

--- a/lib/ecl/ecl_sum_data.cpp
+++ b/lib/ecl/ecl_sum_data.cpp
@@ -811,6 +811,7 @@ double ecl_sum_data_iget( const ecl_sum_data_type * data , int time_index , int 
   if (params_map[params_index] >= 0)
     return file_data->iget( time_index - index_node.offset, params_map[params_index] );
   else {
+    //int node_index = ecl_smspec_get_node_index(data->smspec, params_index);
     const smspec_node_type * smspec_node = ecl_smspec_iget_node(data->smspec, params_index);
     return smspec_node_get_default(smspec_node);
   }
@@ -1177,7 +1178,7 @@ void ecl_sum_data_init_double_frame(const ecl_sum_data_type * data, const ecl_su
   for (int time_index=0; time_index < ecl_sum_data_get_length(data); time_index++) {
     for (int key_index = 0; key_index < ecl_sum_vector_get_size(keywords); key_index++) {
       int param_index = ecl_sum_vector_iget_param_index(keywords, key_index);
-      printf("****** %s, param_index = %d\n", __func__, param_index);
+      //printf("****** %s, param_index = %d, node_index = %d\n", __func__, param_index, ecl_smspec_get_node_index(data->smspec, param_index));
       int data_index = key_index*key_stride + time_index * time_stride;
 
       output_data[data_index] = ecl_sum_data_iget(data, time_index, param_index);

--- a/lib/ecl/ecl_sum_data.cpp
+++ b/lib/ecl/ecl_sum_data.cpp
@@ -1177,10 +1177,12 @@ void ecl_sum_data_init_double_frame(const ecl_sum_data_type * data, const ecl_su
   for (int time_index=0; time_index < ecl_sum_data_get_length(data); time_index++) {
     for (int key_index = 0; key_index < ecl_sum_vector_get_size(keywords); key_index++) {
       int param_index = ecl_sum_vector_iget_param_index(keywords, key_index);
+      printf("****** %s, param_index = %d\n", __func__, param_index);
       int data_index = key_index*key_stride + time_index * time_stride;
 
       output_data[data_index] = ecl_sum_data_iget(data, time_index, param_index);
     }
+    printf("------------------------------------ \n");
   }
 }
 

--- a/lib/ecl/ecl_sum_data.cpp
+++ b/lib/ecl/ecl_sum_data.cpp
@@ -811,8 +811,7 @@ double ecl_sum_data_iget( const ecl_sum_data_type * data , int time_index , int 
   if (params_map[params_index] >= 0)
     return file_data->iget( time_index - index_node.offset, params_map[params_index] );
   else {
-    int node_index = ecl_smspec_get_node_index(data->smspec, params_index);
-    const smspec_node_type * smspec_node = ecl_smspec_iget_node(data->smspec, node_index);
+    const smspec_node_type * smspec_node = ecl_smspec_iget_node_w_params_index(data->smspec, params_index);
     return smspec_node_get_default(smspec_node);
   }
 }
@@ -1076,10 +1075,9 @@ static void ecl_sum_data_init_double_vector__(const ecl_sum_data_type * data, in
     const auto& data_file = data->data_files[index_node.data_index];
     const auto& params_map = index_node.params_map;
     int params_index = params_map[main_params_index];
-    int node_index = ecl_smspec_get_node_index(data->smspec, main_params_index);
 
     if (report_only) {
-      const smspec_node_type * smspec_node = ecl_smspec_iget_node(data->smspec, node_index);
+      const smspec_node_type * smspec_node = ecl_smspec_iget_node_w_params_index(data->smspec, main_params_index);
       double default_value = smspec_node_get_default(smspec_node);
       offset += data_file->get_data_report(params_index, index_node.length, &output_data[offset], default_value);
     } else {
@@ -1087,7 +1085,7 @@ static void ecl_sum_data_init_double_vector__(const ecl_sum_data_type * data, in
       if (params_index >= 0)
         data_file->get_data(params_index, index_node.length, &output_data[offset]);
       else {
-        const smspec_node_type * smspec_node = ecl_smspec_iget_node(data->smspec, node_index);
+        const smspec_node_type * smspec_node = ecl_smspec_iget_node_w_params_index(data->smspec, main_params_index);
         for (int i=0; i < index_node.length; i++)
           output_data[offset + i] = smspec_node_get_default(smspec_node);
       }

--- a/lib/ecl/ecl_sum_data.cpp
+++ b/lib/ecl/ecl_sum_data.cpp
@@ -1178,7 +1178,6 @@ void ecl_sum_data_init_double_frame(const ecl_sum_data_type * data, const ecl_su
   for (int time_index=0; time_index < ecl_sum_data_get_length(data); time_index++) {
     for (int key_index = 0; key_index < ecl_sum_vector_get_size(keywords); key_index++) {
       int param_index = ecl_sum_vector_iget_param_index(keywords, key_index);
-      //printf("****** %s, param_index = %d, node_index = %d\n", __func__, param_index, ecl_smspec_get_node_index(data->smspec, param_index));
       int data_index = key_index*key_stride + time_index * time_stride;
 
       output_data[data_index] = ecl_sum_data_iget(data, time_index, param_index);

--- a/lib/ecl/ecl_sum_data.cpp
+++ b/lib/ecl/ecl_sum_data.cpp
@@ -811,8 +811,8 @@ double ecl_sum_data_iget( const ecl_sum_data_type * data , int time_index , int 
   if (params_map[params_index] >= 0)
     return file_data->iget( time_index - index_node.offset, params_map[params_index] );
   else {
-    //int node_index = ecl_smspec_get_node_index(data->smspec, params_index);
-    const smspec_node_type * smspec_node = ecl_smspec_iget_node(data->smspec, params_index);
+    int node_index = ecl_smspec_get_node_index(data->smspec, params_index);
+    const smspec_node_type * smspec_node = ecl_smspec_iget_node(data->smspec, node_index);
     return smspec_node_get_default(smspec_node);
   }
 }
@@ -1076,10 +1076,10 @@ static void ecl_sum_data_init_double_vector__(const ecl_sum_data_type * data, in
     const auto& data_file = data->data_files[index_node.data_index];
     const auto& params_map = index_node.params_map;
     int params_index = params_map[main_params_index];
-
+    int node_index = ecl_smspec_get_node_index(data->smspec, main_params_index);
 
     if (report_only) {
-      const smspec_node_type * smspec_node = ecl_smspec_iget_node(data->smspec, main_params_index);
+      const smspec_node_type * smspec_node = ecl_smspec_iget_node(data->smspec, node_index);
       double default_value = smspec_node_get_default(smspec_node);
       offset += data_file->get_data_report(params_index, index_node.length, &output_data[offset], default_value);
     } else {
@@ -1087,7 +1087,7 @@ static void ecl_sum_data_init_double_vector__(const ecl_sum_data_type * data, in
       if (params_index >= 0)
         data_file->get_data(params_index, index_node.length, &output_data[offset]);
       else {
-        const smspec_node_type * smspec_node = ecl_smspec_iget_node(data->smspec, main_params_index);
+        const smspec_node_type * smspec_node = ecl_smspec_iget_node(data->smspec, node_index);
         for (int i=0; i < index_node.length; i++)
           output_data[offset + i] = smspec_node_get_default(smspec_node);
       }
@@ -1183,7 +1183,6 @@ void ecl_sum_data_init_double_frame(const ecl_sum_data_type * data, const ecl_su
 
       output_data[data_index] = ecl_sum_data_iget(data, time_index, param_index);
     }
-    printf("------------------------------------ \n");
   }
 }
 

--- a/lib/ecl/ecl_sum_vector.cpp
+++ b/lib/ecl/ecl_sum_vector.cpp
@@ -67,6 +67,7 @@ ecl_sum_vector_type * ecl_sum_vector_alloc(const ecl_sum_type * ecl_sum, bool ad
     ecl_sum_vector->key_list = stringlist_alloc_new( );
     if (add_keywords) {
       const ecl_smspec_type * smspec = ecl_sum_get_smspec(ecl_sum);
+      printf("********* %s: num nodes = %d\n", __func__, ecl_smspec_num_nodes(smspec));
       for (int i=0; i < ecl_smspec_num_nodes(smspec); i++) {
         const smspec_node_type * node = ecl_smspec_iget_node( smspec , i );
         const char * key = smspec_node_get_gen_key1(node);

--- a/lib/ecl/ecl_sum_vector.cpp
+++ b/lib/ecl/ecl_sum_vector.cpp
@@ -67,7 +67,6 @@ ecl_sum_vector_type * ecl_sum_vector_alloc(const ecl_sum_type * ecl_sum, bool ad
     ecl_sum_vector->key_list = stringlist_alloc_new( );
     if (add_keywords) {
       const ecl_smspec_type * smspec = ecl_sum_get_smspec(ecl_sum);
-      printf("********* %s: num nodes = %d\n", __func__, ecl_smspec_num_nodes(smspec));
       for (int i=0; i < ecl_smspec_num_nodes(smspec); i++) {
         const smspec_node_type * node = ecl_smspec_iget_node( smspec , i );
         const char * key = smspec_node_get_gen_key1(node);

--- a/lib/ecl/ecl_sum_vector.cpp
+++ b/lib/ecl/ecl_sum_vector.cpp
@@ -68,7 +68,7 @@ ecl_sum_vector_type * ecl_sum_vector_alloc(const ecl_sum_type * ecl_sum, bool ad
     if (add_keywords) {
       const ecl_smspec_type * smspec = ecl_sum_get_smspec(ecl_sum);
       for (int i=0; i < ecl_smspec_num_nodes(smspec); i++) {
-        const smspec_node_type * node = ecl_smspec_iget_node( smspec , i );
+        const smspec_node_type * node = ecl_smspec_iget_node_w_node_index( smspec , i );
         const char * key = smspec_node_get_gen_key1(node);
         /*
           The TIME keyword is special case handled to not be included; that is

--- a/lib/ecl/tests/ecl_smspec.cpp
+++ b/lib/ecl/tests/ecl_smspec.cpp
@@ -30,8 +30,8 @@ void test_sort( ecl_smspec_type * smspec )
   test_assert_int_equal( num_nodes, ecl_smspec_num_nodes( smspec ));
 
   for (int i=1; i < ecl_smspec_num_nodes( smspec ); i++) {
-    const smspec_node_type * node1 = ecl_smspec_iget_node( smspec, i - 1 );
-    const smspec_node_type * node2 = ecl_smspec_iget_node( smspec, i );
+    const smspec_node_type * node1 = ecl_smspec_iget_node_w_node_index( smspec, i - 1 );
+    const smspec_node_type * node2 = ecl_smspec_iget_node_w_node_index( smspec, i );
     test_assert_true( smspec_node_cmp( node1 , node2 ) <= 0 );
 
     test_assert_int_equal( smspec_node_get_params_index( node1 ) , i - 1 );
@@ -43,7 +43,7 @@ void test_copy(const ecl_smspec_type * smspec1) {
   ecl_sum_type * ecl_sum2 = ecl_sum_alloc_writer("CASE", false, true, ":", 0, true, 100, 100, 100);
   const ecl_smspec_type * smspec2 = ecl_sum_get_smspec(ecl_sum2);
   for (int i=0; i < ecl_smspec_num_nodes(smspec1); i++) {
-    const smspec_node_type * node = ecl_smspec_iget_node(smspec1, i);
+    const smspec_node_type * node = ecl_smspec_iget_node_w_node_index(smspec1, i);
     ecl_sum_add_smspec_node(ecl_sum2, node);
   }
   test_assert_true( ecl_smspec_equal(smspec1, smspec2));

--- a/lib/ecl/tests/ecl_sum_alloc_resampled_test.cpp
+++ b/lib/ecl/tests/ecl_sum_alloc_resampled_test.cpp
@@ -41,9 +41,9 @@ void test_correct_time_vector() {
   test_assert_int_equal(  ecl_sum_get_report_time(ecl_sum_resampled, 2)  , util_make_date_utc( 6,1,2010 ));
 
   const ecl_smspec_type * smspec_resampled = ecl_sum_get_smspec(ecl_sum_resampled);
-  const smspec_node_type * node1 = ecl_smspec_iget_node(smspec_resampled, 1);
-  const smspec_node_type * node2 = ecl_smspec_iget_node(smspec_resampled, 2);
-  const smspec_node_type * node3 = ecl_smspec_iget_node(smspec_resampled, 3);
+  const smspec_node_type * node1 = ecl_smspec_iget_node_w_params_index(smspec_resampled, 1);
+  const smspec_node_type * node2 = ecl_smspec_iget_node_w_params_index(smspec_resampled, 2);
+  const smspec_node_type * node3 = ecl_smspec_iget_node_w_params_index(smspec_resampled, 3);
   test_assert_string_equal( "BPR" , smspec_node_get_keyword(node2) );
   test_assert_string_equal( "BARS" , smspec_node_get_unit(node2) );
 

--- a/lib/ecl/tests/ecl_sum_data_intermediate_test.cpp
+++ b/lib/ecl/tests/ecl_sum_data_intermediate_test.cpp
@@ -236,17 +236,22 @@ void verify_CASE4() {
   ecl_sum_type * sum = ecl_sum_fread_alloc_case("CASE4", ":");
 
   int i;
+  double_vector_type * d;
+  d = ecl_sum_alloc_data_vector(sum, 0, false); double_vector_free(d);
+  d = ecl_sum_alloc_data_vector(sum, 1, false); double_vector_free(d);
+  d = ecl_sum_alloc_data_vector(sum, 2, false); double_vector_free(d);
+  d = ecl_sum_alloc_data_vector(sum, 4, false); double_vector_free(d);
 
   //NOTE: param indices 0, 1, 2, 4 are the same as 0, 1, 2, 3 in verify_CASE3
   //      vector nr. 4 (Case4) == vector nr. 3 (Case 3)
-  for (int j=0; j < 3; j++) {
+  /*for (int j=0; j < 3; j++) {
     if (j < 2)
       i = j;
     else
       i = j + 1;
-    printf("**** %s: HERE 0, j = %d\n", __func__, j);
+    printf("**** %s: HERE 0, i+1 = %d\n", __func__, i+1);
     double_vector_type * d = ecl_sum_alloc_data_vector(sum, i+1, false);
-    printf("**** %s: HERE 1, j = %d\n", __func__, j);
+    printf("**** %s: HERE 1, i+1 = %d\n", __func__, i+1);
 
     ieq(d,0,(2 - j)*10  + 100);
     ieq(d,1,(2 - j)*10  + 200);
@@ -266,12 +271,12 @@ void verify_CASE4() {
     ieq(d,7,(2 - j)*1000 + 30000);
     ieq(d,8,(2 - j)*1000 + 40000);
     double_vector_free(d);
-  }
+  }*/
 
-  /*ecl_sum_vector_type * vector = ecl_sum_vector_alloc(sum, true); 
+  ecl_sum_vector_type * vector = ecl_sum_vector_alloc(sum, true); 
   double frame[27]; //3 vectors X 9 data points pr. vector
   ecl_sum_init_double_frame(sum, vector, frame);
-  ecl_sum_vector_free(vector);  */
+  ecl_sum_vector_free(vector);
 
   ecl_sum_free(sum);
 }

--- a/lib/ecl/tests/ecl_sum_data_intermediate_test.cpp
+++ b/lib/ecl/tests/ecl_sum_data_intermediate_test.cpp
@@ -235,7 +235,6 @@ void write_CASE3(bool unified) {
 void verify_CASE4() {
   ecl_sum_type * sum = ecl_sum_fread_alloc_case("CASE4", ":");
 
-  int i;
   double_vector_type * d;
   d = ecl_sum_alloc_data_vector(sum, 0, false); double_vector_free(d);
   d = ecl_sum_alloc_data_vector(sum, 1, false); double_vector_free(d);

--- a/lib/ecl/tests/ecl_sum_data_intermediate_test.cpp
+++ b/lib/ecl/tests/ecl_sum_data_intermediate_test.cpp
@@ -5,7 +5,12 @@
 #include <ert/util/double_vector.h>
 #include <ert/util/vector.h>
 
+#include <ert/ecl/ecl_endian_flip.hpp>
+#include <ert/ecl/ecl_type.hpp>
+#include <ert/ecl/ecl_kw.hpp>
+#include <ert/ecl/ecl_file.hpp>
 #include <ert/ecl/ecl_sum.hpp>
+#include <ert/ecl/ecl_sum_vector.hpp>
 
 
 /*
@@ -190,12 +195,16 @@ void verify_CASE3() {
     double_vector_free(d);
   }
 
+  ecl_sum_vector_type * vector = ecl_sum_vector_alloc(sum, true); 
+  double frame[27]; //3 vectors X 9 data points pr. vector
+  ecl_sum_init_double_frame(sum, vector, frame);
+  ecl_sum_vector_free(vector);
+
   ecl_sum_free(sum);
 }
 
 
 void write_CASE3(bool unified) {
-  test_work_area_type * work_area = test_work_area_alloc("SMSPEC");
   write_CASE2(unified);
   {
     time_t start_time = util_make_date_utc( 1,1,2010 );
@@ -221,12 +230,106 @@ void write_CASE3(bool unified) {
     ecl_sum_free(ecl_sum);
     verify_CASE3();
   }
-  test_work_area_free(work_area);
+}
+
+void verify_CASE4() {
+  ecl_sum_type * sum = ecl_sum_fread_alloc_case("CASE4", ":");
+
+  int i;
+
+  //NOTE: param indices 0, 1, 2, 4 are the same as 0, 1, 2, 3 in verify_CASE3
+  //      vector nr. 4 (Case4) == vector nr. 3 (Case 3)
+  for (int j=0; j < 3; j++) {
+    if (j < 2)
+      i = j;
+    else
+      i = j + 1;
+    double_vector_type * d = ecl_sum_alloc_data_vector(sum, i+1, false);
+
+    ieq(d,0,(2 - j)*10  + 100);
+    ieq(d,1,(2 - j)*10  + 200);
+    ieq(d,2,(2 - j)*10  + 300);
+
+    if (i == 0) {
+      const smspec_node_type * node = ecl_smspec_iget_node(ecl_sum_get_smspec(sum), i);
+      double default_value = smspec_node_get_default(node);
+      ieq(d,3,default_value);
+      ieq(d,4,default_value);
+    } else {
+      ieq(d,3,(2 - j)*100 + 1000);
+      ieq(d,4,(2 - j)*100 + 2000);
+    }
+    ieq(d,5,(2 - j)*1000 + 10000);
+    ieq(d,6,(2 - j)*1000 + 20000);
+    ieq(d,7,(2 - j)*1000 + 30000);
+    ieq(d,8,(2 - j)*1000 + 40000);
+    double_vector_free(d);
+  }
+
+  ecl_sum_vector_type * vector = ecl_sum_vector_alloc(sum, true); 
+  double frame[36]; //3 vectors X 9 data points pr. vector
+  ecl_sum_init_double_frame(sum, vector, frame);
+  ecl_sum_vector_free(vector);  
+
+  ecl_sum_free(sum);
 }
 
 
+void write_CASE4(bool unified) {
+  test_work_area_type * work_area = test_work_area_alloc("CASE4");
+  write_CASE3(unified);
+  {
+    ecl_file_type * sum_file    = ecl_file_open("CASE3.UNSMRY", 0);
+    ecl_file_type * smspec_file = ecl_file_open("CASE3.SMSPEC", 0);
+
+    ecl_kw_type * keywords = ecl_file_iget_named_kw(smspec_file, "KEYWORDS", 0);
+    ecl_kw_resize(keywords, 5);
+    ecl_kw_iset_char_ptr(keywords, 3, "HELLO");
+    ecl_kw_iset_char_ptr(keywords, 4, "BPR");
+
+    ecl_kw_type * nums = ecl_file_iget_named_kw(smspec_file, "NUMS", 0);
+    ecl_kw_resize(nums, 5);
+    unsigned int * nums_ptr = (unsigned int *)ecl_kw_get_int_ptr(nums);
+    nums_ptr[3] = 5;
+    nums_ptr[4] = 1;
+
+    ecl_kw_type * wgnames = ecl_file_iget_named_kw(smspec_file, "WGNAMES", 0);
+    ecl_kw_resize(wgnames, 5);
+    ecl_kw_iset_char_ptr(wgnames, 4, ":+:+:+:+");
+
+    ecl_kw_type * units = ecl_file_iget_named_kw(smspec_file, "UNITS", 0);
+    ecl_kw_resize(units, 5);
+    ecl_kw_iset_char_ptr(units, 4, "BARS");
+   
+    int num_params = ecl_file_get_num_named_kw(sum_file, "PARAMS");
+    for (int i = 0; i < num_params; i++) {
+      ecl_kw_type * params_kw = ecl_file_iget_named_kw(sum_file, "PARAMS", i);
+      ecl_kw_resize(params_kw, 5);
+      float * ptr = (float*)ecl_kw_get_void_ptr(params_kw);
+      ptr[4] = ptr[3];
+      ptr[3] = -1;
+    }
+  
+    fortio_type * f;
+    const char * filename_sum = "CASE4.UNSMRY";
+    f = fortio_open_writer( filename_sum, false, ECL_ENDIAN_FLIP );
+    ecl_file_fwrite_fortio(sum_file, f, 0);
+    fortio_fclose( f );
+
+    const char * filename_smspec = "CASE4.SMSPEC";
+    f = fortio_open_writer( filename_smspec, false, ECL_ENDIAN_FLIP );
+    ecl_file_fwrite_fortio(smspec_file, f, 0);
+    fortio_fclose( f );
+
+    ecl_file_close(smspec_file);
+    ecl_file_close(sum_file);
+    verify_CASE4();
+  }
+  test_work_area_free(work_area);
+}
+
 int main() {
-  write_CASE3(true);
-  write_CASE3(false);
+  write_CASE4(true);
+  write_CASE4(false);
   return 0;
 }

--- a/lib/ecl/tests/ecl_sum_data_intermediate_test.cpp
+++ b/lib/ecl/tests/ecl_sum_data_intermediate_test.cpp
@@ -180,7 +180,7 @@ void verify_CASE3() {
     ieq(d,2,(2 - i)*10  + 300);
 
     if (i == 0) {
-      const smspec_node_type * node = ecl_smspec_iget_node(ecl_sum_get_smspec(sum), i);
+      const smspec_node_type * node = ecl_smspec_iget_node_w_params_index(ecl_sum_get_smspec(sum), i);
       double default_value = smspec_node_get_default(node);
       ieq(d,3,default_value);
       ieq(d,4,default_value);

--- a/lib/ecl/tests/ecl_sum_data_intermediate_test.cpp
+++ b/lib/ecl/tests/ecl_sum_data_intermediate_test.cpp
@@ -244,7 +244,9 @@ void verify_CASE4() {
       i = j;
     else
       i = j + 1;
+    printf("**** %s: HERE 0, j = %d\n", __func__, j);
     double_vector_type * d = ecl_sum_alloc_data_vector(sum, i+1, false);
+    printf("**** %s: HERE 1, j = %d\n", __func__, j);
 
     ieq(d,0,(2 - j)*10  + 100);
     ieq(d,1,(2 - j)*10  + 200);
@@ -266,10 +268,10 @@ void verify_CASE4() {
     double_vector_free(d);
   }
 
-  ecl_sum_vector_type * vector = ecl_sum_vector_alloc(sum, true); 
-  double frame[36]; //3 vectors X 9 data points pr. vector
+  /*ecl_sum_vector_type * vector = ecl_sum_vector_alloc(sum, true); 
+  double frame[27]; //3 vectors X 9 data points pr. vector
   ecl_sum_init_double_frame(sum, vector, frame);
-  ecl_sum_vector_free(vector);  
+  ecl_sum_vector_free(vector);  */
 
   ecl_sum_free(sum);
 }
@@ -284,14 +286,14 @@ void write_CASE4(bool unified) {
 
     ecl_kw_type * keywords = ecl_file_iget_named_kw(smspec_file, "KEYWORDS", 0);
     ecl_kw_resize(keywords, 5);
-    ecl_kw_iset_char_ptr(keywords, 3, "HELLO");
+    ecl_kw_iset_char_ptr(keywords, 3, "WTPRWI1");
     ecl_kw_iset_char_ptr(keywords, 4, "BPR");
 
     ecl_kw_type * nums = ecl_file_iget_named_kw(smspec_file, "NUMS", 0);
     ecl_kw_resize(nums, 5);
     unsigned int * nums_ptr = (unsigned int *)ecl_kw_get_int_ptr(nums);
     nums_ptr[3] = 5;
-    nums_ptr[4] = 1;
+    nums_ptr[4] = 8;  //a different 
 
     ecl_kw_type * wgnames = ecl_file_iget_named_kw(smspec_file, "WGNAMES", 0);
     ecl_kw_resize(wgnames, 5);

--- a/lib/ecl/tests/ecl_sum_data_intermediate_test.cpp
+++ b/lib/ecl/tests/ecl_sum_data_intermediate_test.cpp
@@ -240,42 +240,17 @@ void verify_CASE4() {
   d = ecl_sum_alloc_data_vector(sum, 0, false); double_vector_free(d);
   d = ecl_sum_alloc_data_vector(sum, 1, false); double_vector_free(d);
   d = ecl_sum_alloc_data_vector(sum, 2, false); double_vector_free(d);
-  d = ecl_sum_alloc_data_vector(sum, 4, false); double_vector_free(d);
-
-  //NOTE: param indices 0, 1, 2, 4 are the same as 0, 1, 2, 3 in verify_CASE3
-  //      vector nr. 4 (Case4) == vector nr. 3 (Case 3)
-  /*for (int j=0; j < 3; j++) {
-    if (j < 2)
-      i = j;
-    else
-      i = j + 1;
-    printf("**** %s: HERE 0, i+1 = %d\n", __func__, i+1);
-    double_vector_type * d = ecl_sum_alloc_data_vector(sum, i+1, false);
-    printf("**** %s: HERE 1, i+1 = %d\n", __func__, i+1);
-
-    ieq(d,0,(2 - j)*10  + 100);
-    ieq(d,1,(2 - j)*10  + 200);
-    ieq(d,2,(2 - j)*10  + 300);
-
-    if (i == 0) {
-      const smspec_node_type * node = ecl_smspec_iget_node(ecl_sum_get_smspec(sum), i);
-      double default_value = smspec_node_get_default(node);
-      ieq(d,3,default_value);
-      ieq(d,4,default_value);
-    } else {
-      ieq(d,3,(2 - j)*100 + 1000);
-      ieq(d,4,(2 - j)*100 + 2000);
-    }
-    ieq(d,5,(2 - j)*1000 + 10000);
-    ieq(d,6,(2 - j)*1000 + 20000);
-    ieq(d,7,(2 - j)*1000 + 30000);
-    ieq(d,8,(2 - j)*1000 + 40000);
-    double_vector_free(d);
-  }*/
+  d = ecl_sum_alloc_data_vector(sum, 4, false);
+  ieq(d, 0, -99);
+  ieq(d, 4, -99);
+  ieq(d, 5, 10000);
+  ieq(d, 8, 40000);
+  double_vector_free(d);
 
   ecl_sum_vector_type * vector = ecl_sum_vector_alloc(sum, true); 
   double frame[27]; //3 vectors X 9 data points pr. vector
   ecl_sum_init_double_frame(sum, vector, frame);
+  test_assert_double_equal(frame[26], 40000);
   ecl_sum_vector_free(vector);
 
   ecl_sum_free(sum);

--- a/lib/include/ert/ecl/ecl_smspec.hpp
+++ b/lib/include/ert/ecl/ecl_smspec.hpp
@@ -145,7 +145,7 @@ typedef struct ecl_smspec_struct ecl_smspec_type;
   int                        ecl_smspec_num_nodes( const ecl_smspec_type * smspec);
   const   smspec_node_type * ecl_smspec_iget_node_w_node_index( const ecl_smspec_type * smspec , int node_index );
   const   smspec_node_type * ecl_smspec_iget_node_w_params_index( const ecl_smspec_type * smspec , int params_index );
-
+  const smspec_node_type   * ecl_smspec_iget_node(const ecl_smspec_type * smspec, int index);
 
   char                     * ecl_smspec_alloc_well_key( const ecl_smspec_type * smspec , const char * keyword , const char * wgname);
   bool                       ecl_smspec_equal( const ecl_smspec_type * self , const ecl_smspec_type * other);

--- a/lib/include/ert/ecl/ecl_smspec.hpp
+++ b/lib/include/ert/ecl/ecl_smspec.hpp
@@ -152,6 +152,9 @@ typedef struct ecl_smspec_struct ecl_smspec_type;
   void                       ecl_smspec_sort( ecl_smspec_type * smspec );
   ert_ecl_unit_enum          ecl_smspec_get_unit_system(const ecl_smspec_type * smspec);
 
+
+  int ecl_smspec_get_node_index(const ecl_smspec_type * smspec, int params_index);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/include/ert/ecl/ecl_smspec.hpp
+++ b/lib/include/ert/ecl/ecl_smspec.hpp
@@ -143,7 +143,8 @@ typedef struct ecl_smspec_struct ecl_smspec_type;
   const int                * ecl_smspec_get_grid_dims( const ecl_smspec_type * smspec );
   int                        ecl_smspec_get_params_size( const ecl_smspec_type * smspec );
   int                        ecl_smspec_num_nodes( const ecl_smspec_type * smspec);
-  const   smspec_node_type * ecl_smspec_iget_node( const ecl_smspec_type * smspec , int index );
+  const   smspec_node_type * ecl_smspec_iget_node_w_node_index( const ecl_smspec_type * smspec , int node_index );
+  const   smspec_node_type * ecl_smspec_iget_node_w_params_index( const ecl_smspec_type * smspec , int params_index );
 
 
   char                     * ecl_smspec_alloc_well_key( const ecl_smspec_type * smspec , const char * keyword , const char * wgname);
@@ -152,8 +153,6 @@ typedef struct ecl_smspec_struct ecl_smspec_type;
   void                       ecl_smspec_sort( ecl_smspec_type * smspec );
   ert_ecl_unit_enum          ecl_smspec_get_unit_system(const ecl_smspec_type * smspec);
 
-
-  int ecl_smspec_get_node_index(const ecl_smspec_type * smspec, int params_index);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Please note:  PR # NR. 500!!!!

**Task**
Call to python EclSum.pandas_frame() may cause a util_abort.


**Approach**
This is use to erronous calls to ecl_smspec_iget_node using the params_index instead of the node_index.
An inverse index_map in ecl_smspec is created, mapping the params index to a node index. 

**Pre un-WIP checklist**
- [x] Statoil tests pass locally

Please note 2:: Links to PR # NR 400 in libres:

Statoil/libres#400

Tilfeldig - neppe!
