### PR TITLE
WIP: Changed ecl_sum_vector to use numpy_dates instead of mpl_dates

### DIFF
--- a/python/ecl/summary/ecl_sum_vector.py
+++ b/python/ecl/summary/ecl_sum_vector.py
@@ -106,7 +106,7 @@ class EclSumVector(object):
         warnings.warn("The mpl_dates property has been deprecated - use numpy_dates instead",
                      DeprecationWarning)
 
-        return parent.get_mpl_dates(report_only)
+        return parent.get_mpl_dates(self.report_only)
 
     @property
     def numpy_dates(self):

--- a/python/ecl/summary/ecl_sum_vector.py
+++ b/python/ecl/summary/ecl_sum_vector.py
@@ -46,7 +46,8 @@ class EclSumVector(object):
 
         self.__dates = parent.get_dates(report_only)
         self.__days = parent.get_days(report_only)
-        self.__mpl_dates = parent.get_mpl_dates(report_only)
+        self.__mpl_dates = parent.get_numpy_dates(report_only)
+        self.__numpy_dates = parent.get_numpy_dates(report_only)
         self.__report_step = parent.get_report_step(report_only)
         self.__values = None
 
@@ -99,8 +100,20 @@ class EclSumVector(object):
     def mpl_dates(self):
         """
         All the dates as numpy vector of dates in matplotlib format.
+        This property will be replaced by numpy_dates, but is kept for
+        backwards-compatibility for the time-being. Usage will trigger
+        a depreciation warning.
         """
-        return self.__mpl_dates
+        warning.warn("The mpl_dates property has been deprecated - use numpy_dates instead",
+                     DeprecationWarning)
+        return self.__numpy_dates
+
+    @property
+    def numpy_dates(self):
+        """
+        All the dates as numpy vector of dates in matplotlib format.
+        """
+        return self.__numpy_dates
 
     @property
     def report_step(self):
@@ -119,7 +132,7 @@ class EclSumVector(object):
         return EclSumNode(self.__report_step[index],
                           self.__days[index],
                           self.__dates[index],
-                          self.__mpl_dates[index],
+                          self.__numpy_dates[index],
                           self.__values[index])
 
 

--- a/python/ecl/summary/ecl_sum_vector.py
+++ b/python/ecl/summary/ecl_sum_vector.py
@@ -112,7 +112,7 @@ class EclSumVector(object):
     @property
     def numpy_dates(self):
         """
-        All the dates as numpy vector of dates in matplotlib format.
+        All the dates as numpy vector of dates in numpy format.
         """
         return self.__numpy_dates
 

--- a/python/ecl/summary/ecl_sum_vector.py
+++ b/python/ecl/summary/ecl_sum_vector.py
@@ -16,6 +16,7 @@
 
 from __future__ import print_function
 import warnings
+from ecl.summary import EclSum
 from ecl.summary.ecl_sum_node import EclSumNode
 
 
@@ -46,7 +47,6 @@ class EclSumVector(object):
 
         self.__dates = parent.get_dates(report_only)
         self.__days = parent.get_days(report_only)
-        self.__mpl_dates = parent.get_numpy_dates(report_only)
         self.__numpy_dates = parent.get_numpy_dates(report_only)
         self.__report_step = parent.get_report_step(report_only)
         self.__values = None
@@ -106,7 +106,8 @@ class EclSumVector(object):
         """
         warning.warn("The mpl_dates property has been deprecated - use numpy_dates instead",
                      DeprecationWarning)
-        return self.__numpy_dates
+
+        return EclSum.get_mpl_dates(report_only)
 
     @property
     def numpy_dates(self):

--- a/python/ecl/summary/ecl_sum_vector.py
+++ b/python/ecl/summary/ecl_sum_vector.py
@@ -46,7 +46,7 @@ class EclSumVector(object):
 
         self.__dates = parent.get_dates(report_only)
         self.__days = parent.get_days(report_only)
-        self.__numpy_dates = parent.get_numpy_dates(report_only)
+        self.__numpy_dates = parent.numpy_dates(report_only)
         self.__report_step = parent.get_report_step(report_only)
         self.__values = None
 
@@ -132,7 +132,7 @@ class EclSumVector(object):
         return EclSumNode(self.__report_step[index],
                           self.__days[index],
                           self.__dates[index],
-                          self.__numpy_dates[index],
+                          self.mpl_dates[index],
                           self.__values[index])
 
 

--- a/python/ecl/summary/ecl_sum_vector.py
+++ b/python/ecl/summary/ecl_sum_vector.py
@@ -46,7 +46,7 @@ class EclSumVector(object):
 
         self.__dates = parent.get_dates(report_only)
         self.__days = parent.get_days(report_only)
-        self.__numpy_dates = parent.numpy_dates(report_only)
+        self.__numpy_dates = parent.numpy_dates
         self.__report_step = parent.get_report_step(report_only)
         self.__values = None
 

--- a/python/ecl/summary/ecl_sum_vector.py
+++ b/python/ecl/summary/ecl_sum_vector.py
@@ -103,7 +103,7 @@ class EclSumVector(object):
         backwards-compatibility for the time-being. Usage will trigger
         a depreciation warning.
         """
-        warning.warn("The mpl_dates property has been deprecated - use numpy_dates instead",
+        warnings.warn("The mpl_dates property has been deprecated - use numpy_dates instead",
                      DeprecationWarning)
 
         return parent.get_mpl_dates(report_only)

--- a/python/ecl/summary/ecl_sum_vector.py
+++ b/python/ecl/summary/ecl_sum_vector.py
@@ -16,7 +16,6 @@
 
 from __future__ import print_function
 import warnings
-from ecl.summary import EclSum
 from ecl.summary.ecl_sum_node import EclSumNode
 
 
@@ -107,7 +106,7 @@ class EclSumVector(object):
         warning.warn("The mpl_dates property has been deprecated - use numpy_dates instead",
                      DeprecationWarning)
 
-        return EclSum.get_mpl_dates(report_only)
+        return parent.get_mpl_dates(report_only)
 
     @property
     def numpy_dates(self):

--- a/python/ecl/summary/ecl_sum_vector.py
+++ b/python/ecl/summary/ecl_sum_vector.py
@@ -106,7 +106,7 @@ class EclSumVector(object):
         warnings.warn("The mpl_dates property has been deprecated - use numpy_dates instead",
                      DeprecationWarning)
 
-        return parent.get_mpl_dates(self.report_only)
+        return self.parent.get_mpl_dates(self.report_only)
 
     @property
     def numpy_dates(self):


### PR DESCRIPTION
**Task**
ecl_sum_vector.py makes use of get_mpl_dates() which leads to a depreciation warning. ecl_sum_vector should use the new numpy_dates()


**Approach**
Replaced all occurances of "mpl_dates" with "numpy_dates". Maintainted __mpl_dates property for backward compatibility. Usage of the mpl_dates property will trigger a Depreciation Warning.


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally

Did not perform tests. Need some assistance to get the tests going.
