### PR TITLE
WIP: vector_resize takes extra arg default_value.

### DIFF
--- a/lib/util/tests/ert_util_type_vector_test.cpp
+++ b/lib/util/tests/ert_util_type_vector_test.cpp
@@ -263,8 +263,8 @@ void test_resize() {
   int i;
   int def = 77;
   int_vector_type * vec = int_vector_alloc(0,def);
-  int_vector_resize( vec , 10 );
-  test_assert_int_equal( int_vector_size( vec ) , 10 );
+  int_vector_resize( vec , 10 , int_vector_get_default(vec) );
+  test_assert_int_equal( int_vector_size( vec ) , 10  );
   for (i=0; i < 10; i++)
     test_assert_int_equal( int_vector_iget( vec , i ) , def );
 
@@ -272,12 +272,12 @@ void test_resize() {
   for (i=5; i < 10; i++)
     test_assert_int_equal( int_vector_iget( vec , i ) , 5 );
 
-  int_vector_resize( vec , 5 );
+  int_vector_resize( vec , 5 , int_vector_get_default(vec));
   test_assert_int_equal( int_vector_size( vec ) , 5 );
   for (i=0; i < 5; i++)
     test_assert_int_equal( int_vector_iget( vec , i ) , def );
 
-  int_vector_resize( vec , 10 );
+  int_vector_resize( vec , 10, int_vector_get_default(vec) );
   test_assert_int_equal( int_vector_size( vec ) , 10 );
   for (i=0; i < 10; i++)
     test_assert_int_equal( int_vector_iget( vec , i ) , def );
@@ -373,11 +373,21 @@ void test_equal_index() {
   int_vector_free(v3);
 }
 
-
+void test_misc() {
+  int_vector_type * v = int_vector_alloc(5, 123);
+  test_assert_int_equal( int_vector_iget(v, 2), 123 );
+  int_vector_resize(v, 20, 0);
+  test_assert_int_equal( int_vector_iget(v, 4), 123);
+  test_assert_int_equal( int_vector_iget(v, 9), 0 );
+  test_assert_int_equal( int_vector_iget(v, 19), 0);
+  //int_vector_iset(v, 10, 66);
+  //test_assert_int_equal( int_vector_iget(v, 10), 66);
+}
 
 int main(int argc , char ** argv) {
+  test_misc();
 
-  int_vector_type * int_vector = int_vector_alloc( 0 , 99);
+  /*int_vector_type * int_vector = int_vector_alloc( 0 , 99);
 
   test_abort();
   test_assert_int_equal( -1 , int_vector_index(int_vector , 100));
@@ -466,5 +476,5 @@ int main(int argc , char ** argv) {
   test_empty();
   test_insert_double();
   test_equal_index();
-  exit(0);
+  exit(0);*/
 }

--- a/lib/util/tests/ert_util_type_vector_test.cpp
+++ b/lib/util/tests/ert_util_type_vector_test.cpp
@@ -263,7 +263,7 @@ void test_resize() {
   int i;
   int def = 77;
   int_vector_type * vec = int_vector_alloc(0,def);
-  int_vector_resize( vec , 10 , int_vector_get_default(vec) );
+  int_vector_resize( vec , 10 , def);
   test_assert_int_equal( int_vector_size( vec ) , 10  );
   for (i=0; i < 10; i++)
     test_assert_int_equal( int_vector_iget( vec , i ) , def );
@@ -272,12 +272,12 @@ void test_resize() {
   for (i=5; i < 10; i++)
     test_assert_int_equal( int_vector_iget( vec , i ) , 5 );
 
-  int_vector_resize( vec , 5 , int_vector_get_default(vec));
+  int_vector_resize( vec , 5 , def);
   test_assert_int_equal( int_vector_size( vec ) , 5 );
   for (i=0; i < 5; i++)
     test_assert_int_equal( int_vector_iget( vec , i ) , def );
 
-  int_vector_resize( vec , 10, int_vector_get_default(vec) );
+  int_vector_resize( vec , 10, def );
   test_assert_int_equal( int_vector_size( vec ) , 10 );
   for (i=0; i < 10; i++)
     test_assert_int_equal( int_vector_iget( vec , i ) , def );
@@ -380,14 +380,12 @@ void test_misc() {
   test_assert_int_equal( int_vector_iget(v, 4), 123);
   test_assert_int_equal( int_vector_iget(v, 9), 0 );
   test_assert_int_equal( int_vector_iget(v, 19), 0);
-  //int_vector_iset(v, 10, 66);
-  //test_assert_int_equal( int_vector_iget(v, 10), 66);
 }
 
 int main(int argc , char ** argv) {
   test_misc();
 
-  /*int_vector_type * int_vector = int_vector_alloc( 0 , 99);
+  int_vector_type * int_vector = int_vector_alloc( 0 , 99);
 
   test_abort();
   test_assert_int_equal( -1 , int_vector_index(int_vector , 100));
@@ -476,5 +474,5 @@ int main(int argc , char ** argv) {
   test_empty();
   test_insert_double();
   test_equal_index();
-  exit(0);*/
+  exit(0);
 }

--- a/lib/util/vector_template.cpp
+++ b/lib/util/vector_template.cpp
@@ -137,14 +137,14 @@ UTIL_SAFE_CAST_FUNCTION(@TYPE@_vector , TYPE_VECTOR_ID);
 UTIL_IS_INSTANCE_FUNCTION(@TYPE@_vector , TYPE_VECTOR_ID);
 
 
-static void @TYPE@_vector_realloc_data__(@TYPE@_vector_type * vector , int new_alloc_size) {
+static void @TYPE@_vector_realloc_data__(@TYPE@_vector_type * vector , int new_alloc_size, @TYPE@ default_value) {
   if (new_alloc_size != vector->alloc_size) {
     if (vector->data_owner) {
       if (new_alloc_size > 0) {
         int i;
         vector->data = (@TYPE@*)util_realloc(vector->data , new_alloc_size * sizeof * vector->data );
         for (i=vector->alloc_size;  i < new_alloc_size; i++)
-          vector->data[i] = vector->default_value;
+          vector->data[i] = default_value;
       } else {
         if (vector->alloc_size > 0) {
           free(vector->data);
@@ -163,7 +163,7 @@ static void @TYPE@_vector_memmove(@TYPE@_vector_type * vector , int offset , int
     util_abort("%s: offset:%d  left_shift:%d - invalid \n",__func__ , offset , -shift);
 
   if ((shift + vector->size > vector->alloc_size))
-    @TYPE@_vector_realloc_data__( vector , util_int_min( 2*vector->alloc_size , shift + vector->size ));
+    @TYPE@_vector_realloc_data__( vector , util_int_min( 2*vector->alloc_size , shift + vector->size ), vector->default_value);
 
   {
     size_t move_size   = (vector->size - offset) * sizeof(@TYPE@);
@@ -253,11 +253,13 @@ static @TYPE@_vector_type * @TYPE@_vector_alloc__(int init_size , @TYPE@ default
    new_size > current_size: The vector will grow by adding default elements at the end.
 */
 
-void @TYPE@_vector_resize( @TYPE@_vector_type * vector , int new_size ) {
-  if (new_size <= vector->size)
-    vector->size = new_size;
-  else
-    @TYPE@_vector_iset( vector , new_size - 1 , vector->default_value);
+void @TYPE@_vector_resize( @TYPE@_vector_type * vector , int new_size, @TYPE@ default_value ) {
+  if (new_size > vector->size) {
+    for (int i = vector->size; i < vector->alloc_size; i++)
+      vector->data[i] = default_value;
+    @TYPE@_vector_realloc_data__( vector, 2 * new_size, default_value);
+  }
+  vector->size = new_size;
 }
 
 
@@ -397,7 +399,7 @@ void @TYPE@_vector_memcpy( @TYPE@_vector_type * target, const @TYPE@_vector_type
 
 @TYPE@_vector_type * @TYPE@_vector_alloc_copy( const @TYPE@_vector_type * src) {
   @TYPE@_vector_type * copy = @TYPE@_vector_alloc( src->size , src->default_value );
-  @TYPE@_vector_realloc_data__( copy , src->alloc_size );
+  @TYPE@_vector_realloc_data__( copy , src->alloc_size, src->default_value );
   copy->size = src->size;
   memcpy(copy->data , src->data , src->alloc_size * sizeof * src->data );
   return copy;
@@ -616,7 +618,7 @@ void @TYPE@_vector_iset(@TYPE@_vector_type * vector , int index , @TYPE@ value) 
       util_abort("%s: Sorry - can NOT set negative indices. called with index:%d \n",__func__ , index);
     {
       if (vector->alloc_size <= index)
-        @TYPE@_vector_realloc_data__(vector , 2 * (index + 1));  /* Must have ( + 1) here to ensure we are not doing 2*0 */
+        @TYPE@_vector_realloc_data__(vector , 2 * (index + 1), vector->default_value);  /* Must have ( + 1) here to ensure we are not doing 2*0 */
       vector->data[index] = value;
       if (index >= vector->size) {
         int i;
@@ -746,7 +748,7 @@ void @TYPE@_vector_free_container(@TYPE@_vector_type * vector) {
 
 void @TYPE@_vector_free_data(@TYPE@_vector_type * vector) {
   @TYPE@_vector_reset(vector);
-  @TYPE@_vector_realloc_data__(vector , 0);
+  @TYPE@_vector_realloc_data__(vector , 0, vector->default_value);
 }
 
 
@@ -848,7 +850,7 @@ void @TYPE@_vector_set_many(@TYPE@_vector_type * vector , int index , const @TYP
   {
     int min_size = index + length;
     if (min_size > vector->alloc_size)
-      @TYPE@_vector_realloc_data__(vector , 2 * min_size);
+      @TYPE@_vector_realloc_data__(vector , 2 * min_size, vector->default_value);
     memcpy( &vector->data[index] , data , length * sizeof * data);
     if (min_size > vector->size)
       vector->size = min_size;
@@ -931,7 +933,7 @@ void @TYPE@_vector_append_vector(@TYPE@_vector_type * vector , const @TYPE@_vect
 */
 
 void @TYPE@_vector_shrink(@TYPE@_vector_type * vector) {
-  @TYPE@_vector_realloc_data__(vector , vector->size);
+  @TYPE@_vector_realloc_data__(vector , vector->size, vector->default_value);
 }
 
 
@@ -1420,7 +1422,7 @@ void @TYPE@_vector_fprintf(const @TYPE@_vector_type * vector , FILE * stream , c
   vector_resize based on the input size.
 */
 void @TYPE@_vector_fread_data( @TYPE@_vector_type * vector , int size, FILE * stream) {
-  @TYPE@_vector_realloc_data__( vector , size );
+  @TYPE@_vector_realloc_data__( vector , size, vector->default_value );
   util_fread( vector->data , sizeof * vector->data , size , stream , __func__);
   vector->size = size;
 }

--- a/lib/vector_template.h.in
+++ b/lib/vector_template.h.in
@@ -61,7 +61,7 @@ typedef @TYPE@ (@TYPE@_ftype) (@TYPE@);
   int                  @TYPE@_vector_get_min_index(const @TYPE@_vector_type * vector, bool reverse);
   int                  @TYPE@_vector_get_max_index(const @TYPE@_vector_type * vector, bool reverse);
   @TYPE@               @TYPE@_vector_iadd( @TYPE@_vector_type * vector , int index , @TYPE@ delta);
-  void                 @TYPE@_vector_resize( @TYPE@_vector_type * vector , int new_size );
+  void                 @TYPE@_vector_resize( @TYPE@_vector_type * vector , int new_size , @TYPE@ default_value );
   void                 @TYPE@_vector_iset(@TYPE@_vector_type *       , int , @TYPE@);
   void                 @TYPE@_vector_iset_block(@TYPE@_vector_type * vector , int index , int block_size , @TYPE@ value);
   void                 @TYPE@_vector_idel_block( @TYPE@_vector_type * vector , int index , int block_size);


### PR DESCRIPTION
**Approach**
As a part of converting libecl/libres/ert code to c++, the xxx_vector_type objects are under removal, and will be replaced by std::vector. To facilitate the removal, the API of xxx_vector_type is made similar to std::vector. One obstacle is the use of the default_value parameter. This is memorized and used for resize operations, whereas for std::vector, this parameter has to be specified for each resize operation (or 0 is used). 

This PR disregards the setting of default_value for the function xxx_vector_resize.

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally

Statoil/libres#414