### PR TITLE
Change number of expected EclSum warnings to 1

### DIFF
--- a/python/tests/ecl_tests/test_ecl_sum_vector.py
+++ b/python/tests/ecl_tests/test_ecl_sum_vector.py
@@ -38,7 +38,7 @@ class EclSumVectorTest(EclTest):
             warnings.simplefilter("always")
 
             vector = EclSumVector(self.ecl_sum, "FOPT", True)
-            self.assertEqual(len(w), 2)
+            self.assertEqual(len(w), 1)
             assert issubclass(w[-1].category, DeprecationWarning)
 
 


### PR DESCRIPTION
**Task**
After the clean up done in #531, _EclSum_ creates one instead of two warnings upon initialization. Apparently the _Jenkins_ job was executed only on the first commit, hence this internal test slipped through...
