### PR TITLE
GitHub feature cleanup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# These owners will be the default owners for everything in the repo.
+*       @markusdregi
+*       @lars-petter-hauge
+*       @andreabrambilla
+*       @pgdr
+*       @jokva

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,5 @@
-**Task**
-_Short description of the task_
-
+**Issue**
+Resolves #<Issue id>
 
 **Approach**
 _Short description of the approach_
-
-
-**Pre un-WIP checklist**
-- [ ] Statoil tests pass locally


### PR DESCRIPTION
Consists of two commits:
- The first is an over due clean up of the PR template according to our changed working methodology.
- The second is an experiment with code owners. For more information, see: https://help.github.com/articles/about-codeowners/
