### PR TITLE
Escape [ and ] in order to get rid of FutureWarning

### DIFF
--- a/python/ecl/summary/ecl_npv.py
+++ b/python/ecl/summary/ecl_npv.py
@@ -138,6 +138,7 @@ class NPVPriceVector(object):
 class EclNPV(object):
     sumKeyRE = re.compile("[\[]([\w:,]+)[\]]")
 
+
     def __init__(self, baseCase):
         sum = EclSum(baseCase)
         if sum:

--- a/python/ecl/summary/ecl_npv.py
+++ b/python/ecl/summary/ecl_npv.py
@@ -136,8 +136,7 @@ class NPVPriceVector(object):
 
 
 class EclNPV(object):
-    sumKeyRE = re.compile("[[]([\w:,]+)[]]")
-
+    sumKeyRE = re.compile("[\[]([\w:,]+)[\]]")
 
     def __init__(self, baseCase):
         sum = EclSum(baseCase)


### PR DESCRIPTION
**Issue**
Resolves #560 

**Approach**
Solved by escaping `[` and `]` where they are part of the character set to match, and not to be considered regular expression metacharacters.

More information regarding why the `FutureWarning` has been implemented:

- https://github.com/python/cpython/commit/05cb728d68a278d11466f9a6c8258d914135c96c#diff-8721d1362294720bad1dbbbaa4cc06e3
- https://bugs.python.org/issue30349

