### PR TITLE
WIP: nnc_vector.cpp: grid_index_list and nnc_index_list as std::vector.

### DIFF
--- a/lib/ecl/ecl_nnc_export.cpp
+++ b/lib/ecl/ecl_nnc_export.cpp
@@ -17,6 +17,8 @@
 */
 #include <stdlib.h>
 
+#include <vector>
+
 #include <ert/util/int_vector.hpp>
 
 #include <ert/ecl/ecl_file.hpp>
@@ -50,8 +52,8 @@ static int  ecl_nnc_export__( const ecl_grid_type * grid , int lgr_index1 , cons
       int lgr_index2;
       for (lgr_index2=0; lgr_index2 < nnc_info_get_size( nnc_info ); lgr_index2++) {
         const nnc_vector_type * nnc_vector = nnc_info_iget_vector( nnc_info , lgr_index2 );
-        const int_vector_type * grid2_index_list = nnc_vector_get_grid_index_list( nnc_vector );
-        const int_vector_type * nnc_index_list = nnc_vector_get_nnc_index_list( nnc_vector );
+        const std::vector<int>& grid2_index_list = nnc_vector_get_grid_index_list( nnc_vector );
+        const std::vector<int>& nnc_index_list = nnc_vector_get_nnc_index_list( nnc_vector );
         int lgr_nr2 = nnc_vector_get_lgr_nr( nnc_vector );
         const ecl_kw_type * tran_kw = ecl_nnc_export_get_tranx_kw(global_grid  , init_file , lgr_nr1 , lgr_nr2 );
 
@@ -63,8 +65,8 @@ static int  ecl_nnc_export__( const ecl_grid_type * grid , int lgr_index1 , cons
         nnc.global_index1 = global_index1;
 
         for (index2 = 0; index2 < nnc_vector_get_size( nnc_vector ); index2++) {
-          nnc.global_index2 = int_vector_iget( grid2_index_list , index2 );
-          nnc.input_index = int_vector_iget( nnc_index_list, index2 );
+          nnc.global_index2 = grid2_index_list[index2];
+          nnc.input_index = nnc_index_list[index2];
           if(tran_kw) {
             nnc.trans = ecl_kw_iget_as_double(tran_kw, nnc.input_index);
             valid_trans++;

--- a/lib/ecl/ecl_nnc_export.cpp
+++ b/lib/ecl/ecl_nnc_export.cpp
@@ -19,8 +19,6 @@
 
 #include <vector>
 
-#include <ert/util/int_vector.hpp>
-
 #include <ert/ecl/ecl_file.hpp>
 #include <ert/ecl/ecl_grid.hpp>
 #include <ert/ecl/ecl_nnc_export.hpp>

--- a/lib/ecl/ecl_nnc_geometry.cpp
+++ b/lib/ecl/ecl_nnc_geometry.cpp
@@ -61,8 +61,8 @@ static void ecl_nnc_geometry_add_pairs( const ecl_nnc_geometry_type * nnc_geo , 
 
     for (int lgr_index2 = 0; lgr_index2 < nnc_info_get_size( nnc_info ); lgr_index2++) {
       const nnc_vector_type * nnc_vector = nnc_info_iget_vector( nnc_info , lgr_index2 );
-      const int_vector_type * grid2_index_list = nnc_vector_get_grid_index_list( nnc_vector );
-      const int_vector_type * nnc_index_list = nnc_vector_get_nnc_index_list( nnc_vector );
+      const std::vector<int>& grid2_index_list = nnc_vector_get_grid_index_list( nnc_vector );
+      const std::vector<int>& nnc_index_list = nnc_vector_get_nnc_index_list( nnc_vector );
       int lgr_nr2 = nnc_vector_get_lgr_nr( nnc_vector );
 
       for (int index2 = 0; index2 < nnc_vector_get_size( nnc_vector ); index2++) {
@@ -70,8 +70,8 @@ static void ecl_nnc_geometry_add_pairs( const ecl_nnc_geometry_type * nnc_geo , 
         pair.grid_nr1 = lgr_nr1;
         pair.global_index1 = global_index1;
         pair.grid_nr2 = lgr_nr2;
-        pair.global_index2 = int_vector_iget( grid2_index_list , index2 );
-        pair.input_index = int_vector_iget( nnc_index_list, index2 );
+        pair.global_index2 = grid2_index_list[index2];
+        pair.input_index = nnc_index_list[index2];
         nnc_geo->data->push_back(pair);
       }
     }

--- a/lib/ecl/nnc_info.cpp
+++ b/lib/ecl/nnc_info.cpp
@@ -18,9 +18,14 @@
 
 #include <stdlib.h>
 
+#include <vector>
+#include <stdexcept> 
+#include <string>
+
 #include <ert/util/util.h>
 #include <ert/util/vector.hpp>
 #include <ert/util/type_macros.hpp>
+#include <ert/util/vector_util.hpp>
 
 #include <ert/ecl/nnc_info.hpp>
 #include <ert/ecl/nnc_vector.hpp>
@@ -151,27 +156,28 @@ void nnc_info_add_nnc(nnc_info_type * nnc_info, int lgr_nr, int global_cell_numb
   }
 }
 
+bool nnc_info_has_grid_index_list( const nnc_info_type * nnc_info, int lgr_nr ) {
+  return (nnc_info_get_vector( nnc_info , lgr_nr ) != NULL);
+}
 
-const int_vector_type * nnc_info_get_grid_index_list(const nnc_info_type * nnc_info, int lgr_nr) {
+const std::vector<int>& nnc_info_get_grid_index_list(const nnc_info_type * nnc_info, int lgr_nr) {
   nnc_vector_type * nnc_vector = nnc_info_get_vector( nnc_info , lgr_nr );
-  if (nnc_vector)
-    return nnc_vector_get_grid_index_list( nnc_vector );
-  else
-    return NULL;
+  if (!nnc_vector)
+    throw std::invalid_argument(std::string(__func__)); 
+  return nnc_vector_get_grid_index_list( nnc_vector );
 }
 
 
-const int_vector_type * nnc_info_iget_grid_index_list(const nnc_info_type * nnc_info, int lgr_index) {
+const std::vector<int>& nnc_info_iget_grid_index_list(const nnc_info_type * nnc_info, int lgr_index) {
   nnc_vector_type * nnc_vector = nnc_info_iget_vector( nnc_info , lgr_index );
-  if (nnc_vector)
-    return nnc_vector_get_grid_index_list( nnc_vector );
-  else
-    return NULL;
+  if (!nnc_vector)
+    throw std::invalid_argument(std::string(__func__)); 
+  return nnc_vector_get_grid_index_list( nnc_vector );
 }
 
 
 
-const int_vector_type * nnc_info_get_self_grid_index_list(const nnc_info_type * nnc_info) {
+const std::vector<int>& nnc_info_get_self_grid_index_list(const nnc_info_type * nnc_info) {
   return nnc_info_get_grid_index_list( nnc_info , nnc_info->lgr_nr );
 }
 
@@ -207,8 +213,8 @@ void nnc_info_fprintf(const nnc_info_type * nnc_info , FILE * stream) {
       if (lgr_index >= 0) {
         printf("   %02d -> %02d  => ",lgr_nr , lgr_index);
         {
-          const int_vector_type * index_list = nnc_info_iget_grid_index_list( nnc_info , lgr_index );
-          int_vector_fprintf( index_list , stream , " " , "%d");
+          const std::vector<int>& index_list = nnc_info_iget_grid_index_list( nnc_info , lgr_index );
+          vector_util_fprintf<int>( index_list , stream , " " , "%d");
           printf("\n");
         }
       }

--- a/lib/ecl/nnc_vector.cpp
+++ b/lib/ecl/nnc_vector.cpp
@@ -19,6 +19,8 @@
 
 #include <stdlib.h>
 
+#include <vector>
+
 #include <ert/util/util.h>
 #include <ert/util/vector.hpp>
 #include <ert/util/type_macros.hpp>
@@ -33,9 +35,9 @@
 
 struct nnc_vector_struct {
   UTIL_TYPE_ID_DECLARATION;
-  int                lgr_nr;
-  int_vector_type * grid_index_list;
-  int_vector_type * nnc_index_list;
+  int              lgr_nr;
+  std::vector<int> grid_index_list;
+  std::vector<int> nnc_index_list;
 };
 
 
@@ -45,21 +47,19 @@ static UTIL_SAFE_CAST_FUNCTION(nnc_vector , NNC_VECTOR_TYPE_ID)
 
 
 nnc_vector_type * nnc_vector_alloc(int lgr_nr) {
-  nnc_vector_type * nnc_vector = (nnc_vector_type*)util_malloc( sizeof * nnc_vector );
+  nnc_vector_type * nnc_vector = new nnc_vector_type();
   UTIL_TYPE_ID_INIT(nnc_vector , NNC_VECTOR_TYPE_ID);
-  nnc_vector->grid_index_list = int_vector_alloc(0,0);
-  nnc_vector->nnc_index_list  = int_vector_alloc(0,0);
   nnc_vector->lgr_nr = lgr_nr;
   return nnc_vector;
 }
 
 nnc_vector_type * nnc_vector_alloc_copy(const nnc_vector_type * src_vector) {
-  nnc_vector_type * copy_vector =  (nnc_vector_type*)util_malloc( sizeof * src_vector );
+  nnc_vector_type * copy_vector =  new nnc_vector_type();
   UTIL_TYPE_ID_INIT(copy_vector , NNC_VECTOR_TYPE_ID);
 
   copy_vector->lgr_nr = src_vector->lgr_nr;
-  copy_vector->grid_index_list = int_vector_alloc_copy( src_vector->grid_index_list );
-  copy_vector->nnc_index_list  = int_vector_alloc_copy( src_vector->nnc_index_list );
+  copy_vector->grid_index_list = src_vector->grid_index_list;
+  copy_vector->nnc_index_list  = src_vector->nnc_index_list;
   return copy_vector;
 }
 
@@ -75,10 +75,10 @@ bool nnc_vector_equal( const nnc_vector_type * nnc_vector1 , const nnc_vector_ty
     if (nnc_vector1->lgr_nr != nnc_vector2->lgr_nr)
       return false;
 
-    if (!int_vector_equal( nnc_vector1->grid_index_list , nnc_vector2->grid_index_list))
+    if (nnc_vector1->grid_index_list != nnc_vector2->grid_index_list)
       return false;
 
-    if (!int_vector_equal( nnc_vector1->nnc_index_list , nnc_vector2->nnc_index_list))
+    if (nnc_vector1->nnc_index_list != nnc_vector2->nnc_index_list)
       return false;
 
     return true;
@@ -87,9 +87,7 @@ bool nnc_vector_equal( const nnc_vector_type * nnc_vector1 , const nnc_vector_ty
 
 
 void nnc_vector_free( nnc_vector_type * nnc_vector ) {
-  int_vector_free( nnc_vector->grid_index_list );
-  int_vector_free( nnc_vector->nnc_index_list );
-  free( nnc_vector );
+  delete nnc_vector;
 }
 
 
@@ -100,21 +98,21 @@ void nnc_vector_free__(void * arg) {
 
 
 void nnc_vector_add_nnc(nnc_vector_type * nnc_vector, int global_cell_number , int nnc_index) {
-  int_vector_append( nnc_vector->grid_index_list , global_cell_number );
-  int_vector_append( nnc_vector->nnc_index_list , nnc_index);
+  nnc_vector->grid_index_list.push_back( global_cell_number );
+  nnc_vector->nnc_index_list.push_back(nnc_index);
 }
 
 
-const int_vector_type * nnc_vector_get_grid_index_list(const nnc_vector_type * nnc_vector) {
+const std::vector<int>& nnc_vector_get_grid_index_list(const nnc_vector_type * nnc_vector) {
   return nnc_vector->grid_index_list;
 }
 
-const int_vector_type * nnc_vector_get_nnc_index_list(const nnc_vector_type * nnc_vector) {
+const std::vector<int>& nnc_vector_get_nnc_index_list(const nnc_vector_type * nnc_vector) {
   return nnc_vector->nnc_index_list;
 }
 
 int nnc_vector_get_size( const nnc_vector_type * nnc_vector ) {
-  return int_vector_size( nnc_vector->grid_index_list );
+  return nnc_vector->grid_index_list.size();
 }
 
 int nnc_vector_get_lgr_nr( const nnc_vector_type * nnc_vector ) {
@@ -122,9 +120,9 @@ int nnc_vector_get_lgr_nr( const nnc_vector_type * nnc_vector ) {
 }
 
 int nnc_vector_iget_nnc_index( const nnc_vector_type * nnc_vector , int index ) {
-  return int_vector_iget( nnc_vector->nnc_index_list , index );
+  return nnc_vector->nnc_index_list[index];
 }
 
 int nnc_vector_iget_grid_index( const nnc_vector_type * nnc_vector , int index ) {
-  return int_vector_iget( nnc_vector->grid_index_list , index );
+  return nnc_vector->grid_index_list[index];
 }

--- a/lib/ecl/nnc_vector.cpp
+++ b/lib/ecl/nnc_vector.cpp
@@ -24,7 +24,6 @@
 #include <ert/util/util.h>
 #include <ert/util/vector.hpp>
 #include <ert/util/type_macros.hpp>
-#include <ert/util/int_vector.hpp>
 
 #include <ert/ecl/nnc_vector.hpp>
 

--- a/lib/ecl/tests/ecl_nnc_info_test.cpp
+++ b/lib/ecl/tests/ecl_nnc_info_test.cpp
@@ -18,6 +18,8 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
+#include <vector>
+
 #include <ert/util/test_util.hpp>
 #include <ert/util/util.h>
 #include <ert/util/int_vector.hpp>
@@ -53,6 +55,8 @@ void test_equal( ) {
   nnc_info_add_nnc( nnc_info1 , lgr_nr + 2 , 11 , 11 );
   nnc_info_add_nnc( nnc_info2 , lgr_nr + 1 , 10 , 10 );
   test_assert_true( nnc_info_equal( nnc_info1 , nnc_info2 ));
+  nnc_info_free( nnc_info1 );
+  nnc_info_free( nnc_info2 );
 }
 
 
@@ -91,23 +95,22 @@ void basic_test() {
 
 
   nnc_vector_type * nnc_vector = nnc_info_get_vector( nnc_info , 1);
-  const int_vector_type * nnc_cells = nnc_info_get_grid_index_list(nnc_info, 1);
-  test_assert_int_equal(int_vector_size(nnc_cells), 2);
-  test_assert_ptr_equal( nnc_cells , nnc_vector_get_grid_index_list( nnc_vector ));
+  const std::vector<int>& nnc_cells = nnc_info_get_grid_index_list(nnc_info, 1);
+  test_assert_int_equal(nnc_cells.size(), 2);
+  test_assert_ptr_equal( nnc_cells.data() , nnc_vector_get_grid_index_list( nnc_vector ).data());
 
 
   nnc_vector_type * nnc_vector_null  = nnc_info_get_vector( nnc_info , 2);
-  const int_vector_type * nnc_cells_null = nnc_info_get_grid_index_list(nnc_info, 2);
-  test_assert_NULL(nnc_cells_null);
+  test_assert_true( !nnc_info_has_grid_index_list(nnc_info, 2) );
   test_assert_NULL(nnc_vector_null);
 
   nnc_vector_type * nnc_vector_self  = nnc_info_get_self_vector( nnc_info );
   const nnc_vector_type * nnc_vector_77  = nnc_info_get_vector( nnc_info , lgr_nr );
   test_assert_ptr_equal( nnc_vector_77 , nnc_vector_self );
 
-  const int_vector_type * nnc_cells_77 = nnc_info_get_grid_index_list(nnc_info, lgr_nr);
-  const int_vector_type * nnc_cells_self = nnc_info_get_self_grid_index_list(nnc_info);
-  test_assert_ptr_equal( nnc_cells_77 , nnc_cells_self );
+  const std::vector<int>& nnc_cells_77 = nnc_info_get_grid_index_list(nnc_info, lgr_nr);
+  const std::vector<int>& nnc_cells_self = nnc_info_get_self_grid_index_list(nnc_info);
+  test_assert_ptr_equal( nnc_cells_77.data() , nnc_cells_self.data() );
 
 
   test_assert_int_equal( 2 , nnc_info_get_size( nnc_info ));

--- a/lib/ecl/tests/ecl_nnc_test.cpp
+++ b/lib/ecl/tests/ecl_nnc_test.cpp
@@ -18,9 +18,12 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
+#include <vector>
+
 #include <ert/util/test_util.hpp>
 #include <ert/util/util.h>
 #include <ert/util/int_vector.hpp>
+#include <ert/util/vector_util.hpp>
 
 #include <ert/ecl/ecl_grid.hpp>
 #include <ert/ecl/nnc_info.hpp>
@@ -55,9 +58,9 @@ void test_scan( const char * grid_filename) {
 
             if (g2 < ecl_grid_get_global_size( lgr )) {  // Skipping matrix <-> fracture link in dual poro.
               const nnc_info_type * nnc_info = ecl_grid_get_cell_nnc_info1( lgr , g1 );
-              const int_vector_type * index_list = nnc_info_get_grid_index_list( nnc_info , lgr_nr);
+              const std::vector<int>& index_list = nnc_info_get_grid_index_list( nnc_info , lgr_nr);
               test_assert_not_NULL( nnc_info );
-              test_assert_int_not_equal( -1 , int_vector_index( index_list , g2 ));
+              test_assert_int_not_equal( -1 , vector_util_index<int>( index_list , g2 ));
             }
           }
         }
@@ -79,9 +82,9 @@ void test_scan( const char * grid_filename) {
           const nnc_info_type * nnc_info = ecl_grid_get_cell_nnc_info1( ecl_grid , g );
           test_assert_not_NULL( nnc_info );
           {
-            const int_vector_type * index_list = nnc_info_get_grid_index_list( nnc_info , lgr_nr );
-            test_assert_not_NULL( index_list );
-            test_assert_int_not_equal( -1 , int_vector_index( index_list , l ));
+            const std::vector<int>& index_list = nnc_info_get_grid_index_list( nnc_info , lgr_nr );
+            test_assert_true(nnc_info_has_grid_index_list( nnc_info , lgr_nr ) );
+            test_assert_int_not_equal( -1 , vector_util_index<int>( index_list , l ));
           }
         }
       }
@@ -102,9 +105,9 @@ void test_scan( const char * grid_filename) {
           const int g2 = ecl_kw_iget_int( nnc2_kw , i ) - 1;
 
           const nnc_info_type * nnc_info = ecl_grid_get_cell_nnc_info1( lgr1 , g1 );
-          const int_vector_type * index_list = nnc_info_get_grid_index_list( nnc_info , lgr_nr2);
+          const std::vector<int>& index_list = nnc_info_get_grid_index_list( nnc_info , lgr_nr2);
           test_assert_not_NULL( nnc_info );
-          test_assert_int_not_equal( -1 , int_vector_index( index_list , g2 ));
+          test_assert_int_not_equal( -1 , vector_util_index<int>( index_list , g2 ));
         }
       }
     }

--- a/lib/ecl/tests/ecl_nnc_vector.cpp
+++ b/lib/ecl/tests/ecl_nnc_vector.cpp
@@ -18,6 +18,8 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
+#include <vector>
+
 #include <ert/util/test_util.hpp>
 #include <ert/util/int_vector.hpp>
 
@@ -41,17 +43,17 @@ void test_basic() {
   test_assert_int_equal( 6 , nnc_vector_get_size( vector ));
 
   {
-    const int_vector_type * grid_index_list = nnc_vector_get_grid_index_list( vector );
-    const int_vector_type * nnc_index_list = nnc_vector_get_nnc_index_list( vector );
+    const std::vector<int>& grid_index_list = nnc_vector_get_grid_index_list( vector );
+    const std::vector<int>& nnc_index_list = nnc_vector_get_nnc_index_list( vector );
 
-    test_assert_int_equal( 6   , int_vector_size( nnc_index_list ));
-    test_assert_int_equal( 1 , int_vector_iget( nnc_index_list , 0 ));
-    test_assert_int_equal( 6 , int_vector_iget( nnc_index_list , 5 ));
+    test_assert_int_equal( 6   , nnc_index_list.size() );
+    test_assert_int_equal( 1 , nnc_index_list[0] );
+    test_assert_int_equal( 6 , nnc_index_list[5] );
 
-    test_assert_int_equal( 6   , int_vector_size( grid_index_list ));
-    test_assert_int_equal( 100 , int_vector_iget( grid_index_list , 0 ));
-    test_assert_int_equal( 200 , int_vector_iget( grid_index_list , 1 ));
-    test_assert_int_equal( 300 , int_vector_iget( grid_index_list , 2 ));
+    test_assert_int_equal( 6   , grid_index_list.size() );
+    test_assert_int_equal( 100 , grid_index_list[0] );
+    test_assert_int_equal( 200 , grid_index_list[1] );
+    test_assert_int_equal( 300 , grid_index_list[2] );
   }
 
   nnc_vector_free( vector );

--- a/lib/include/ert/ecl/ecl_grid.hpp
+++ b/lib/include/ert/ecl/ecl_grid.hpp
@@ -18,9 +18,7 @@
 
 #ifndef ERT_ECL_GRID_H
 #define ERT_ECL_GRID_H
-#ifdef __cplusplus
-extern "C" {
-#endif
+
 #include <stdbool.h>
 
 #include <ert/util/double_vector.hpp>
@@ -31,6 +29,10 @@ extern "C" {
 #include <ert/ecl/ecl_kw.hpp>
 #include <ert/ecl/grid_dims.hpp>
 #include <ert/ecl/nnc_info.hpp>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define ECL_GRID_COORD_SIZE(nx,ny)    (((nx) + 1) * ((ny) + 1) * 6)
 #define ECL_GRID_ZCORN_SIZE(nx,ny,nz) (((nx) * (ny) * (nz) * 8))

--- a/lib/include/ert/ecl/nnc_info.hpp
+++ b/lib/include/ert/ecl/nnc_info.hpp
@@ -19,16 +19,24 @@
 
 #ifndef ERT_NNC_INFO_H
 #define ERT_NNC_INFO_H
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <ert/util/int_vector.hpp>
 #include <ert/util/type_macros.hpp>
 
 #include <ert/ecl/nnc_vector.hpp>
 
-  typedef struct nnc_info_struct nnc_info_type;
+typedef struct nnc_info_struct nnc_info_type;
+
+#ifdef __cplusplus
+#include <vector>
+  const std::vector<int>& nnc_info_get_grid_index_list(const nnc_info_type * nnc_info, int lgr_nr);
+  const std::vector<int>& nnc_info_iget_grid_index_list(const nnc_info_type * nnc_info, int lgr_index);
+  const std::vector<int>& nnc_info_get_self_grid_index_list(const nnc_info_type * nnc_info);
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
   UTIL_IS_INSTANCE_HEADER(nnc_info);
 
@@ -36,13 +44,10 @@ extern "C" {
   void                    nnc_info_free( nnc_info_type * nnc_info );
   void                    nnc_info_add_nnc(nnc_info_type * nnc_info, int lgr_nr, int global_cell_number, int nnc_index);
 
-  const int_vector_type * nnc_info_iget_grid_index_list(const nnc_info_type * nnc_info, int lgr_index);
   nnc_vector_type       * nnc_info_iget_vector( const nnc_info_type * nnc_info , int lgr_index);
 
-  const int_vector_type * nnc_info_get_grid_index_list(const nnc_info_type * nnc_info, int lgr_nr);
   nnc_vector_type       * nnc_info_get_vector( const nnc_info_type * nnc_info , int lgr_nr);
 
-  const int_vector_type * nnc_info_get_self_grid_index_list(const nnc_info_type * nnc_info);
   nnc_vector_type       * nnc_info_get_self_vector( const nnc_info_type * nnc_info );
 
   int                     nnc_info_get_lgr_nr(const nnc_info_type * nnc_info );
@@ -52,6 +57,7 @@ extern "C" {
 
   bool                    nnc_info_equal( const nnc_info_type * nnc_info1 , const nnc_info_type * nnc_info2 );
   nnc_info_type *         nnc_info_alloc_copy( const nnc_info_type * src_info );
+  bool                    nnc_info_has_grid_index_list( const nnc_info_type * nnc_info, int lgr_nr );
 
 #ifdef __cplusplus
 }

--- a/lib/include/ert/ecl/nnc_vector.hpp
+++ b/lib/include/ert/ecl/nnc_vector.hpp
@@ -19,14 +19,21 @@
 
 #ifndef ERT_NNC_VECTOR_H
 #define ERT_NNC_VECTOR_H
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <ert/util/int_vector.hpp>
 #include <ert/util/type_macros.hpp>
 
-  typedef struct nnc_vector_struct nnc_vector_type;
+typedef struct nnc_vector_struct nnc_vector_type;
+
+#ifdef __cplusplus
+#include <vector>
+  const std::vector<int>& nnc_vector_get_grid_index_list(const nnc_vector_type * nnc_vector);
+  const std::vector<int>& nnc_vector_get_nnc_index_list(const nnc_vector_type * nnc_vector);
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
   UTIL_IS_INSTANCE_HEADER(nnc_vector);
 
@@ -36,8 +43,6 @@ extern "C" {
   nnc_vector_type         * nnc_vector_alloc_copy(const nnc_vector_type * src_vector);
   void                      nnc_vector_free( nnc_vector_type * nnc_vector );
   void                      nnc_vector_add_nnc(nnc_vector_type * nnc_vector, int global_cell_number, int nnc_index);
-  const int_vector_type   * nnc_vector_get_grid_index_list(const nnc_vector_type * nnc_vector);
-  const int_vector_type   * nnc_vector_get_nnc_index_list(const nnc_vector_type * nnc_vector);
   int                       nnc_vector_get_lgr_nr(const nnc_vector_type * nnc_vector );
   void                      nnc_vector_free__(void * arg);
   int                       nnc_vector_get_size( const nnc_vector_type * nnc_vector );

--- a/lib/include/ert/util/vector_util.hpp
+++ b/lib/include/ert/util/vector_util.hpp
@@ -1,0 +1,59 @@
+/*
+   Copyright (C) 2018  Statoil ASA, Norway.
+
+   The file 'vector_util.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#include <stdio.h>
+
+#include <vector>
+
+template <class T>
+int vector_util_index(const std::vector<T>& vec, T value) {
+  if (vec.size() > 0) {
+    int index = 0;
+    while (true) {
+      if (vec[index] == value)
+        break;
+
+      index++;
+      if (index == (int)vec.size()) {
+        index = -1;  /* Not found */
+        break;
+      }
+    }
+
+    return index;
+  } else
+    return -1;
+}
+
+
+template <class T>
+void vector_util_fprintf(const std::vector<T>& vec , FILE * stream , const char * name , const char * fmt) {
+  size_t i;
+  if (name != NULL)
+    fprintf(stream , "%s = [" , name);
+  else
+    fprintf(stream , "[");
+
+  for (i = 0; i < vec.size(); i++) {
+    fprintf(stream , fmt , vec[i]);
+    if (i < (vec.size() - 1))
+      fprintf(stream , ", ");
+  }
+
+  fprintf(stream , "]\n");
+}

--- a/lib/include/ert/util/vector_util.hpp
+++ b/lib/include/ert/util/vector_util.hpp
@@ -19,25 +19,18 @@
 #include <stdio.h>
 
 #include <vector>
+#include <algorithm>
 
 template <class T>
 int vector_util_index(const std::vector<T>& vec, T value) {
-  if (vec.size() > 0) {
-    int index = 0;
-    while (true) {
-      if (vec[index] == value)
-        break;
 
-      index++;
-      if (index == (int)vec.size()) {
-        index = -1;  /* Not found */
-        break;
-      }
-    }
-
-    return index;
-  } else
-    return -1;
+  int index;
+  auto iter = find(vec.begin(), vec.end(), value);
+  if (iter == vec.end())
+    index = -1;
+  else
+    index = iter - vec.begin();
+  return index;
 }
 
 


### PR DESCRIPTION
**Task**
As part of converting the ert-code to c++, the nnc_vector objects will contain std::vector instead of int_vector_type.


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
