### PR TITLE
Smspec shall use std map and std vector

### DIFF
--- a/lib/ecl/ecl_sum_file_data.cpp
+++ b/lib/ecl/ecl_sum_file_data.cpp
@@ -471,7 +471,8 @@ void ecl_sum_file_data::fwrite_report( int report_step , fortio_type * fortio) c
     auto range = this->report_range( report_step );
     for (int index = range.first; index <= range.second; index++) {
       const ecl_sum_tstep_type * tstep = iget_ministep( index );
-      ecl_sum_tstep_fwrite( tstep , ecl_smspec_get_index_map( ecl_smspec ) , fortio );
+      //ecl_sum_tstep_fwrite( tstep , ecl_smspec_get_index_map( ecl_smspec ) , fortio );
+      ecl_sum_tstep_fwrite( tstep , ecl_smspec_get_index_map(ecl_smspec) , ecl_smspec_num_nodes(ecl_smspec), fortio );
     }
   }
 }

--- a/lib/ecl/ecl_sum_tstep.cpp
+++ b/lib/ecl/ecl_sum_tstep.cpp
@@ -269,7 +269,7 @@ int ecl_sum_tstep_get_ministep(const ecl_sum_tstep_type * ministep) {
 
 /*****************************************************************/
 
-void ecl_sum_tstep_fwrite( const ecl_sum_tstep_type * ministep , const int_vector_type * index_map , fortio_type * fortio) {
+void ecl_sum_tstep_fwrite( const ecl_sum_tstep_type * ministep , const int * index_map , int index_map_size, fortio_type * fortio) {
   {
     ecl_kw_type * ministep_kw = ecl_kw_alloc( MINISTEP_KW , 1 , ECL_INT );
     ecl_kw_iset_int( ministep_kw , 0 , ministep->ministep );
@@ -278,16 +278,15 @@ void ecl_sum_tstep_fwrite( const ecl_sum_tstep_type * ministep , const int_vecto
   }
 
   {
-    int compact_size = int_vector_size( index_map );
+    int compact_size = index_map_size;
     ecl_kw_type * params_kw = ecl_kw_alloc( PARAMS_KW , compact_size , ECL_FLOAT );
 
-    const int * index = int_vector_get_ptr( index_map );
     float * data      = (float*)ecl_kw_get_ptr( params_kw );
 
     {
       int i;
       for (i=0; i < compact_size; i++)
-        data[i] = ministep->data[ index[i] ];
+        data[i] = ministep->data[ index_map[i] ];
     }
     ecl_kw_fwrite( params_kw , fortio );
     ecl_kw_free( params_kw );

--- a/lib/ecl/smspec_node.cpp
+++ b/lib/ecl/smspec_node.cpp
@@ -82,6 +82,15 @@ bool smspec_node_equal( const smspec_node_type * node1,  const smspec_node_type 
   return smspec_node_cmp( node1 , node2 ) == 0;
 }
 
+
+bool smspec_node_gt( const smspec_node_type * node1,  const smspec_node_type * node2) {
+  return smspec_node_cmp( node1 , node2 ) > 0;
+}
+
+bool smspec_node_lt( const smspec_node_type * node1,  const smspec_node_type * node2) {
+  return smspec_node_cmp( node1 , node2 ) < 0;
+}
+
 static bool smspec_node_need_wgname(ecl_smspec_var_type var_type) {
   if (var_type == ECL_SMSPEC_COMPLETION_VAR ||
       var_type == ECL_SMSPEC_GROUP_VAR      ||

--- a/lib/ecl/smspec_node.cpp
+++ b/lib/ecl/smspec_node.cpp
@@ -506,7 +506,7 @@ static void smspec_node_set_gen_keys( smspec_node_type * smspec_node , const cha
     break;
   case(ECL_SMSPEC_FIELD_VAR):
     // KEYWORD
-    smspec_node->gen_key1 = util_alloc_string_copy( smspec_node->keyword.c_str() );
+    smspec_node->gen_key1 = smspec_node->keyword;
     break;
   case(ECL_SMSPEC_GROUP_VAR):
     // KEYWORD:WGNAME

--- a/lib/include/ert/ecl/ecl_smspec.hpp
+++ b/lib/include/ert/ecl/ecl_smspec.hpp
@@ -47,7 +47,7 @@ typedef struct ecl_smspec_struct ecl_smspec_type;
 */
 
   int * ecl_smspec_alloc_mapping( const ecl_smspec_type * self, const ecl_smspec_type * other);
-  const int_vector_type * ecl_smspec_get_index_map( const ecl_smspec_type * smspec );
+  const int         * ecl_smspec_get_index_map( const ecl_smspec_type * smspec );
   void                ecl_smspec_index_node( ecl_smspec_type * ecl_smspec , smspec_node_type * smspec_node);
   void                ecl_smspec_insert_node(ecl_smspec_type * ecl_smspec, smspec_node_type * smspec_node);
   void                ecl_smspec_add_node( ecl_smspec_type * ecl_smspec , smspec_node_type * smspec_node );

--- a/lib/include/ert/ecl/ecl_sum_tstep.hpp
+++ b/lib/include/ert/ecl/ecl_sum_tstep.hpp
@@ -50,7 +50,7 @@ typedef struct ecl_sum_tstep_struct ecl_sum_tstep_type;
   int  ecl_sum_tstep_get_report(const ecl_sum_tstep_type * ministep);
   int  ecl_sum_tstep_get_ministep(const ecl_sum_tstep_type * ministep);
 
-  void ecl_sum_tstep_fwrite( const ecl_sum_tstep_type * ministep , const int_vector_type * index_map , fortio_type * fortio);
+  void ecl_sum_tstep_fwrite( const ecl_sum_tstep_type * ministep , const int * index_map , int index_map_size, fortio_type * fortio);
   void ecl_sum_tstep_iset( ecl_sum_tstep_type * tstep , int index , float value);
 
   /// scales with value; equivalent to iset( iget() * scalar)

--- a/lib/include/ert/ecl/smspec_node.hpp
+++ b/lib/include/ert/ecl/smspec_node.hpp
@@ -137,6 +137,8 @@ typedef enum {ECL_SMSPEC_INVALID_VAR            =  0 ,
   int smspec_node_get_R1( const smspec_node_type * smpsec_node );
   int smspec_node_get_R2( const smspec_node_type * smpsec_node );
 
+  bool smspec_node_lt( const smspec_node_type * node1,  const smspec_node_type * node2);
+  bool smspec_node_gt( const smspec_node_type * node1,  const smspec_node_type * node2);
   int smspec_node_cmp( const smspec_node_type * node1, const smspec_node_type * node2);
   int smspec_node_cmp__( const void * node1, const void * node2);
   bool smspec_node_identify_total(const char * keyword, ecl_smspec_var_type var_type);

--- a/lib/util/path.cpp
+++ b/lib/util/path.cpp
@@ -15,6 +15,7 @@
   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
   for more details.
 */
+#include <stdlib.h>
 
 #include <string>
 
@@ -55,10 +56,16 @@ namespace ecl {
 
         {
           const char * c_str = fname.c_str();
+          const char * return_raw;
           if (end_pos == std::string::npos || end_pos < offset)
-            return util_alloc_string_copy( &c_str[offset] );
+            return_raw = util_alloc_string_copy( &c_str[offset] );
+          else
+            return_raw = util_alloc_substring_copy(c_str, offset, end_pos - offset);
+          std::string return_value = return_raw;
+          free( (void*)return_raw );
+          return return_value;
 
-          return util_alloc_substring_copy(c_str, offset, end_pos - offset);
+
         }
       }
 
@@ -71,7 +78,11 @@ namespace ecl {
 
         if (last_slash == std::string::npos || end_pos > last_slash) {
           const char * c_str = fname.c_str();
-          return util_alloc_substring_copy( c_str, end_pos + 1, fname.size() - end_pos - 1);
+
+          const char * return_raw = util_alloc_substring_copy( c_str, end_pos + 1, fname.size() - end_pos - 1);
+          std::string return_value = return_raw;
+          free( (void*)return_raw );
+          return return_value;
         }
 
         return "";


### PR DESCRIPTION
**Task**
This converts some of the hash and vector parameters of ecl_smspec_type into std::map and std::vector.



**Pre un-WIP checklist**
- [x] Statoil tests pass locally
