### PR TITLE
NNC export support Intersect format

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -350,6 +350,7 @@ foreach (name   ecl_alloc_cpgrid
                 ecl_grid_init_fwrite
                 ecl_grid_reset_actnum
                 ecl_grid_ext_actnum
+                ecl_nnc_export_intersect
                 ecl_sum_data_intermediate_test
                 ecl_grid_cell_contains
                 ecl_unsmry_loader_test
@@ -446,7 +447,6 @@ foreach(name ecl_coarse_test
              ecl_grid_layer_contains
              ecl_restart_test
              ecl_nnc_export
-             ecl_nnc_export_intersect
              ecl_nnc_export_get_tran
              ecl_nnc_data_statoil_root
              ecl_sum_case_exists
@@ -520,8 +520,6 @@ add_test(NAME ecl_nnc_export4 COMMAND ecl_nnc_export ${_eclpath}/DualPoro/DUAL_D
 add_test(NAME ecl_nnc_export5 COMMAND ecl_nnc_export ${_eclpath}/DualPoro/DUALPORO TRUE)
 add_test(NAME ecl_nnc_export6 COMMAND ecl_nnc_export ${_eclpath}/nestedLGRcase/TESTCASE_NESTEDLGR TRUE)
 add_test(NAME ecl_nnc_export7 COMMAND ecl_nnc_export ${_eclpath}/TYRIHANS/BASE20150218_MULTFLT FALSE)
-
-add_test(NAME ecl_nnc_export_intersect COMMAND ecl_nnc_export_intersect)
 
 add_test(NAME ecl_nnc_export_get_tran COMMAND ecl_nnc_export_get_tran
     ${_eclpath}/Troll/MSW_LGR/2BRANCHES-CCEWELLPATH-NEW-SCH-TUNED-AR3)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -446,6 +446,7 @@ foreach(name ecl_coarse_test
              ecl_grid_layer_contains
              ecl_restart_test
              ecl_nnc_export
+             ecl_nnc_export_intersect
              ecl_nnc_export_get_tran
              ecl_nnc_data_statoil_root
              ecl_sum_case_exists
@@ -519,6 +520,8 @@ add_test(NAME ecl_nnc_export4 COMMAND ecl_nnc_export ${_eclpath}/DualPoro/DUAL_D
 add_test(NAME ecl_nnc_export5 COMMAND ecl_nnc_export ${_eclpath}/DualPoro/DUALPORO TRUE)
 add_test(NAME ecl_nnc_export6 COMMAND ecl_nnc_export ${_eclpath}/nestedLGRcase/TESTCASE_NESTEDLGR TRUE)
 add_test(NAME ecl_nnc_export7 COMMAND ecl_nnc_export ${_eclpath}/TYRIHANS/BASE20150218_MULTFLT FALSE)
+
+add_test(NAME ecl_nnc_export_intersect COMMAND ecl_nnc_export_intersect)
 
 add_test(NAME ecl_nnc_export_get_tran COMMAND ecl_nnc_export_get_tran
     ${_eclpath}/Troll/MSW_LGR/2BRANCHES-CCEWELLPATH-NEW-SCH-TUNED-AR3)

--- a/lib/ecl/ecl_nnc_export.cpp
+++ b/lib/ecl/ecl_nnc_export.cpp
@@ -26,11 +26,47 @@
 #include <ert/ecl/ecl_kw_magic.hpp>
 
 
-int ecl_nnc_export_get_size( const ecl_grid_type * grid ) {
-  return ecl_grid_get_num_nnc( grid );
+
+/**
+ * Return true if the NNC information is stored in the Intersect format, false otherwise.
+ * In the Intersect format, the NNC information stored in the grid is unrealiable.
+ * The correct NNC data is stored in the init file instead
+ */
+bool ecl_nnc_intersect_format(const ecl_grid_type * grid, const ecl_file_type * init_file) {
+   if(   !ecl_file_has_kw(init_file, NNC1_KW) ||
+         !ecl_file_has_kw(init_file, NNC2_KW) ||
+         !ecl_file_has_kw(init_file, TRANNNC_KW))
+      return false;
+   // In the specific case we are treating, there should be just 1 occurrence of the kw
+   const auto nnc1_num = ecl_kw_get_size(ecl_file_iget_named_kw(init_file, NNC1_KW, 0));
+   const auto nnc2_num = ecl_kw_get_size(ecl_file_iget_named_kw(init_file, NNC2_KW, 0));
+   const auto tran_num = ecl_kw_get_size(ecl_file_iget_named_kw(init_file, TRANNNC_KW, 0));
+   return nnc1_num == tran_num && nnc2_num == tran_num;
 }
 
 
+int ecl_nnc_export_get_size( const ecl_grid_type * grid , const ecl_file_type * init_file ) {
+   return ecl_nnc_intersect_format(grid, init_file) ?
+         ecl_kw_get_size(ecl_file_iget_named_kw(init_file, TRANNNC_KW, 0)) : // Intersect format
+         ecl_grid_get_num_nnc( grid ); // Eclipse format
+}
+
+static int ecl_nnc_export_intersect__(const ecl_file_type * init_file , ecl_nnc_type * nnc_data, int * nnc_offset) {
+   const auto nnc1_kw = ecl_file_iget_named_kw(init_file, NNC1_KW, 0);
+   const auto nnc2_kw = ecl_file_iget_named_kw(init_file, NNC2_KW, 0);
+   const auto tran_kw = ecl_file_iget_named_kw(init_file, TRANNNC_KW, 0);
+
+   auto nnc_index = *nnc_offset;
+   for(int i = 0; i < ecl_kw_get_size(tran_kw); ++i) {
+      auto const nnc1 = ecl_kw_iget_int(nnc1_kw, i);
+      auto const nnc2 = ecl_kw_iget_int(nnc2_kw, i);
+      auto const tran = ecl_kw_iget_as_double(tran_kw, i);
+      nnc_data[nnc_index] = ecl_nnc_type{0, nnc1, 0, nnc2, i, tran};
+      ++nnc_index;
+   }
+   *nnc_offset = nnc_index;
+   return ecl_kw_get_size(tran_kw); // Assume all valid
+}
 
 
 static int  ecl_nnc_export__( const ecl_grid_type * grid , int lgr_index1 , const ecl_file_type * init_file , ecl_nnc_type * nnc_data, int * nnc_offset) {
@@ -86,15 +122,22 @@ static int  ecl_nnc_export__( const ecl_grid_type * grid , int lgr_index1 , cons
 int  ecl_nnc_export( const ecl_grid_type * grid , const ecl_file_type * init_file , ecl_nnc_type * nnc_data) {
   int nnc_index = 0;
   int total_valid_trans = 0;
-  total_valid_trans = ecl_nnc_export__( grid , 0 , init_file , nnc_data , &nnc_index );
-  {
-    int lgr_index;
-    for (lgr_index = 0; lgr_index < ecl_grid_get_num_lgr(grid); lgr_index++) {
-      ecl_grid_type * igrid = ecl_grid_iget_lgr( grid , lgr_index );
-      total_valid_trans += ecl_nnc_export__( igrid , lgr_index , init_file , nnc_data , &nnc_index );
-    }
+  if(ecl_nnc_intersect_format(grid, init_file)) {
+     // Intersect format
+     total_valid_trans = ecl_nnc_export_intersect__(init_file, nnc_data, &nnc_index);
   }
-  nnc_index = ecl_nnc_export_get_size( grid );
+  else {
+    // Eclipse format
+    total_valid_trans = ecl_nnc_export__( grid , 0 , init_file , nnc_data , &nnc_index );
+    {
+      int lgr_index;
+      for (lgr_index = 0; lgr_index < ecl_grid_get_num_lgr(grid); lgr_index++) {
+        ecl_grid_type * igrid = ecl_grid_iget_lgr( grid , lgr_index );
+        total_valid_trans += ecl_nnc_export__( igrid , lgr_index , init_file , nnc_data , &nnc_index );
+      }
+    }
+    nnc_index = ecl_grid_get_num_nnc( grid );
+  }
   ecl_nnc_sort( nnc_data , nnc_index );
   return total_valid_trans;
 }

--- a/lib/ecl/ecl_nnc_export.cpp
+++ b/lib/ecl/ecl_nnc_export.cpp
@@ -130,8 +130,7 @@ int  ecl_nnc_export( const ecl_grid_type * grid , const ecl_file_type * init_fil
     // Eclipse format
     total_valid_trans = ecl_nnc_export__( grid , 0 , init_file , nnc_data , &nnc_index );
     {
-      int lgr_index;
-      for (lgr_index = 0; lgr_index < ecl_grid_get_num_lgr(grid); lgr_index++) {
+      for (int lgr_index = 0; lgr_index < ecl_grid_get_num_lgr(grid); lgr_index++) {
         ecl_grid_type * igrid = ecl_grid_iget_lgr( grid , lgr_index );
         total_valid_trans += ecl_nnc_export__( igrid , lgr_index , init_file , nnc_data , &nnc_index );
       }

--- a/lib/ecl/tests/ecl_nnc_export.cpp
+++ b/lib/ecl/tests/ecl_nnc_export.cpp
@@ -74,8 +74,10 @@ int count_kw_data( const ecl_file_type * file , ecl_grid_type * grid , const cha
 
 void test_count(const char * name) {
   char * grid_file_name = ecl_util_alloc_filename(NULL , name , ECL_EGRID_FILE , false  , -1);
+  char * init_file_name = ecl_util_alloc_filename(NULL , name , ECL_INIT_FILE , false  , -1);
   ecl_grid_type * grid = ecl_grid_alloc( grid_file_name );
   ecl_file_type * grid_file = ecl_file_open( grid_file_name , 0 );
+  ecl_file_type * init_file = ecl_file_open( init_file_name , 0);
 
   int num_nnc = 0;
 
@@ -83,7 +85,7 @@ void test_count(const char * name) {
   num_nnc += count_kw_data( grid_file , grid , "NNCG" , NULL);
   num_nnc += count_kw_data( grid_file , grid , "NNA1" , NULL);
 
-  test_assert_int_equal( num_nnc , ecl_nnc_export_get_size( grid ));
+  test_assert_int_equal(num_nnc, ecl_nnc_export_get_size(grid, init_file));
 
   free(grid_file_name);
   ecl_grid_free( grid );
@@ -97,7 +99,7 @@ void test_nnc_export_missing_TRANX(const char * name ) {
   if (util_entry_exists(init_file_name)) {
     ecl_grid_type * grid = ecl_grid_alloc( grid_file_name );
     ecl_file_type * init_file = ecl_file_open( init_file_name , 0);
-    ecl_nnc_type  * nnc_data1 = (ecl_nnc_type *) util_calloc( ecl_nnc_export_get_size( grid ) , sizeof * nnc_data1 );
+    ecl_nnc_type * nnc_data1 = (ecl_nnc_type *) util_calloc(ecl_nnc_export_get_size(grid, init_file), sizeof *nnc_data1);
     int count = ecl_nnc_export(grid, init_file, nnc_data1);
     int i;
     test_assert_int_equal( count , 0 );
@@ -113,8 +115,8 @@ void test_export(const char * name, bool have_tran_data) {
     ecl_grid_type * grid = ecl_grid_alloc( grid_file_name );
     ecl_file_type * grid_file = ecl_file_open( grid_file_name , 0 );
     ecl_file_type * init_file = ecl_file_open( init_file_name , 0);
-    ecl_nnc_type  * nnc_data1 = (ecl_nnc_type *) util_calloc( ecl_nnc_export_get_size( grid ) , sizeof * nnc_data1 );
-    ecl_nnc_type  * nnc_data2 = (ecl_nnc_type *) util_calloc( ecl_nnc_export_get_size( grid ) , sizeof * nnc_data2 );
+    ecl_nnc_type * nnc_data1 = (ecl_nnc_type *) util_calloc(ecl_nnc_export_get_size(grid, init_file), sizeof *nnc_data1);
+    ecl_nnc_type * nnc_data2 = (ecl_nnc_type *) util_calloc(ecl_nnc_export_get_size(grid, init_file), sizeof *nnc_data2);
 
 
     {
@@ -214,23 +216,23 @@ void test_export(const char * name, bool have_tran_data) {
         }
       }
 
-      test_assert_int_equal( nnc_offset , ecl_nnc_export_get_size( grid ));
+      test_assert_int_equal(nnc_offset, ecl_nnc_export_get_size(grid, init_file ));
       ecl_nnc_sort( nnc_data1 , nnc_offset );
     }
 
     {
       int export_size = ecl_nnc_export( grid , init_file , nnc_data2 );
-      test_assert_int_equal( export_size , ecl_nnc_export_get_size( grid ));
+      test_assert_int_equal(export_size , ecl_nnc_export_get_size(grid, init_file));
     }
 
     {
       int i;
-      int size = ecl_nnc_export_get_size( grid );
+      int size = ecl_nnc_export_get_size(grid, init_file);
       for (i=0; i < size; i++)
         test_assert_int_equal( 0 , ecl_nnc_sort_cmp( &nnc_data1[i] , &nnc_data2[i]));
     }
 
-    for (int i =0; i < ecl_nnc_export_get_size( grid ); i++)
+    for (int i = 0; i < ecl_nnc_export_get_size(grid, init_file); i++)
       test_assert_true( ecl_nnc_equal( &nnc_data1[i] , &nnc_data2[i] ));
 
     {
@@ -238,7 +240,7 @@ void test_export(const char * name, bool have_tran_data) {
       ecl_file_view_type * view_file = ecl_file_get_global_view( init_file );
       ecl_nnc_data_type * nnc_geo_data = ecl_nnc_data_alloc_tran(grid, nnc_geo, view_file);
 
-      test_assert_int_equal( ecl_nnc_export_get_size( grid ), ecl_nnc_geometry_size( nnc_geo ));
+      test_assert_int_equal(ecl_nnc_export_get_size(grid, init_file), ecl_nnc_geometry_size(nnc_geo));
       for (int i=0; i < ecl_nnc_geometry_size( nnc_geo ); i++) {
         const ecl_nnc_pair_type *nnc_pair = ecl_nnc_geometry_iget( nnc_geo , i );
         ecl_nnc_type * nnc1 = &nnc_data1[i];

--- a/lib/ecl/tests/ecl_nnc_export_intersect.cpp
+++ b/lib/ecl/tests/ecl_nnc_export_intersect.cpp
@@ -23,6 +23,7 @@
 #include <ert/util/test_util.hpp>
 
 #include <ert/ecl/ecl_nnc_export.hpp>
+#include <ert/ecl/ecl_endian_flip.h>
 #include <ert/ecl/ecl_kw_magic.hpp>
 #include <ert/ecl/ecl_nnc_data.hpp>
 #include <ert/ecl/ecl_grid.hpp>
@@ -40,21 +41,13 @@ const auto GRID_NNC_NUM = 342;
 const auto INIT_NNC_NUM = 298;
 
 
-void install_SIGNALS(void) {
-  signal(SIGSEGV , util_abort_signal);    /* Segmentation violation, i.e. overwriting memory ... */
-  signal(SIGINT  , util_abort_signal);    /* Control C */
-  signal(SIGTERM , util_abort_signal);    /* If killing the program with SIGTERM (the default kill signal) you will get a backtrace.
-                                             Killing with SIGKILL (-9) will not give a backtrace.*/
-}
-
-
 ERT::ert_unique_ptr<ecl_grid_type, ecl_grid_free>
 make_intersect_grid() {
    auto out = ERT::ert_unique_ptr<ecl_grid_type, ecl_grid_free>(
          ecl_grid_alloc_rectangular(GRIDX, GRIDY, GRIDZ, 1., 1., 1., nullptr)
          );
    for(auto i = 0; i < GRID_NNC_NUM; ++i)
-      ecl_grid_add_self_nnc(out.get(), 0, 0, i);
+      ecl_grid_add_self_nnc(out.get(), 2 * i + 1, 2 * i, i);
    return out;
 }
 
@@ -66,14 +59,14 @@ make_intersect_init_file() {
    auto nnc2_kw = ecl_kw_alloc(NNC2_KW, INIT_NNC_NUM, ECL_INT);
    auto tran_kw = ecl_kw_alloc(TRANNNC_KW, INIT_NNC_NUM, ECL_DOUBLE);
    for(auto i = 0; i < INIT_NNC_NUM; ++i) {
-      ecl_kw_iset_int(nnc1_kw, i, 1);
-      ecl_kw_iset_int(nnc2_kw, i, 2);
-      ecl_kw_iset_double(tran_kw, i, 2. * i);
+      ecl_kw_iset_int(nnc1_kw, i, 2 * i);
+      ecl_kw_iset_int(nnc2_kw, i, 2 * i + 1 );
+      ecl_kw_iset_double(tran_kw, i, 2.5 * i);
    }
 
    // write to file directly using fortio
    auto init_filename = util_alloc_tmp_file("/tmp", "ecl_nnc_export_intersect_init_file", false);
-   auto fortio = fortio_open_writer(init_filename, false, true);
+   auto fortio = fortio_open_writer(init_filename, false, ECL_ENDIAN_FLIP);
    ecl_kw_fwrite(nnc1_kw, fortio);
    ecl_kw_fwrite(nnc2_kw, fortio);
    ecl_kw_fwrite(tran_kw, fortio);
@@ -84,6 +77,9 @@ make_intersect_init_file() {
          ecl_file_open(init_filename, 0)
          );
 
+   ecl_kw_free(nnc1_kw);
+   ecl_kw_free(nnc2_kw);
+   ecl_kw_free(tran_kw);
    free(init_filename);
    return out;
 }
@@ -92,7 +88,7 @@ make_intersect_init_file() {
 
 
 int main(int argc, char ** argv) {
-  install_SIGNALS();
+  util_install_signals();
 
   const auto grid = make_intersect_grid();
   const auto init_file = make_intersect_init_file();
@@ -111,9 +107,9 @@ int main(int argc, char ** argv) {
      auto const& nnc = nnc_data[i];
      test_assert_int_equal(nnc.grid_nr1, 0);
      test_assert_int_equal(nnc.grid_nr2, 0);
-     test_assert_int_equal(nnc.global_index1, 1); // as set in make_intersect_init_file()
-     test_assert_int_equal(nnc.global_index2, 2); // as set in make_intersect_init_file()
-     test_assert_double_equal(nnc.trans, 2. * i); // as set in make_intersect_init_file()
+     test_assert_int_equal(nnc.global_index1, 2 * i);     // as set in make_intersect_init_file()
+     test_assert_int_equal(nnc.global_index2, 2 * i + 1); // as set in make_intersect_init_file()
+     test_assert_double_equal(nnc.trans, 2.5 * i);        // as set in make_intersect_init_file()
      test_assert_int_equal(nnc.input_index, i);
   }
 

--- a/lib/ecl/tests/ecl_nnc_export_intersect.cpp
+++ b/lib/ecl/tests/ecl_nnc_export_intersect.cpp
@@ -1,0 +1,121 @@
+/*
+   Copyright (C) 2018  Statoil ASA, Norway.
+
+   The file 'ecl_nnc_export_intersect.c' is part of ERT - Ensemble based
+   Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more detals.
+*/
+// #include <stdlib.h>
+// #include <stdbool.h>
+#include <signal.h>
+
+#include <ert/util/test_util.hpp>
+
+#include <ert/ecl/ecl_nnc_export.hpp>
+#include <ert/ecl/ecl_kw_magic.hpp>
+#include <ert/ecl/ecl_nnc_data.hpp>
+#include <ert/ecl/ecl_grid.hpp>
+#include <ert/ecl/ecl_file.hpp>
+
+#include <ert/util/ert_unique_ptr.hpp>
+#include <ert/util/util.hpp>
+
+
+
+namespace {
+
+const auto GRIDX = 10, GRIDY = 10, GRIDZ = 10;
+const auto GRID_NNC_NUM = 342;
+const auto INIT_NNC_NUM = 298;
+
+
+void install_SIGNALS(void) {
+  signal(SIGSEGV , util_abort_signal);    /* Segmentation violation, i.e. overwriting memory ... */
+  signal(SIGINT  , util_abort_signal);    /* Control C */
+  signal(SIGTERM , util_abort_signal);    /* If killing the program with SIGTERM (the default kill signal) you will get a backtrace.
+                                             Killing with SIGKILL (-9) will not give a backtrace.*/
+}
+
+
+ERT::ert_unique_ptr<ecl_grid_type, ecl_grid_free>
+make_intersect_grid() {
+   auto out = ERT::ert_unique_ptr<ecl_grid_type, ecl_grid_free>(
+         ecl_grid_alloc_rectangular(GRIDX, GRIDY, GRIDZ, 1., 1., 1., nullptr)
+         );
+   for(auto i = 0; i < GRID_NNC_NUM; ++i)
+      ecl_grid_add_self_nnc(out.get(), 0, 0, i);
+   return out;
+}
+
+
+ERT::ert_unique_ptr<ecl_file_type, ecl_file_close>
+make_intersect_init_file() {
+   // Create keywords with useless data
+   auto nnc1_kw = ecl_kw_alloc(NNC1_KW, INIT_NNC_NUM, ECL_INT);
+   auto nnc2_kw = ecl_kw_alloc(NNC2_KW, INIT_NNC_NUM, ECL_INT);
+   auto tran_kw = ecl_kw_alloc(TRANNNC_KW, INIT_NNC_NUM, ECL_DOUBLE);
+   for(auto i = 0; i < INIT_NNC_NUM; ++i) {
+      ecl_kw_iset_int(nnc1_kw, i, 1);
+      ecl_kw_iset_int(nnc2_kw, i, 2);
+      ecl_kw_iset_double(tran_kw, i, 2. * i);
+   }
+
+   // write to file directly using fortio
+   auto init_filename = util_alloc_tmp_file("/tmp", "ecl_nnc_export_intersect_init_file", false);
+   auto fortio = fortio_open_writer(init_filename, false, true);
+   ecl_kw_fwrite(nnc1_kw, fortio);
+   ecl_kw_fwrite(nnc2_kw, fortio);
+   ecl_kw_fwrite(tran_kw, fortio);
+   fortio_fclose(fortio);
+
+   // reopen the file as an ecl file
+   auto out = ERT::ert_unique_ptr<ecl_file_type, ecl_file_close>(
+         ecl_file_open(init_filename, 0)
+         );
+
+   free(init_filename);
+   return out;
+}
+} /* unnamed namespace */
+
+
+
+int main(int argc, char ** argv) {
+  install_SIGNALS();
+
+  const auto grid = make_intersect_grid();
+  const auto init_file = make_intersect_init_file();
+
+  test_assert_true(ecl_nnc_intersect_format(grid.get(), init_file.get()));
+  test_assert_int_equal(ecl_nnc_export_get_size(grid.get(), init_file.get()), INIT_NNC_NUM);
+
+  auto nnc_data = std::vector<ecl_nnc_type>(
+        ecl_nnc_export_get_size(grid.get(), init_file.get())
+        );
+  auto const total_valid_trans = ecl_nnc_export(grid.get(), init_file.get(), nnc_data.data());
+  test_assert_int_equal(total_valid_trans, INIT_NNC_NUM);
+  test_assert_int_equal(int(nnc_data.size()), INIT_NNC_NUM);
+
+  for(auto i = 0; i < int(nnc_data.size()); ++i) {
+     auto const& nnc = nnc_data[i];
+     test_assert_int_equal(nnc.grid_nr1, 0);
+     test_assert_int_equal(nnc.grid_nr2, 0);
+     test_assert_int_equal(nnc.global_index1, 1); // as set in make_intersect_init_file()
+     test_assert_int_equal(nnc.global_index2, 2); // as set in make_intersect_init_file()
+     test_assert_double_equal(nnc.trans, 2. * i); // as set in make_intersect_init_file()
+     test_assert_int_equal(nnc.input_index, i);
+  }
+
+  return 0;
+}

--- a/lib/include/ert/ecl/ecl_nnc_export.hpp
+++ b/lib/include/ert/ecl/ecl_nnc_export.hpp
@@ -45,7 +45,8 @@ typedef struct {
 } ecl_nnc_type;
 
 
-  int   ecl_nnc_export_get_size( const ecl_grid_type * grid );
+bool ecl_nnc_intersect_format(const ecl_grid_type * grid, const ecl_file_type * init_file);
+  int   ecl_nnc_export_get_size( const ecl_grid_type * grid , const ecl_file_type * init_file );
   int  ecl_nnc_export( const ecl_grid_type * grid , const ecl_file_type * init_file , ecl_nnc_type * nnc_data);
 
   ecl_kw_type * ecl_nnc_export_get_tranx_kw( const ecl_grid_type * grid , const ecl_file_type * init_file ,  int lgr_nr1, int lgr_nr2 );


### PR DESCRIPTION
The Intersect simulator stores NNC information differently wrt Eclipse. With this PR, libecl uses the correct NNC data when running the NNC export.

Note that this affects exclusively for the nnc export. `EclGrid` would still expose the wrong data if loaded from an Intersect file

See https://github.com/Statoil/libecl/issues/505

**Pre un-WIP checklist**
- [x] Statoil tests pass locally
