### PR TITLE
WIP: xxx vector type resize cases

### DIFF
--- a/lib/ecl/ecl_grid.cpp
+++ b/lib/ecl/ecl_grid.cpp
@@ -2104,6 +2104,8 @@ static void ecl_grid_init_mapaxes( ecl_grid_type * ecl_grid , bool apply_mapaxes
 
 static void ecl_grid_add_lgr( ecl_grid_type * main_grid , ecl_grid_type * lgr_grid) {
   vector_append_owned_ref( main_grid->LGR_list , lgr_grid , ecl_grid_free__);
+  if ( lgr_grid->lgr_nr >= int_vector_size(main_grid->lgr_index_map) )
+    int_vector_resize( main_grid->lgr_index_map, lgr_grid->lgr_nr+1 , 0);
   int_vector_iset(main_grid->lgr_index_map, lgr_grid->lgr_nr, vector_get_size(main_grid->LGR_list)-1);
   hash_insert_ref( main_grid->LGR_hash , lgr_grid->name , lgr_grid);
 }

--- a/lib/ecl/fault_block_layer.cpp
+++ b/lib/ecl/fault_block_layer.cpp
@@ -67,6 +67,8 @@ fault_block_type * fault_block_layer_add_block( fault_block_layer_type * layer ,
     fault_block_type * block = fault_block_alloc( layer , block_id );
     int storage_index = vector_get_size( layer->blocks );
 
+    if (block_id >= int_vector_size(layer->block_map))
+      int_vector_resize(layer->block_map, block_id+1, -1);
     int_vector_iset( layer->block_map , block_id , storage_index );
     vector_append_owned_ref( layer->blocks , block , fault_block_free__ );
 

--- a/lib/ecl/nnc_info.cpp
+++ b/lib/ecl/nnc_info.cpp
@@ -127,6 +127,8 @@ nnc_vector_type * nnc_info_get_self_vector( const nnc_info_type * nnc_info ) {
 
 static void nnc_info_add_vector( nnc_info_type * nnc_info , nnc_vector_type * nnc_vector) {
   vector_append_owned_ref( nnc_info->lgr_list , nnc_vector , nnc_vector_free__ );
+  if (nnc_vector_get_lgr_nr( nnc_vector ) >= int_vector_size( nnc_info->lgr_index_map ) )
+    int_vector_resize( nnc_info->lgr_index_map , nnc_vector_get_lgr_nr( nnc_vector)+1, -1);
   int_vector_iset( nnc_info->lgr_index_map , nnc_vector_get_lgr_nr( nnc_vector ) , vector_get_size( nnc_info->lgr_list ) - 1 );
 }
 

--- a/lib/ecl/well_branch_collection.cpp
+++ b/lib/ecl/well_branch_collection.cpp
@@ -107,6 +107,8 @@ bool well_branch_collection_add_start_segment( well_branch_collection_type * bra
     else {
       int new_index = vector_get_size( branches->__start_segments );
       vector_append_ref( branches->__start_segments , start_segment);
+      if (branch_id >= int_vector_size(branches->index_map))
+        int_vector_resize(branches->index_map, branch_id+1, -1);
       int_vector_iset( branches->index_map , branch_id , new_index);
     }
 

--- a/lib/ecl/well_rseg_loader.cpp
+++ b/lib/ecl/well_rseg_loader.cpp
@@ -79,6 +79,7 @@ double * well_rseg_loader_load_values(const well_rseg_loader_type * loader, int 
     int_vector_type * index_map = loader->absolute_index_map;
 
     int index = 0;
+    int_vector_resize( index_map, int_vector_size(loader->relative_index_map), 0 );
     for(index = 0; index < int_vector_size(loader->relative_index_map); index++) {
         int relative_index = int_vector_iget(loader->relative_index_map, index);
         int_vector_iset(index_map, index, relative_index + rseg_offset);

--- a/lib/ecl/well_segment_collection.cpp
+++ b/lib/ecl/well_segment_collection.cpp
@@ -70,6 +70,8 @@ void well_segment_collection_add( well_segment_collection_type * segment_collect
   else {
     int new_index = vector_get_size(segment_collection->__segment_storage);
     vector_append_owned_ref( segment_collection->__segment_storage , segment , well_segment_free__);
+    if (segment_id >= int_vector_size(segment_collection->segment_index_map))
+      int_vector_resize(segment_collection->segment_index_map, segment_id+1, -1);
     int_vector_iset( segment_collection->segment_index_map , segment_id , new_index);
   }
 }

--- a/lib/util/tests/ert_util_type_vector_test.cpp
+++ b/lib/util/tests/ert_util_type_vector_test.cpp
@@ -94,10 +94,12 @@ void test_contains() {
   int_vector_type * int_vector = int_vector_alloc( 0 , 100);
 
   test_assert_false( int_vector_contains( int_vector , 100 ));
+  int_vector_resize( int_vector, 1, 100 );
   int_vector_iset( int_vector , 0 , 77 );
   test_assert_false( int_vector_contains( int_vector , 100 ));
   test_assert_true( int_vector_contains( int_vector , 77 ));
 
+  int_vector_resize( int_vector, 11, 100 );
   int_vector_iset( int_vector , 10 , 33 );
   test_assert_true( int_vector_contains( int_vector , 100 ));
   test_assert_true( int_vector_contains( int_vector , 77 ));
@@ -126,6 +128,7 @@ void test_contains_sorted() {
 
 void test_div() {
   int_vector_type * int_vector = int_vector_alloc( 0 , 100);
+  int_vector_resize( int_vector, 11, 100 );
   int_vector_iset( int_vector , 10 , 100 );
   int_vector_div( int_vector , 10 );
   {
@@ -393,8 +396,10 @@ int main(int argc , char ** argv) {
 
   test_assert_true( int_vector_is_instance( int_vector ));
   test_assert_false( double_vector_is_instance( int_vector ));
+  int_vector_resize( int_vector, 3, 99 );
   int_vector_iset( int_vector , 2 , 0);
   int_vector_insert( int_vector , 2 , 77 );
+  int_vector_resize( int_vector, 6, 99 );
   int_vector_iset( int_vector , 5 , -10);
 
   assert_equal( int_vector_iget(int_vector , 0 ) == 99 );

--- a/lib/util/tests/ert_util_type_vector_test.cpp
+++ b/lib/util/tests/ert_util_type_vector_test.cpp
@@ -242,6 +242,8 @@ void test_idel_insert() {
 void test_iset_block() {
   int_vector_type * vec = int_vector_alloc(0,0);
 
+  int_vector_resize( vec, 10, 0 );
+  int_vector_resize( vec, 20, 77 );
   int_vector_iset_block( vec , 10 , 10 , 77 );
   test_assert_int_equal( int_vector_size( vec ) , 20 );
   {
@@ -348,9 +350,9 @@ void test_empty() {
 
 
 void test_equal_index() {
-  int_vector_type * v1 = int_vector_alloc(0,0);
-  int_vector_type * v2 = int_vector_alloc(0,0);
-  int_vector_type * v3 = int_vector_alloc(0,0);
+  int_vector_type * v1 = int_vector_alloc(5,0);
+  int_vector_type * v2 = int_vector_alloc(5,0);
+  int_vector_type * v3 = int_vector_alloc(5,0);
 
   for (int i=0; i < 5; i++) {
     int_vector_iset(v1,i,i);

--- a/lib/util/vector.cpp
+++ b/lib/util/vector.cpp
@@ -589,6 +589,7 @@ int_vector_type * vector_alloc_sort_perm(const vector_type * vector , vector_cmp
   vector_sort_node_type * sort_data = vector_alloc_sort_data( vector , cmp );
   int_vector_type * sort_perm = int_vector_alloc(0,0);
   int i;
+  int_vector_resize( sort_perm, vector->size, 0 );
   for (i = 0; i < vector->size; i++)
     int_vector_iset( sort_perm , i , sort_data[i].index);
 

--- a/lib/util/vector_template.cpp
+++ b/lib/util/vector_template.cpp
@@ -348,7 +348,8 @@ void @TYPE@_vector_memcpy_data_block( @TYPE@_vector_type * target , const @TYPE@
 
 void @TYPE@_vector_memcpy_from_data( @TYPE@_vector_type * target , const @TYPE@ * src , int src_size ) {
   @TYPE@_vector_reset( target );
-  @TYPE@_vector_iset( target , src_size - 1 , 0 );
+  //@TYPE@_vector_iset( target , src_size - 1 , 0 );
+  @TYPE@_vector_resize( target, src_size, 0);
   memcpy( target->data , src , src_size * sizeof * target->data );
 }
 

--- a/lib/util/vector_template.cpp
+++ b/lib/util/vector_template.cpp
@@ -255,9 +255,14 @@ static @TYPE@_vector_type * @TYPE@_vector_alloc__(int init_size , @TYPE@ default
 
 void @TYPE@_vector_resize( @TYPE@_vector_type * vector , int new_size, @TYPE@ default_value ) {
   if (new_size > vector->size) {
-    for (int i = vector->size; i < vector->alloc_size; i++)
-      vector->data[i] = default_value;
-    @TYPE@_vector_realloc_data__( vector, 2 * new_size, default_value);
+    if (new_size > vector->alloc_size) {
+      for (int i = vector->size; i < vector->alloc_size; i++)
+        vector->data[i] = default_value;
+      @TYPE@_vector_realloc_data__( vector, 2 * new_size, default_value);
+    }
+    else
+      for (int i = vector->size; i < new_size; i++)
+        vector->data[i] = default_value;
   }
   vector->size = new_size;
 }
@@ -612,6 +617,8 @@ void @TYPE@_vector_inplace_div( @TYPE@_vector_type * vector , const @TYPE@_vecto
 */
 
 void @TYPE@_vector_iset(@TYPE@_vector_type * vector , int index , @TYPE@ value) {
+  /*if (index >= vector->size)
+    util_abort("*********** %s: index out of range, range = [0, %d>, index = %d\n", __func__, vector->size, index);*/
   @TYPE@_vector_assert_writable( vector );
   {
     if (index < 0)
@@ -731,7 +738,10 @@ void @TYPE@_vector_insert( @TYPE@_vector_type * vector , int index , @TYPE@ valu
 
 
 void @TYPE@_vector_append(@TYPE@_vector_type * vector , @TYPE@ value) {
-  @TYPE@_vector_iset(vector , vector->size , value);
+  //@TYPE@_vector_iset(vector , vector->size , value);
+  int size = vector->size;
+  @TYPE@_vector_resize(vector, size+1, 0);
+  vector->data[size] = value;
 }
 
 

--- a/lib/util/vector_template.cpp
+++ b/lib/util/vector_template.cpp
@@ -618,8 +618,6 @@ void @TYPE@_vector_inplace_div( @TYPE@_vector_type * vector , const @TYPE@_vecto
 */
 
 void @TYPE@_vector_iset(@TYPE@_vector_type * vector , int index , @TYPE@ value) {
-  /*if (index >= vector->size)
-    util_abort("*********** %s: index out of range, range = [0, %d>, index = %d\n", __func__, vector->size, index);*/
   @TYPE@_vector_assert_writable( vector );
   {
     if (index < 0)

--- a/lib/util/vector_template.cpp
+++ b/lib/util/vector_template.cpp
@@ -230,7 +230,7 @@ static @TYPE@_vector_type * @TYPE@_vector_alloc__(int init_size , @TYPE@ default
 
   @TYPE@_vector_set_read_only( vector , false );
   if (init_size > 0)
-    @TYPE@_vector_iset( vector , init_size - 1 , default_value );  /* Filling up the init size elements with the default value */
+    @TYPE@_vector_resize( vector , init_size , default_value );  /* Filling up the init size elements with the default value */
 
   return vector;
 }


### PR DESCRIPTION
**Task**
During replacement of  objects of type xxx_vector_type with std::vector,  the are some incompatibility issues. This is related to the default_value of xxx_vector_type. This is an attempt to weed out some incompability issues so that a faster conversion process can take place. 

**Approach**
In situations were xxx_vector_iset is invoked, the size of the vector object mut be greated than the index argument. 

**Pre un-WIP checklist**
- [x] Statoil tests pass locally
