### PR TITLE
Check restart file for LGR info when loading well info

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -676,7 +676,9 @@ add_test(NAME well_segment_load
 add_test(NAME well_segment_branch_conn_load
          COMMAND well_segment_branch_conn_load ${_eclpath}/MSWcase/MSW_CASE.X0021)
 
-add_test(NAME well_info COMMAND well_info ${_eclpath}/Gurbat/ECLIPSE.EGRID)
+add_test(NAME well_info1 COMMAND well_info ${_eclpath}/Gurbat/ECLIPSE.EGRID)
+add_test(NAME well_info2 COMMAND well_info ${_eclpath}/well_info_rio/BMS8_TMPL_1-BMS8_105DST_EMBED_T0_1.EGRID
+                                           ${_eclpath}/well_info_rio/BMS8_TMPL_1-BMS8_105DST_EMBED_T0_1.UNRST)
 
 add_test(NAME well_conn_CF COMMAND well_conn_CF ${_eclpath}/Gurbat/ECLIPSE.X0060)
 

--- a/lib/ecl/tests/well_info.cpp
+++ b/lib/ecl/tests/well_info.cpp
@@ -30,6 +30,7 @@
 
 
 int main(int argc , char ** argv) {
+  util_install_signals();
   const char * grid_file    = argv[1];
 
   ecl_grid_type * grid = ecl_grid_alloc( grid_file );
@@ -37,6 +38,9 @@ int main(int argc , char ** argv) {
   {
     well_info_type * well_info = well_info_alloc( grid );
     test_assert_not_NULL( well_info );
+    if (argc >= 3)
+      well_info_load_rstfile(well_info, argv[2], true);
+
     well_info_free( well_info );
   }
   ecl_grid_free( grid );

--- a/lib/ecl/well_state.cpp
+++ b/lib/ecl/well_state.cpp
@@ -447,10 +447,19 @@ static void well_state_add_LGR_connections(well_state_type * well_state,
   int num_lgr = ecl_grid_get_num_lgr( grid );
   for (int lgr_index = 0; lgr_index < num_lgr; lgr_index++) {
     ecl_file_view_type * lgr_view = ecl_file_view_add_blockview(file_view , LGR_KW , lgr_index);
-    const char * grid_name = ecl_grid_iget_lgr_name( grid , lgr_index );
-    int well_nr = well_state_get_lgr_well_nr( well_state , lgr_view );
-    if (well_nr >= 0)
-      well_state_add_connections__( well_state , lgr_view , grid_name , lgr_index + 1, well_nr );
+    /*
+      Even though the grid has LGR information the restart file is not required
+      to have corresponding LGR information. This has for a long time been
+      unchecked, and there might be bugs lurking based on the incorrect
+      assumption that if the grid has LGR information then the corresponding LGR
+      information can also be found in the restart file.
+    */
+    if (lgr_view) {
+      const char * grid_name = ecl_grid_iget_lgr_name( grid , lgr_index );
+      int well_nr = well_state_get_lgr_well_nr( well_state , lgr_view );
+      if (well_nr >= 0)
+        well_state_add_connections__( well_state , lgr_view , grid_name , lgr_index + 1, well_nr );
+    }
   }
 }
 


### PR DESCRIPTION
Issue from user in Equinor: Hard crash when loading well_info.

Previously it has been a hard/unchecked assumption that the LGR information is consistent between GRID file and UNRST file; now we have encountered a case where the grid has LGR information, and the UNRST file is lacking it. 

Simple enough to fix with a `if ()` guard when loading the UNRST file, but there might be other bugs lurking based on the same implicit assumption.