### PR TITLE
Unconditionally initialize the nums vector for all keywords

### DIFF
--- a/lib/ecl/smspec_node.cpp
+++ b/lib/ecl/smspec_node.cpp
@@ -71,6 +71,8 @@ static const char* special_vars[] = {"NEWTON",
                                      "WNEWTON"};
 
 
+static const int nums_unused = 0;
+
 /**
    This struct contains meta-information about one element in the smspec
    file; the content is based on the smspec vectors WGNAMES, KEYWORDS, UNIT
@@ -716,13 +718,13 @@ smspec_node::smspec_node(int param_index, const char * keyword, int num, const c
 
 smspec_node::smspec_node(int param_index, const char * keyword, const char * wgname, const char * unit, float default_value, const char * key_join_string)
   : smspec_node(param_index,
-                     keyword,
-                     wgname,
-                     0,
-                     unit,
-                     nullptr,
-                     default_value,
-                     key_join_string)
+                keyword,
+                wgname,
+                nums_unused,
+                unit,
+                nullptr,
+                default_value,
+                key_join_string)
 {
 }
 
@@ -740,13 +742,13 @@ smspec_node::smspec_node(int param_index, const char * keyword, const char * wgn
 
 smspec_node::smspec_node(int param_index, const char * keyword, const char * unit, float default_value)
   : smspec_node(param_index,
-                     keyword,
-                     nullptr,
-                     0,
-                     unit,
-                     nullptr,
-                     default_value,
-                     nullptr)
+                keyword,
+                nullptr,
+                nums_unused,
+                unit,
+                nullptr,
+                default_value,
+                nullptr)
 {
 }
 
@@ -801,6 +803,7 @@ smspec_node::smspec_node(int param_index,
   this->params_index = param_index;
   this->default_value = default_value;
   this->keyword = keyword;
+  this->num = num;
   this->unit = unit;
   this->rate_variable = smspec_node_identify_rate(this->keyword.c_str());
   this->total_variable = smspec_node_identify_total(this->keyword.c_str(), this->var_type);

--- a/lib/ecl/tests/ecl_smspec_node.cpp
+++ b/lib/ecl/tests/ecl_smspec_node.cpp
@@ -93,6 +93,25 @@ static void test_identify_total_variable() {
   test_assert_false(smspec_node_identify_total("SPR", ECL_SMSPEC_SEGMENT_VAR));
 }
 
+
+void test_nums_default() {
+  ecl::smspec_node field_node( 0, "FOPT" , "UNIT" , 0);
+  ecl::smspec_node group_node( 0, "GOPR" , "G1", "UNIT" , 0, ":");
+  ecl::smspec_node well_node( 0, "WOPR" , "W1", "UNIT" , 0, ":");
+
+  int default_nums = 0;
+  /*
+    The integer constant default nums corresponds to the symbol nums_unused
+    in smspec_node.cpp. It is duplicated here to avoid exporting it - it should
+    not really be a publically available symbol.
+  */
+
+  test_assert_int_equal( field_node.get_num(), default_nums);
+  test_assert_int_equal( group_node.get_num(), default_nums);
+  test_assert_int_equal( well_node.get_num(), default_nums);
+}
+
+
 void test_cmp_types() {
   const int dims[3] = {10,10,10};
   ecl::smspec_node field_node( 0, "FOPT" , "UNIT" , 0);
@@ -168,4 +187,5 @@ int main(int argc, char ** argv) {
   test_cmp_region( );
   test_identify_rate_variable();
   test_identify_total_variable();
+  test_nums_default();
 }


### PR DESCRIPTION
This comes from: https://github.com/OPM/opm-simulators/pull/1685

The summary values - as defined in the SMSPEC files - are composed of three parts: 

1. The keyword part - stored in the `KEYWORDS` vector.
2. The well/group name stored in the `WGNAME` vector.
3. An Integer value stored in the `NUMS` vector - exactly how this integer value should be interpreted depends on the keyword part.

Depending on the keyword value the corresponding `WGNAME` and `NUMS` values might - or might not be relevant. E.g the keyword `WWCT:OP_X` is a combination of the keyword `WWCT` and the `WGNAME` value `OP_X` - in this case the `NUMS` value is completely ignored. Another variety is the region pressure in region 7: `RPR:7`- this is a combination of the keyword `RPR` and the `NUMS` value 7 - in this case the `WGNAME`element is ignored.

As described in the OPM issue the `nums` value was not explicitly initiialized for situations where it was not used, leading to random unitiialized values in the `SMSPEC` files. With this PR the `smspec_node->num` value is unconditionally set - the change at line 806 is the relevant fix.