### PR TITLE
Remove ERT_BUILD_CXX cmake switch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,6 @@ option( ENABLE_PYTHON       "Build and install the Python wrappers"             
 option( BUILD_SHARED_LIBS   "Build shared libraries"                                  ON )
 option( ERT_USE_OPENMP      "Use OpenMP"                                              OFF )
 option( RST_DOC             "Build RST documentation"                                 OFF)
-option( ERT_BUILD_CXX       "Build some CXX wrappers"                                 ON)
 option( USE_RPATH           "Don't strip RPATH from libraries and binaries"           OFF)
 option( INSTALL_ERT_LEGACY  "Add ert legacy wrappers"                                 OFF)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,6 @@ build_script:
     - cmake %W64% -DBUILD_SHARED_LIBS=ON
                   -DCMAKE_BUILD_TYPE=Release
                   -DENABLE_PYTHON=ON
-                  -DERT_BUILD_CXX=OFF
                   -DBUILD_APPLICATIONS=ON
     - cmake --build . --config %configuration% --target install
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -54,11 +54,6 @@ if (ZLIB_FOUND)
     list(APPEND opt_srcs util/util_zlib.cpp)
 endif ()
 
-if (ERT_BUILD_CXX)
-    list(APPEND opt_srcs ecl/FortIO.cpp
-                         ecl/EclFilename.cpp
-)
-endif ()
 
 configure_file(build_config.h.in   include/ert/util/build_config.h)
 configure_file(ert_api_config.h.in include/ert/util/ert_api_config.h)
@@ -144,6 +139,8 @@ add_library(ecl util/rng.cpp
                 ecl/well_segment_collection.cpp
                 ecl/well_branch_collection.cpp
                 ecl/well_rseg_loader.cpp
+                ecl/FortIO.cpp
+                ecl/EclFilename.cpp
 
                 geometry/geo_surface.cpp
                 geometry/geo_util.cpp
@@ -211,23 +208,10 @@ install(TARGETS ecl
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(DIRECTORY include/
         DESTINATION include
-        PATTERN *.h
-)
-install(DIRECTORY include/
-        DESTINATION include
-        PATTERN *.hpp EXCLUDE
 )
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/
         DESTINATION include
-        PATTERN *.h
 )
-
-if (ERT_BUILD_CXX)
-    install(DIRECTORY include/
-            DESTINATION include
-            PATTERN *.hpp
-)
-endif ()
 
 if (NOT BUILD_TESTS)
     return ()
@@ -428,19 +412,17 @@ foreach (name geo_util_xlines geo_polygon geo_polygon_collection)
     add_test(NAME ${name} COMMAND ${name})
 endforeach ()
 
-if (ERT_BUILD_CXX)
-    foreach (test ert_util_unique_ptr)
-        add_executable(${test} util/tests/${test}.cpp)
-        target_link_libraries(${test} ecl)
-        add_test(NAME ${test} COMMAND ${test})
-    endforeach()
+foreach (test ert_util_unique_ptr)
+    add_executable(${test} util/tests/${test}.cpp)
+    target_link_libraries(${test} ecl)
+    add_test(NAME ${test} COMMAND ${test})
+endforeach()
 
-    foreach (test eclxx_kw eclxx_fortio eclxx_filename eclxx_types)
-        add_executable(${test} ecl/tests/${test}.cpp)
-        target_link_libraries(${test} ecl)
-        add_test(NAME ${test} COMMAND ${test})
-    endforeach ()
-endif ()
+foreach (test eclxx_kw eclxx_fortio eclxx_filename eclxx_types)
+    add_executable(${test} ecl/tests/${test}.cpp)
+    target_link_libraries(${test} ecl)
+    add_test(NAME ${test} COMMAND ${test})
+endforeach ()
 
 foreach(name ecl_coarse_test
              ecl_grid_layer_contains


### PR DESCRIPTION
**Task**
This PR will remove the `ERT_BUILD_CXX` switch from the build system. The switch has been defaulted to `ON` for a long time, and the whole codebase is now built with a C++ compiler. 

The purpose of the PR is just a minor simplification of the build system - one switch less to relate to.

**Approach**
Removed switch from root `CMakeLists.txt` and removed all `if (ERT_BUILD_CXX)` conditinals.

This PR and Statoil/ert#211 are related, but since the `ERT_BUILD_CXX`defaulted to `ON` the two can be merged independently.