### PR TITLE
Update the implementation to identify region-to-region variables

### DIFF
--- a/lib/ecl/smspec_node.cpp
+++ b/lib/ecl/smspec_node.cpp
@@ -164,28 +164,61 @@ ecl_smspec_var_type ecl::smspec_node::identify_var_type(const char * var) {
     case('R'):
       {
         /*
-          The distinction between region-to-region variables and plain
-          region variables is less than clear: The current
-          interpretation is that the cases:
+          The distinction between regular region variables and region-to-region
+          variables is less than clear. The manual prescribes a rule based on
+          the characters at position 3 and 4 or 4 and 5.
 
-             1. Any variable matching:
+             R*FT*  => Region to region
+             R**FT* => Region to region
+             R*FR*  => Region to region
+             R**FR* => Region to region
 
-                a) Starts with 'R'
-                b) Has 'F' as the third character
+             RORFR  => exception - normal region var.
 
-             2. The variable "RNLF"
 
-          Get variable type ECL_SMSPEC_REGION_2_REGION_VAR. The rest
-          get the type ECL_SMSPEC_REGION_VAR.
+           In addition older test cases seem to imply the following extra
+           rules/exceptions:
+
+             RNLF: region to region variable
+             RxF : region to region variable
+
+           The manual does not seem to offer any backup for these extra rules.
         */
 
-        if (util_string_equal( var , "RNLF"))
+        if (strlen(var) == 3 && var[2] == 'F') {
           var_type = ECL_SMSPEC_REGION_2_REGION_VAR;
-        else if (var[2] == 'F')
-          var_type = ECL_SMSPEC_REGION_2_REGION_VAR;
-        else
-          var_type  = ECL_SMSPEC_REGION_VAR;
+          break;
+        }
 
+        if (util_string_equal( var , "RNLF")) {
+          var_type = ECL_SMSPEC_REGION_2_REGION_VAR;
+          break;
+        }
+
+        if (util_string_equal(var, "RORFR")) {
+          var_type = ECL_SMSPEC_REGION_VAR;
+          break;
+        }
+
+        if (strlen(var) >= 4) {
+          if (var[2] == 'F') {
+            if (var[3] == 'T' || var[3] == 'R') {
+              var_type = ECL_SMSPEC_REGION_2_REGION_VAR;
+              break;
+            }
+          }
+        }
+
+        if (strlen(var) >= 5) {
+          if (var[3] == 'F') {
+            if (var[4] == 'T' || var[4] == 'R') {
+              var_type = ECL_SMSPEC_REGION_2_REGION_VAR;
+              break;
+            }
+          }
+        }
+
+        var_type = ECL_SMSPEC_REGION_VAR;
       }
       break;
     case('S'):
@@ -202,6 +235,7 @@ ecl_smspec_var_type ecl::smspec_node::identify_var_type(const char * var) {
       var_type = ECL_SMSPEC_MISC_VAR;
     }
   }
+
   return var_type;
 }
 

--- a/python/tests/ecl_tests/test_sum.py
+++ b/python/tests/ecl_tests/test_sum.py
@@ -124,10 +124,16 @@ class SumTest(EclTest):
         self.assertEqual( EclSum.varType( "WNEWTON") , EclSumVarType.ECL_SMSPEC_MISC_VAR )
         self.assertEqual( EclSum.varType( "AARQ:4") , EclSumVarType.ECL_SMSPEC_AQUIFER_VAR )
 
+        self.assertEqual( EclSum.varType("RXFT"),  EclSumVarType.ECL_SMSPEC_REGION_2_REGION_VAR)
+        self.assertEqual( EclSum.varType("RxxFT"), EclSumVarType.ECL_SMSPEC_REGION_2_REGION_VAR)
+        self.assertEqual( EclSum.varType("RXFR"),  EclSumVarType.ECL_SMSPEC_REGION_2_REGION_VAR)
+        self.assertEqual( EclSum.varType("RxxFR"), EclSumVarType.ECL_SMSPEC_REGION_2_REGION_VAR)
+        self.assertEqual( EclSum.varType("RORFR"), EclSumVarType.ECL_SMSPEC_REGION_VAR)
+
         case = createEclSum("CSV" , [("FOPT", None , 0, "SM3") ,
                                      ("FOPR" , None , 0, "SM3/DAY"),
                                      ("AARQ" , None , 10, "???"),
-                                    ("RGPT" , None  ,1, "SM3")])
+                                     ("RGPT" , None  ,1, "SM3")])
 
         node1 = case.smspec_node( "FOPT" )
         self.assertEqual( node1.varType( ) , EclSumVarType.ECL_SMSPEC_FIELD_VAR )


### PR DESCRIPTION
The type of the summary variables is inferred by looking at the string, e.g. all variables like `WWCT` and `WOPT` which start with `W` are well variables.

Variables starting with 'R' are region properties, but for region properties there is a sub-category of variables which describe region-to-region properties. This PR updates the code to identify region-to-region properties. Previously the algorithm to detect a region to region variable was just to check the third character - and all variables with `var[2] == 'F'`were classified as region to region variables.

This PR will change the classification in two ways:

1. It is stricter - in addition to third character we *also check the fourth character* - and require that `var[3] == 'T' || var[3] == 'R'`.

2. It is more lenient - we also check for the substring `FT` or `FR` one character further out in the string - i.e. starting at the fourth character in var.

